### PR TITLE
feat(ci): update deploy pipeline for dual-Lambda architecture

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,16 +159,26 @@ jobs:
           push_bootstrap_if_empty "$MIGRATE_ECR_URL" "Migrate"
 
           # Determine placeholder URI for Terraform (API ECR as source of truth).
-          # Both Lambda modules use this same URI on first create; lifecycle rules
-          # ignore image_uri after that and CI manages actual deployments.
+          # Both Lambda modules share this same placeholder_image_uri on initial
+          # creation only. After first deploy, lifecycle { ignore_changes = [image_uri] }
+          # takes over and CI manages each Lambda's image independently.
           API_ECR_REPO="${API_ECR_URL##*/}"
           if aws ecr describe-images \
               --repository-name "$API_ECR_REPO" \
               --image-ids imageTag=latest &>/dev/null; then
             echo "API ECR has :latest — using as placeholder"
             echo "placeholder_uri=$API_ECR_URL:latest" >> "$GITHUB_OUTPUT"
+          elif aws ecr describe-images \
+              --repository-name "$API_ECR_REPO" \
+              --image-ids imageTag=bootstrap &>/dev/null; then
+            echo "API ECR has :bootstrap — using as placeholder"
+            echo "placeholder_uri=$API_ECR_URL:bootstrap" >> "$GITHUB_OUTPUT"
           else
-            echo "Using :bootstrap as placeholder"
+            # Neither :latest nor :bootstrap exists (repo has only custom tags).
+            # Push :bootstrap so the placeholder URI points to a real image.
+            echo "No :latest or :bootstrap — pushing :bootstrap now"
+            docker tag "$LAMBDA_BOOTSTRAP_IMAGE" "$API_ECR_URL:bootstrap"
+            docker push "$API_ECR_URL:bootstrap"
             echo "placeholder_uri=$API_ECR_URL:bootstrap" >> "$GITHUB_OUTPUT"
           fi
 
@@ -235,6 +245,7 @@ jobs:
             -t $ECR_REPOSITORY_URL:latest \
             .
 
+      # Paths validated here must match the Dockerfile layout (apps/api/Dockerfile).
       - name: Validate API container
         env:
           ECR_REPOSITORY_URL: ${{ needs.terraform.outputs.ecr_repository_url }}
@@ -274,6 +285,8 @@ jobs:
 
       # --- Migration Lambda ---
 
+      # Build context must be monorepo root (.) because the Dockerfile COPYs
+      # package.json, package-lock.json, and workspace manifests from the root.
       - name: Build migrate Docker image
         env:
           ECR_REPOSITORY_URL: ${{ needs.terraform.outputs.migrate_ecr_repository_url }}
@@ -284,6 +297,8 @@ jobs:
             -t $ECR_REPOSITORY_URL:latest \
             .
 
+      # Paths validated here must match the Dockerfile layout (tools/migrate/Dockerfile)
+      # and the runtime constants in tools/migrate/src/index.ts (PRISMA_CLI path).
       - name: Validate migrate container
         env:
           ECR_REPOSITORY_URL: ${{ needs.terraform.outputs.migrate_ecr_repository_url }}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -116,7 +116,7 @@ variable "migrate_ecr_max_images" {
 }
 
 variable "placeholder_image_uri" {
-  description = "Lambda base image URI used as a placeholder until CI/CD deploys the service image. CI always passes this via -var from LAMBDA_BOOTSTRAP_IMAGE in deploy.yml (single source of truth). Default is used only for local terraform apply runs; update via: bash scripts/get-lambda-bootstrap-digest.sh"
+  description = "Lambda base image URI used as a placeholder until CI/CD deploys the service image. Shared by both lambda_api and lambda_migrate modules on initial creation only; after that, lifecycle { ignore_changes = [image_uri] } takes over and CI manages each Lambda's image independently. CI always passes this via -var from LAMBDA_BOOTSTRAP_IMAGE in deploy.yml (single source of truth). Default is used only for local terraform apply runs; update via: bash scripts/get-lambda-bootstrap-digest.sh"
   type        = string
   default     = "public.ecr.aws/lambda/nodejs@sha256:b1d950b97aaedc054c6c9c5409c98cf5c8f29de370a6f344113e1aeeaa441707"
 }


### PR DESCRIPTION
## Summary

- **build job**: Uploads `tools/migrate/dist/` as `migrate-dist` artifact alongside existing `api-dist`
- **terraform job**: Bootstraps both ECR repos (API + migrate) with targeted apply; pushes bootstrap image to any empty repos; adds `migrate_function_name` and `migrate_ecr_repository_url` to outputs
- **deploy-lambda → deploy-lambdas**: Downloads both artifacts, builds/validates/pushes/deploys both container images, waits for both Lambda updates
- **migrate-database**: Invokes the dedicated migration Lambda (`migrate_function_name`) instead of the API Lambda
- **Container validation**: API image validates `index.js` only; migrate image validates `index.js`, `node_modules/prisma/build/index.js`, `prisma/schema.prisma`, `prisma.config.ts`, and `prisma/migrations/`

### Design decisions

- **Bootstrap pushes to both ECR repos**: Each repo gets its own bootstrap image so each Lambda has a valid image from its own repo, even if the deploy fails mid-way.
- **Single placeholder URI**: Both Lambda modules use the same `placeholder_image_uri` (from API ECR) on first Terraform create. This avoids needing separate Terraform variables. After creation, `lifecycle { ignore_changes = [image_uri] }` takes over and CI manages actual images.
- **Sequential Lambda deploys**: API deploys first, then migrate, then waits for both. Keeps the workflow readable and debuggable.

Closes #49

## Test plan

- [ ] Workflow YAML is valid (no syntax errors)
- [ ] After merge to `main`: both ECR repos bootstrap correctly
- [ ] Both Docker images build and pass container validation
- [ ] Both Lambdas deploy with correct images
- [ ] Migration Lambda invoked successfully
- [ ] Health check passes on API endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the deployment workflow to support separate API and migration Lambda containers with coordinated provisioning and rollout.

New Features:
- Upload and deploy a dedicated migrate Lambda artifact and container image alongside the existing API Lambda.
- Introduce a separate migration Lambda invocation in the migrate-database job instead of using the API Lambda.

Enhancements:
- Extend Terraform bootstrap to provision and initialize both API and migrate ECR repositories, sharing a placeholder image URI for initial Lambda creation.
- Split the deploy job into sequential API and migrate Lambda build/validate/push/deploy steps, including more targeted container content validation for each image.
- Adjust workflow dependencies so verification and migration steps depend on the new dual-Lambda deploy job.