### PR TITLE
Release: artist profile API endpoint

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.0",
+    "@surfaced-art/db": "^0.0.1",
+    "@surfaced-art/types": "^0.0.1",
     "hono": "^4.7.0"
   },
   "devDependencies": {

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest'
-import { app } from './index'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@surfaced-art/db', () => ({
+  prisma: {
+    artistProfile: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+const { app } = await import('./index')
 
 describe('API', () => {
   describe('GET /', () => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,10 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 import { handle } from 'hono/aws-lambda'
+import { prisma } from '@surfaced-art/db'
 
 import { healthRoutes } from './routes/health'
+import { createArtistRoutes } from './routes/artists'
 
 // Create Hono app
 const app = new Hono()
@@ -21,6 +23,7 @@ app.use(
 
 // Mount routes
 app.route('/health', healthRoutes)
+app.route('/artists', createArtistRoutes(prisma))
 
 // Root route
 app.get('/', (c) => {

--- a/apps/api/src/routes/artists.test.ts
+++ b/apps/api/src/routes/artists.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { createArtistRoutes } from './artists'
+
+// Mock artist data matching what Prisma would return
+const mockApprovedArtist = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  userId: '550e8400-e29b-41d4-a716-446655440001',
+  displayName: 'Abbey Peters',
+  slug: 'abbey-peters',
+  bio: 'A ceramic artist based in Portland.',
+  location: 'Portland, OR',
+  websiteUrl: 'https://abbeypeters.com',
+  instagramUrl: 'https://instagram.com/abbeypeters',
+  stripeAccountId: null,
+  originZip: '97201',
+  status: 'approved' as const,
+  commissionsOpen: false,
+  coverImageUrl: 'https://cdn.example.com/cover.jpg',
+  profileImageUrl: 'https://cdn.example.com/profile.jpg',
+  applicationSource: null,
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+  updatedAt: new Date('2025-01-01T00:00:00Z'),
+  categories: [
+    { id: 'cat-1', artistId: '550e8400-e29b-41d4-a716-446655440000', category: 'ceramics' },
+    { id: 'cat-2', artistId: '550e8400-e29b-41d4-a716-446655440000', category: 'mixed_media' },
+  ],
+  cvEntries: [
+    {
+      id: 'cv-1',
+      artistId: '550e8400-e29b-41d4-a716-446655440000',
+      type: 'exhibition',
+      title: 'Solo Show at Gallery X',
+      institution: 'Gallery X',
+      year: 2024,
+      description: 'Solo exhibition featuring ceramic vessels.',
+      sortOrder: 0,
+    },
+    {
+      id: 'cv-2',
+      artistId: '550e8400-e29b-41d4-a716-446655440000',
+      type: 'education',
+      title: 'MFA Ceramics',
+      institution: 'Art Institute',
+      year: 2020,
+      description: null,
+      sortOrder: 1,
+    },
+  ],
+  processMedia: [
+    {
+      id: 'pm-1',
+      artistId: '550e8400-e29b-41d4-a716-446655440000',
+      type: 'photo',
+      url: 'https://cdn.example.com/process1.jpg',
+      videoAssetId: null,
+      videoPlaybackId: null,
+      videoProvider: null,
+      sortOrder: 0,
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+    },
+  ],
+  listings: [
+    {
+      id: 'listing-1',
+      artistId: '550e8400-e29b-41d4-a716-446655440000',
+      type: 'standard',
+      title: 'Ceramic Vessel #1',
+      description: 'A handmade ceramic vessel.',
+      medium: 'Stoneware',
+      category: 'ceramics',
+      price: 12500,
+      status: 'available',
+      isDocumented: true,
+      quantityTotal: 1,
+      quantityRemaining: 1,
+      artworkLength: 8,
+      artworkWidth: 8,
+      artworkHeight: 12,
+      packedLength: 12,
+      packedWidth: 12,
+      packedHeight: 16,
+      packedWeight: 5,
+      editionNumber: null,
+      editionTotal: null,
+      reservedUntil: null,
+      createdAt: new Date('2025-02-01T00:00:00Z'),
+      updatedAt: new Date('2025-02-01T00:00:00Z'),
+      images: [
+        {
+          id: 'img-1',
+          listingId: 'listing-1',
+          url: 'https://cdn.example.com/listing1-front.jpg',
+          isProcessPhoto: false,
+          sortOrder: 0,
+          createdAt: new Date('2025-02-01T00:00:00Z'),
+        },
+        {
+          id: 'img-2',
+          listingId: 'listing-1',
+          url: 'https://cdn.example.com/listing1-back.jpg',
+          isProcessPhoto: false,
+          sortOrder: 1,
+          createdAt: new Date('2025-02-01T00:00:00Z'),
+        },
+      ],
+    },
+    {
+      id: 'listing-2',
+      artistId: '550e8400-e29b-41d4-a716-446655440000',
+      type: 'standard',
+      title: 'Sold Piece',
+      description: 'A previously sold piece.',
+      medium: 'Porcelain',
+      category: 'ceramics',
+      price: 25000,
+      status: 'sold',
+      isDocumented: false,
+      quantityTotal: 1,
+      quantityRemaining: 0,
+      artworkLength: null,
+      artworkWidth: null,
+      artworkHeight: null,
+      packedLength: 10,
+      packedWidth: 10,
+      packedHeight: 14,
+      packedWeight: 4,
+      editionNumber: null,
+      editionTotal: null,
+      reservedUntil: null,
+      createdAt: new Date('2025-01-15T00:00:00Z'),
+      updatedAt: new Date('2025-01-20T00:00:00Z'),
+      images: [],
+    },
+  ],
+}
+
+const mockPendingArtist = {
+  ...mockApprovedArtist,
+  id: '550e8400-e29b-41d4-a716-446655440002',
+  slug: 'pending-artist',
+  status: 'pending' as const,
+}
+
+function createMockPrisma(findUniqueResult: unknown = null) {
+  return {
+    artistProfile: {
+      findUnique: vi.fn().mockResolvedValue(findUniqueResult),
+    },
+  } as unknown as Parameters<typeof createArtistRoutes>[0]
+}
+
+function createTestApp(prisma: ReturnType<typeof createMockPrisma>) {
+  const app = new Hono()
+  app.route('/artists', createArtistRoutes(prisma))
+  return app
+}
+
+describe('GET /artists/:slug', () => {
+  let mockPrisma: ReturnType<typeof createMockPrisma>
+  let app: ReturnType<typeof createTestApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('happy path', () => {
+    beforeEach(() => {
+      mockPrisma = createMockPrisma(mockApprovedArtist)
+      app = createTestApp(mockPrisma)
+    })
+
+    it('should return 200 with full artist profile for a valid slug', async () => {
+      const res = await app.request('/artists/abbey-peters')
+      expect(res.status).toBe(200)
+
+      const data = await res.json()
+      expect(data.displayName).toBe('Abbey Peters')
+      expect(data.slug).toBe('abbey-peters')
+      expect(data.bio).toBe('A ceramic artist based in Portland.')
+      expect(data.location).toBe('Portland, OR')
+    })
+
+    it('should include categories as a flat string array', async () => {
+      const res = await app.request('/artists/abbey-peters')
+      const data = await res.json()
+
+      expect(data.categories).toEqual(['ceramics', 'mixed_media'])
+    })
+
+    it('should include CV entries sorted by sort_order', async () => {
+      const res = await app.request('/artists/abbey-peters')
+      const data = await res.json()
+
+      expect(data.cvEntries).toHaveLength(2)
+      expect(data.cvEntries[0].title).toBe('Solo Show at Gallery X')
+      expect(data.cvEntries[0].sortOrder).toBe(0)
+      expect(data.cvEntries[1].title).toBe('MFA Ceramics')
+      expect(data.cvEntries[1].sortOrder).toBe(1)
+    })
+
+    it('should include process media sorted by sort_order', async () => {
+      const res = await app.request('/artists/abbey-peters')
+      const data = await res.json()
+
+      expect(data.processMedia).toHaveLength(1)
+      expect(data.processMedia[0].url).toBe('https://cdn.example.com/process1.jpg')
+      expect(data.processMedia[0].type).toBe('photo')
+    })
+
+    it('should include listings with images', async () => {
+      const res = await app.request('/artists/abbey-peters')
+      const data = await res.json()
+
+      expect(data.listings).toHaveLength(2)
+
+      // Available listing with images
+      const available = data.listings.find((l: { status: string }) => l.status === 'available')
+      expect(available.title).toBe('Ceramic Vessel #1')
+      expect(available.price).toBe(12500)
+      expect(available.images).toHaveLength(2)
+      expect(available.images[0].sortOrder).toBe(0)
+
+      // Sold listing
+      const sold = data.listings.find((l: { status: string }) => l.status === 'sold')
+      expect(sold.title).toBe('Sold Piece')
+      expect(sold.images).toHaveLength(0)
+    })
+
+    it('should preserve zero-valued dimensions instead of coercing to null', async () => {
+      const artistWithZeroDimensions = {
+        ...mockApprovedArtist,
+        listings: [
+          {
+            ...mockApprovedArtist.listings[0],
+            artworkLength: 0,
+            artworkWidth: 0,
+            artworkHeight: 0,
+          },
+        ],
+      }
+      mockPrisma = createMockPrisma(artistWithZeroDimensions)
+      app = createTestApp(mockPrisma)
+
+      const res = await app.request('/artists/abbey-peters')
+      const data = await res.json()
+
+      expect(data.listings[0].artworkLength).toBe(0)
+      expect(data.listings[0].artworkWidth).toBe(0)
+      expect(data.listings[0].artworkHeight).toBe(0)
+    })
+
+    it('should omit private fields (userId, stripeAccountId, originZip, applicationSource)', async () => {
+      const res = await app.request('/artists/abbey-peters')
+      const data = await res.json()
+
+      expect(data).not.toHaveProperty('userId')
+      expect(data).not.toHaveProperty('stripeAccountId')
+      expect(data).not.toHaveProperty('originZip')
+      expect(data).not.toHaveProperty('applicationSource')
+    })
+
+    it('should call Prisma with correct query parameters', async () => {
+      await app.request('/artists/abbey-peters')
+
+      expect(mockPrisma.artistProfile.findUnique).toHaveBeenCalledWith({
+        where: { slug: 'abbey-peters' },
+        include: {
+          categories: true,
+          cvEntries: { orderBy: { sortOrder: 'asc' } },
+          processMedia: { orderBy: { sortOrder: 'asc' } },
+          listings: {
+            include: {
+              images: { orderBy: { sortOrder: 'asc' } },
+            },
+            orderBy: { createdAt: 'desc' },
+          },
+        },
+      })
+    })
+  })
+
+  describe('404 for non-existent slug', () => {
+    beforeEach(() => {
+      mockPrisma = createMockPrisma(null)
+      app = createTestApp(mockPrisma)
+    })
+
+    it('should return 404 when slug does not exist', async () => {
+      const res = await app.request('/artists/nonexistent-artist')
+      expect(res.status).toBe(404)
+
+      const data = await res.json()
+      expect(data.error).toBe('Artist not found')
+    })
+  })
+
+  describe('404 for non-approved artists', () => {
+    beforeEach(() => {
+      mockPrisma = createMockPrisma(mockPendingArtist)
+      app = createTestApp(mockPrisma)
+    })
+
+    it('should return 404 for pending artist', async () => {
+      const res = await app.request('/artists/pending-artist')
+      expect(res.status).toBe(404)
+
+      const data = await res.json()
+      expect(data.error).toBe('Artist not found')
+    })
+
+    it('should return 404 for suspended artist', async () => {
+      const suspendedArtist = { ...mockApprovedArtist, status: 'suspended' }
+      mockPrisma = createMockPrisma(suspendedArtist)
+      app = createTestApp(mockPrisma)
+
+      const res = await app.request('/artists/abbey-peters')
+      expect(res.status).toBe(404)
+
+      const data = await res.json()
+      expect(data.error).toBe('Artist not found')
+    })
+  })
+})

--- a/apps/api/src/routes/artists.ts
+++ b/apps/api/src/routes/artists.ts
@@ -1,0 +1,116 @@
+import { Hono } from 'hono'
+import type { PrismaClient } from '@surfaced-art/db'
+import type { ArtistProfileResponse } from '@surfaced-art/types'
+
+export function createArtistRoutes(prisma: PrismaClient) {
+  const artists = new Hono()
+
+  /**
+   * GET /artists/:slug
+   * Returns a full artist profile with categories, CV entries, process media, and listings
+   */
+  artists.get('/:slug', async (c) => {
+    const slug = c.req.param('slug')
+
+    const artist = await prisma.artistProfile.findUnique({
+      where: { slug },
+      include: {
+        categories: true,
+        cvEntries: {
+          orderBy: { sortOrder: 'asc' },
+        },
+        processMedia: {
+          orderBy: { sortOrder: 'asc' },
+        },
+        listings: {
+          include: {
+            images: {
+              orderBy: { sortOrder: 'asc' },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    })
+
+    if (!artist || artist.status !== 'approved') {
+      return c.json({ error: 'Artist not found' }, 404)
+    }
+
+    const response: ArtistProfileResponse = {
+      id: artist.id,
+      displayName: artist.displayName,
+      slug: artist.slug,
+      bio: artist.bio,
+      location: artist.location,
+      websiteUrl: artist.websiteUrl,
+      instagramUrl: artist.instagramUrl,
+      status: artist.status,
+      commissionsOpen: artist.commissionsOpen,
+      coverImageUrl: artist.coverImageUrl,
+      profileImageUrl: artist.profileImageUrl,
+      createdAt: artist.createdAt,
+      updatedAt: artist.updatedAt,
+      categories: artist.categories.map((c) => c.category),
+      cvEntries: artist.cvEntries.map((entry) => ({
+        id: entry.id,
+        artistId: entry.artistId,
+        type: entry.type,
+        title: entry.title,
+        institution: entry.institution,
+        year: entry.year,
+        description: entry.description,
+        sortOrder: entry.sortOrder,
+      })),
+      processMedia: artist.processMedia.map((media) => ({
+        id: media.id,
+        artistId: media.artistId,
+        type: media.type,
+        url: media.url,
+        videoAssetId: media.videoAssetId,
+        videoPlaybackId: media.videoPlaybackId,
+        videoProvider: media.videoProvider,
+        sortOrder: media.sortOrder,
+        createdAt: media.createdAt,
+      })),
+      listings: artist.listings.map((listing) => ({
+        id: listing.id,
+        artistId: listing.artistId,
+        type: listing.type,
+        title: listing.title,
+        description: listing.description,
+        medium: listing.medium,
+        category: listing.category,
+        price: listing.price,
+        status: listing.status,
+        isDocumented: listing.isDocumented,
+        quantityTotal: listing.quantityTotal,
+        quantityRemaining: listing.quantityRemaining,
+        artworkLength: listing.artworkLength != null ? Number(listing.artworkLength) : null,
+        artworkWidth: listing.artworkWidth != null ? Number(listing.artworkWidth) : null,
+        artworkHeight: listing.artworkHeight != null ? Number(listing.artworkHeight) : null,
+        packedLength: Number(listing.packedLength),
+        packedWidth: Number(listing.packedWidth),
+        packedHeight: Number(listing.packedHeight),
+        packedWeight: Number(listing.packedWeight),
+        editionNumber: listing.editionNumber,
+        editionTotal: listing.editionTotal,
+        reservedUntil: listing.reservedUntil,
+        createdAt: listing.createdAt,
+        updatedAt: listing.updatedAt,
+        images: listing.images.map((img) => ({
+          id: img.id,
+          listingId: img.listingId,
+          url: img.url,
+          isProcessPhoto: img.isProcessPhoto,
+          sortOrder: img.sortOrder,
+          createdAt: img.createdAt,
+        })),
+      })),
+    }
+
+    return c.json(response)
+  })
+
+  return artists
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
+        "@surfaced-art/db": "^0.0.1",
+        "@surfaced-art/types": "^0.0.1",
         "hono": "^4.7.0"
       },
       "devDependencies": {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,4 +37,7 @@ export type {
   Save,
   Follow,
   Waitlist,
+  // API response types
+  ListingWithImages,
+  ArtistProfileResponse,
 } from './interfaces'

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -262,3 +262,23 @@ export interface Waitlist {
   email: string
   createdAt: Date
 }
+
+// ─── API Response Types ─────────────────────────────────────────────
+
+/**
+ * Listing with its images, as returned within an artist profile response
+ */
+export interface ListingWithImages extends Listing {
+  images: ListingImage[]
+}
+
+/**
+ * Full artist profile response for GET /artists/:slug
+ * Contains the profile plus all related data needed to render the page
+ */
+export interface ArtistProfileResponse extends Omit<ArtistProfile, 'userId' | 'stripeAccountId' | 'originZip' | 'applicationSource'> {
+  categories: CategoryType[]
+  cvEntries: ArtistCvEntry[]
+  processMedia: ArtistProcessMedia[]
+  listings: ListingWithImages[]
+}


### PR DESCRIPTION
## Summary

- Implements `GET /artists/:slug` API endpoint — the first Phase 2 backend route
- Adds `ArtistProfileResponse` and `ListingWithImages` response types to `packages/types`
- Registers the artist route in the API app with Prisma dependency injection

## What's included

### feat(api): add GET /artists/:slug endpoint
Returns everything the frontend needs to render a complete artist profile in a single request:
- Profile fields (display name, bio, location, URLs, images, commissions status)
- Categories as a flat string array
- CV entries sorted by `sort_order`
- Process media sorted by `sort_order`
- All listings (available + sold) with images, ordered by `created_at` desc

Design decisions:
- Factory pattern (`createArtistRoutes(prisma)`) for clean dependency injection in tests
- Private fields excluded from response (`userId`, `stripeAccountId`, `originZip`, `applicationSource`)
- Prisma `Decimal` fields converted to plain numbers via explicit null checks
- Single Prisma query with nested includes (no N+1)

### fix(api): use explicit null checks for nullable Decimal dimension fields
Fixes a subtle bug where `artworkLength ? Number(...)` would coerce valid zero values to `null`. Now uses `artworkLength != null ? Number(...)` instead.

## Test coverage (11 tests)
- Happy path with full nested response
- Categories as flat string array
- CV entries and process media sorted correctly
- Listings include nested images
- Zero-valued dimensions preserved (not coerced to null)
- Private fields omitted
- Prisma query structure verified
- 404 for non-existent slug
- 404 for pending artist
- 404 for suspended artist

## Files changed (8 files, +481 / -2)

| File | Change |
|------|--------|
| `apps/api/src/routes/artists.ts` | New — artist profile route |
| `apps/api/src/routes/artists.test.ts` | New — 11 unit tests |
| `apps/api/src/index.ts` | Register `/artists` route |
| `apps/api/src/index.test.ts` | Add `@surfaced-art/db` mock |
| `packages/types/src/interfaces.ts` | Add response types |
| `packages/types/src/index.ts` | Export new types |
| `apps/api/package.json` | Add workspace deps |
| `package-lock.json` | Lockfile update |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an artist profile API endpoint and shared response types to support fetching complete artist data by slug.

New Features:
- Introduce ListingWithImages and ArtistProfileResponse shared types for artist profile payloads.
- Add GET /artists/:slug route that returns an approved artist’s full profile, related media, and listings in a single response.
- Wire the new artist routes into the API app using the shared Prisma client dependency.

Bug Fixes:
- Ensure zero-valued artwork dimension fields are preserved by using explicit null checks when converting numeric values.

Enhancements:
- Mock the Prisma client in API index tests to isolate route behavior from the database.
- Export the new API response types from the shared types package for reuse across services.

Build:
- Add @surfaced-art/db and @surfaced-art/types as dependencies for the API app.

Tests:
- Add comprehensive tests for the artist profile endpoint covering happy path, data shaping, sorting, privacy filtering, error cases, and Prisma query structure.