### PR TITLE
fix(api): correct prisma CLI path and add container validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,21 +203,32 @@ jobs:
         env:
           ECR_REPOSITORY_URL: ${{ needs.terraform.outputs.ecr_repository_url }}
           IMAGE_TAG: ${{ github.sha }}
+          # Keep in sync with PRISMA_CLI in apps/api/src/index.ts
+          PRISMA_CLI_PATH: /var/task/packages/db/node_modules/prisma/build/index.js
         run: |
           echo "Checking container has required files..."
-          docker run --rm --entrypoint="" $ECR_REPOSITORY_URL:$IMAGE_TAG \
-            sh -c "
-              set -e
-              echo '--- Handler bundle ---'
-              ls -la /var/task/index.js
-              echo '--- Prisma CLI ---'
-              ls -la /var/task/packages/db/node_modules/prisma/build/index.js
-              echo '--- Prisma schema ---'
-              ls -la /var/task/prisma/schema.prisma
-              echo '--- Prisma migrations ---'
-              ls /var/task/prisma/migrations/
-              echo 'All required files present.'
-            "
+          docker run --rm --entrypoint="" \
+            -e PRISMA_CLI_PATH="$PRISMA_CLI_PATH" \
+            $ECR_REPOSITORY_URL:$IMAGE_TAG \
+            sh -c '
+              ok=true
+              for f in \
+                /var/task/index.js \
+                "$PRISMA_CLI_PATH" \
+                /var/task/prisma/schema.prisma; do
+                if test -f "$f"; then
+                  echo "OK   $f"
+                else
+                  echo "MISSING $f" >&2; ok=false
+                fi
+              done
+              if ! test -d /var/task/prisma/migrations; then
+                echo "MISSING /var/task/prisma/migrations/" >&2; ok=false
+              else
+                echo "OK   /var/task/prisma/migrations/"
+              fi
+              $ok && echo "All required files present." || { echo "Validation failed" >&2; exit 1; }
+            '
 
       - name: Push Docker image
         env:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,7 +53,8 @@ const honoHandler = handle(app)
 // .bin symlinks (broken by workspace hoisting) or npx being available.
 // prisma is a dep of @surfaced-art/db so npm installs it under that workspace.
 const LAMBDA_ROOT = process.env.LAMBDA_TASK_ROOT ?? '/var/task'
-const PRISMA_MIGRATE_CMD = `node packages/db/node_modules/prisma/build/index.js migrate deploy`
+const PRISMA_CLI = `${LAMBDA_ROOT}/packages/db/node_modules/prisma/build/index.js`
+const PRISMA_MIGRATE_CMD = `node ${PRISMA_CLI} migrate deploy`
 
 // Lambda handler — supports two invocation modes:
 //   1. API Gateway (normal HTTP traffic) — delegated to Hono


### PR DESCRIPTION
## Summary
- **Fix prisma CLI path**: prisma is not hoisted to root `node_modules/` — it lives at `packages/db/node_modules/prisma/` because it's a dependency of `@surfaced-art/db`. Updated the migration handler to use the correct workspace path.
- **Add container validation step**: new "Validate container contents" step in the deploy workflow checks that the handler bundle, prisma CLI, schema, and migrations all exist inside the Docker image *before* pushing to ECR. Catches missing-file issues without waiting for Lambda invocation.

### Files changed
- `apps/api/src/index.ts` — correct prisma path to `packages/db/node_modules/prisma/build/index.js`
- `.github/workflows/deploy.yml` — split build/push into build → validate → push

## Test plan
- [x] `npm run test` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Container validation step passes in pipeline
- [ ] Migration Lambda invocation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Prisma CLI path used by the API Lambda migration handler and introduce a pre-push Docker image validation step in the deploy workflow.

Bug Fixes:
- Correct the Prisma migrate command to use the Prisma CLI installed under the db workspace inside the Lambda container.

CI:
- Split the deploy workflow Docker step into build, validate container contents, and push phases, adding checks that required handler, Prisma CLI, schema, and migrations exist in the image before publishing.