### PR TITLE
fix(api): correct Lambda base image in Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@
 # (including its native migration engine binary) is available for
 # running `prisma migrate deploy` from within the VPC.
 
-FROM public.ecr.aws/lambda/nodejs20.x:latest
+FROM public.ecr.aws/lambda/nodejs:20
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 


### PR DESCRIPTION
## Summary
The Dockerfile at `apps/api/Dockerfile` still referenced the non-existent `public.ecr.aws/lambda/nodejs20.x:latest`. Changed to `public.ecr.aws/lambda/nodejs:20` — same fix applied to the bootstrap image in deploy.yml earlier.

## Test plan
- [ ] Docker build in deploy-lambda job completes
- [ ] Lambda function updates with the real image
- [ ] Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)