### PR TITLE
fix(infra): terraform import for CloudWatch log group state migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,20 @@ jobs:
           terraform init \
             -backend-config="key=prod/terraform.tfstate"
 
+      # One-time migration: import existing CloudWatch log groups into new
+      # centralized state addresses. Safe to re-run (skips if already imported).
+      # TODO: Remove this step after one successful deploy.
+      - name: Import CloudWatch log groups (one-time migration)
+        working-directory: infrastructure/terraform
+        env:
+          TF_CLI_ARGS_import: >-
+            -var-file="environments/prod.tfvars"
+            -var="db_password=${{ secrets.TF_VAR_db_password }}"
+            -var="google_client_id=${{ secrets.TF_VAR_google_client_id }}"
+            -var="google_client_secret=${{ secrets.TF_VAR_google_client_secret }}"
+            -var="placeholder_image_uri=${{ env.LAMBDA_BOOTSTRAP_IMAGE }}"
+        run: bash ../../scripts/tf-state-mv-log-groups.sh
+
       # Bootstrap: create ECR repos before Lambdas so we can push images.
       # Lambda (package_type=Image) requires a private ECR image; public ECR URIs are invalid.
       - name: Bootstrap ECR Repositories


### PR DESCRIPTION
## Summary

- Fixes the failed deploy from PR #84 where `terraform apply` tried to recreate existing CloudWatch log groups
- Replaces the `terraform state mv` script with `terraform import` — works regardless of whether resources are already in state or were removed by a partial apply
- Adds a one-time "Import CloudWatch log groups" step to `deploy.yml` that runs before `terraform apply`, passing required vars via `TF_CLI_ARGS_import`
- Script is idempotent: checks `terraform state list` before each import, skips resources already present

## What happened

PR #84 merged the log group centralization but the deploy failed because the state migration script wasn't run first. Terraform destroyed the old state entries and tried to create new log groups, but the actual AWS resources still existed (`ResourceAlreadyExistsException`). This PR fixes the state by importing the existing log groups.

## After successful deploy

Remove these two items:
- `scripts/tf-state-mv-log-groups.sh`
- The "Import CloudWatch log groups (one-time migration)" step in `deploy.yml`

## Test plan

- [x] All quality gates pass (test, lint, typecheck, build)
- [ ] Deploy pipeline imports 4 log groups and applies cleanly
- [ ] Post-deploy `terraform plan` shows no pending changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update CloudWatch log group migration to import existing resources into centralized Terraform state and wire it into the production deploy workflow as a one-time pre-apply step.

Bug Fixes:
- Prevent Terraform from attempting to recreate existing CloudWatch log groups by importing them into the new centralized state addresses before apply.

Enhancements:
- Replace the previous state-move script with an idempotent Terraform import script that safely skips log groups already present in state.

Deployment:
- Add a one-time CloudWatch log group import step to the production deploy GitHub Actions workflow, passing required variables via TF_CLI_ARGS_import.