### PR TITLE
fix(infra): fix failing deploy - ECR state mv + valid placeholder image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,18 @@ jobs:
           terraform init \
             -backend-config="key=prod/terraform.tfstate"
 
+      # One-time migration: ECR repo was moved from module.lambda_api to root.
+      # State mv is idempotent — no-ops silently if already at the target address.
+      - name: Migrate Terraform State (ECR repo move)
+        working-directory: infrastructure/terraform
+        run: |
+          terraform state mv \
+            module.lambda_api.aws_ecr_repository.api \
+            aws_ecr_repository.api 2>/dev/null || true
+          terraform state mv \
+            module.lambda_api.aws_ecr_lifecycle_policy.api \
+            aws_ecr_lifecycle_policy.api 2>/dev/null || true
+
       - name: Terraform Apply
         working-directory: infrastructure/terraform
         run: |

--- a/infrastructure/terraform/modules/lambda-api/variables.tf
+++ b/infrastructure/terraform/modules/lambda-api/variables.tf
@@ -77,7 +77,7 @@ variable "cloudfront_url" {
 }
 
 variable "placeholder_image_uri" {
-  description = "Pinned Lambda base image URI used as a placeholder until CI/CD deploys the service image."
+  description = "Lambda base image URI used as a placeholder until CI/CD deploys the service image."
   type        = string
-  default     = "public.ecr.aws/lambda/nodejs20.x:1"
+  default     = "public.ecr.aws/lambda/nodejs20.x:latest"
 }


### PR DESCRIPTION
## Summary

Fixes the Terraform apply that has been failing on every deploy run since PR #18.

**Root cause 1 — ECR state drift**: The ECR repository was moved from `module.lambda_api` to root `main.tf` in PR #18. Terraform's state file still has the resource at the old address, so it tries to `CreateRepository` — which the GitHub Actions IAM user is not permitted to do. Fix: add a `terraform state mv` step before apply to relocate the existing resource. The command is idempotent (`|| true`) so it's safe on all subsequent runs.

**Root cause 2 — Invalid placeholder image**: `public.ecr.aws/lambda/nodejs20.x:1` doesn't exist on the public ECR. The `:1` tag was added in the code review but isn't a real tag for that image. Reverted to `latest`, which is valid and gets immediately overwritten by CI's docker build + push on the same deploy run.

## Action required from repo owner

Add `ecr:CreateRepository` and `ecr:PutLifecyclePolicy` to the `surfaced-art-github-actions` IAM user in the AWS console. Not strictly needed today (state mv means no create happens), but required for future infra changes involving ECR.

## Test plan

- [ ] PR workflow passes
- [ ] After merge: deploy workflow runs `state mv` (no-op or moves resource)
- [ ] Terraform apply succeeds
- [ ] Lambda deploys with container image
- [ ] Migrations run via Lambda invoke
- [ ] Health check returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix deployment failures by migrating Terraform ECR resources in CI and correcting the Lambda placeholder image URI.

Bug Fixes:
- Add an idempotent Terraform state migration step in the deploy workflow to align ECR repository and lifecycle policy resources with their new locations.
- Update the Lambda placeholder image default URI to use a valid public ECR tag so deployments succeed.