### PR TITLE
feat(ci): add CI workflow for PRs to dev and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate Prisma Client
-        run: npm run db:generate --workspace=@surfaced-art/db
-
       - name: Build
         run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate Prisma Client
-        run: npm run db:generate --workspace=@surfaced-art/db
-
       - name: Build
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ infrastructure/terraform/**/.terraform.lock.hcl
 
 # Prisma
 packages/db/node_modules/.prisma
+packages/db/src/generated/
 
 # IDE
 .idea

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4,7 +4,8 @@
 // All primary keys are UUIDs
 
 generator client {
-  provider = "prisma-client-js"
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
 }
 
 datasource db {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '../src/generated/prisma/client'
 
 const prisma = new PrismaClient()
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from './generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 // Create a global PrismaClient instance to prevent multiple instances in development
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Re-export Prisma types
-export * from '@prisma/client'
+export * from './generated/prisma/client'
 
 // Export the client instance as default
 export default prisma

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
+    "db:generate": {
+      "cache": false
+    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "db:generate"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "dev": {


### PR DESCRIPTION
## Summary

- Creates `.github/workflows/ci.yml` — runs all quality gates (build, typecheck, lint, test) on PRs targeting `dev` and `main`
- Mirrors the build job from `deploy.yml` without artifact uploads
- Uses `concurrency` with `cancel-in-progress: true` to avoid redundant runs on rapid pushes
- Enables branch protection rules to block merge on failed checks

### Why this matters

Previously, the only CI ran on push to `main` via the deploy workflow. Broken code could land in `dev` unchecked. This workflow catches issues at the PR stage.

Closes #53

## Test plan

- [ ] PR to `dev` triggers the CI workflow
- [ ] PR to `main` triggers the CI workflow
- [ ] All quality gates run: build, typecheck, lint, test
- [ ] Failed checks block the PR from merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Introduce a CI GitHub Actions workflow that runs build, typecheck, lint, and test on PRs to the dev and main branches.