### PR TITLE
fix(ci): correct Lambda public ECR base image URI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,8 +132,8 @@ jobs:
             --output text 2>/dev/null || echo "0")
           if [ "$IMAGE_COUNT" = "0" ]; then
             echo "ECR is empty — pushing bootstrap image..."
-            docker pull public.ecr.aws/lambda/nodejs20.x:latest
-            docker tag public.ecr.aws/lambda/nodejs20.x:latest $ECR_URL:bootstrap
+            docker pull public.ecr.aws/lambda/nodejs:20
+            docker tag public.ecr.aws/lambda/nodejs:20 $ECR_URL:bootstrap
             docker push $ECR_URL:bootstrap
             echo "placeholder_uri=$ECR_URL:bootstrap" >> $GITHUB_OUTPUT
           else

--- a/infrastructure/terraform/modules/lambda-api/variables.tf
+++ b/infrastructure/terraform/modules/lambda-api/variables.tf
@@ -79,5 +79,5 @@ variable "cloudfront_url" {
 variable "placeholder_image_uri" {
   description = "Lambda base image URI used as a placeholder until CI/CD deploys the service image."
   type        = string
-  default     = "public.ecr.aws/lambda/nodejs20.x:latest"
+  default     = "public.ecr.aws/lambda/nodejs:20"
 }


### PR DESCRIPTION
## Summary
- Fixes the bootstrap docker pull: `public.ecr.aws/lambda/nodejs20.x:latest` doesn't exist
- Correct URI is `public.ecr.aws/lambda/nodejs:20`
- Fixed in both `deploy.yml` bootstrap step and the Terraform `placeholder_image_uri` variable default

## Test plan
- [ ] Deploy pipeline bootstrap step pulls `public.ecr.aws/lambda/nodejs:20` successfully
- [ ] Bootstrap image pushed to private ECR
- [ ] Full terraform apply creates Lambda with private ECR image
- [ ] Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct Lambda base image URIs used by CI bootstrap and Terraform defaults to point at the valid public ECR Node.js 20 image.

CI:
- Update deploy workflow bootstrap step to pull and tag the correct public ECR Node.js 20 Lambda base image.

Deployment:
- Align Terraform lambda-api module placeholder image URI with the corrected public ECR Node.js 20 Lambda base image.