### PR TITLE
fix(infra): prevent set -e from aborting import script

### DIFF
--- a/scripts/tf-state-mv-log-groups.sh
+++ b/scripts/tf-state-mv-log-groups.sh
@@ -56,10 +56,14 @@ import_if_needed() {
   fi
 
   echo "${label} — importing..."
-  if terraform import "${address}" "${log_group_name}"; then
+  # Use `|| rc=$?` instead of `if` to guarantee set -e cannot intercept
+  # the non-zero exit code before our handler runs.
+  local rc=0
+  terraform import "${address}" "${log_group_name}" || rc=$?
+  if [ "$rc" -eq 0 ]; then
     echo "${label} — imported successfully"
   else
-    echo "${label} — not found in AWS, terraform apply will create it"
+    echo "${label} — import exited ${rc}; resource likely absent in AWS, terraform apply will create it"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Fixes the one-time CloudWatch log group import script so it doesn't abort on the first failed `terraform import`
- The previous `if terraform import ...; then ... else ... fi` pattern is unreliable under `set -e` — bash can propagate the non-zero exit before reaching the `else` branch
- Switches to `cmd || rc=$?` which unconditionally captures the exit code regardless of `errexit` settings

## Context
The last deploy attempt (PR #85) still failed at the import step because `set -euo pipefail` caused the script to exit immediately when `terraform import` returned non-zero, even though the `if` block was supposed to catch it.

After this fix, the script will:
1. Try to import each log group
2. If import fails (resource doesn't exist in AWS), log a message and continue
3. Let `terraform apply` create the log groups fresh

## Test plan
- [ ] Deploy runs the import step without aborting
- [ ] `terraform apply` creates all 4 CloudWatch log groups with correct retention
- [ ] After successful deploy, remove script and workflow step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the Terraform CloudWatch log group import script continues execution when imports fail under strict bash error settings.

Enhancements:
- Update the import helper to handle non-zero terraform import exit codes gracefully without being interrupted by set -e.
- Improve script logging to indicate whether each log group was imported successfully or will be created by terraform apply.