### PR TITLE
fix(ci): bootstrap ECR with private image before Lambda creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,44 @@ jobs:
             module.lambda_api.aws_ecr_lifecycle_policy.api \
             aws_ecr_lifecycle_policy.api 2>/dev/null || true
 
+      # Bootstrap: create ECR repo before Lambda so we can push an image.
+      # Lambda (package_type=Image) requires a private ECR image; public ECR URIs are invalid.
+      - name: Bootstrap ECR Repository
+        working-directory: infrastructure/terraform
+        run: |
+          terraform apply -auto-approve -input=false \
+            -target=aws_ecr_repository.api \
+            -target=aws_ecr_lifecycle_policy.api \
+            -var-file="environments/prod.tfvars" \
+            -var="db_password=${{ secrets.TF_VAR_db_password }}" \
+            -var="google_client_id=${{ secrets.TF_VAR_google_client_id }}" \
+            -var="google_client_secret=${{ secrets.TF_VAR_google_client_secret }}"
+
+      - name: Login to Amazon ECR (bootstrap)
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # Only push bootstrap image on first deploy (when ECR is empty).
+      # Subsequent deploys already have a valid image from a previous deploy-lambda run.
+      - name: Push bootstrap image to ECR if empty
+        id: bootstrap
+        working-directory: infrastructure/terraform
+        run: |
+          ECR_URL=$(terraform output -raw ecr_repository_url)
+          IMAGE_COUNT=$(aws ecr describe-images \
+            --repository-name surfaced-art-prod-api \
+            --query 'length(imageDetails)' \
+            --output text 2>/dev/null || echo "0")
+          if [ "$IMAGE_COUNT" = "0" ]; then
+            echo "ECR is empty — pushing bootstrap image..."
+            docker pull public.ecr.aws/lambda/nodejs20.x:latest
+            docker tag public.ecr.aws/lambda/nodejs20.x:latest $ECR_URL:bootstrap
+            docker push $ECR_URL:bootstrap
+            echo "placeholder_uri=$ECR_URL:bootstrap" >> $GITHUB_OUTPUT
+          else
+            echo "ECR already has $IMAGE_COUNT image(s) — skipping bootstrap"
+            echo "placeholder_uri=$ECR_URL:latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Terraform Apply
         working-directory: infrastructure/terraform
         run: |
@@ -110,7 +148,8 @@ jobs:
             -var-file="environments/prod.tfvars" \
             -var="db_password=${{ secrets.TF_VAR_db_password }}" \
             -var="google_client_id=${{ secrets.TF_VAR_google_client_id }}" \
-            -var="google_client_secret=${{ secrets.TF_VAR_google_client_secret }}"
+            -var="google_client_secret=${{ secrets.TF_VAR_google_client_secret }}" \
+            -var="placeholder_image_uri=${{ steps.bootstrap.outputs.placeholder_uri }}"
 
       - name: Get Terraform Outputs
         id: output


### PR DESCRIPTION
## Summary
- Lambda with `package_type=Image` cannot use public ECR image URIs — AWS rejects them at CreateFunction time
- Splits terraform apply into two phases: ECR-only target apply first, then full apply
- On first deploy, pulls public Lambda base image, retags and pushes to private ECR as `:bootstrap`
- Full terraform apply then uses the private ECR URI as `placeholder_image_uri`
- Subsequent deploys skip the bootstrap (ECR already has images; `ignore_changes = [image_uri]` means Terraform won't overwrite the CI-managed image)

Also updates `surfaced-art-ecr-manage` inline policy instructions to include full ECR permissions (GetLifecyclePolicy + docker push actions).

## Test plan
- [ ] Update `surfaced-art-ecr-manage` inline policy with full ECR permissions
- [ ] Re-run deploy workflow
- [ ] Confirm bootstrap step pushes image on first deploy
- [ ] Confirm Lambda creates successfully with private ECR image
- [ ] Confirm health check passes at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bootstrap the Lambda ECR repository and image before full Terraform deployment so Lambda can be created with a private ECR image URI.

CI:
- Split the deploy workflow into an initial ECR-only Terraform apply followed by the main apply using a placeholder image URI.
- Add a bootstrap step to log in to ECR, push a Lambda base image to a private repository on first deploy, and pass its URI into Terraform.