### PR TITLE
fix(security): upgrade lodash to 4.17.23 (CVE-2025-13465)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7531,9 +7531,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "minimatch": ">=10.2.1"
+    "minimatch": ">=10.2.1",
+    "lodash": ">=4.17.23"
   },
   "packageManager": "npm@10.8.0",
   "engines": {


### PR DESCRIPTION
## Summary

- Adds `"lodash": ">=4.17.23"` to npm `overrides` (alongside the existing minimatch override) to force the patched version throughout the transitive dependency tree
- `lodash@4.17.23` was published 2026-01-21 — same day as the CVE — and contains the fix commit referenced in GHSA-xxjr-mmjv-4gpg

## Background

`lodash@4.17.21` is a transitive dependency via `prisma` → `@prisma/dev` → `@mrleebo/prisma-ast` → `chevrotain`. The vulnerability (prototype pollution in `_.unset` and `_.omit`, CVSS 6.5) is in lodash itself, not in any code we write. An npm override is the correct mechanism since we don't directly depend on lodash.

The 5 open Hono Dependabot alerts (#3–7) were dismissed as `not_used` directly via the GitHub API — we are on `hono@4.12.1` (latest, no patch available) and none of the affected middleware are used in this project.

## Test plan

- [ ] PR workflow passes
- [ ] `npm ls lodash` shows `4.17.23` throughout the tree
- [ ] No regressions in tests or build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce a patched lodash version across the dependency tree to address a security vulnerability.

Bug Fixes:
- Mitigate lodash prototype pollution vulnerability by overriding all lodash dependencies to version 4.17.23 or higher.

Build:
- Add an npm override for lodash to ensure all transitive usages resolve to version 4.17.23 or later.