### PR TITLE
feat(web): add dark mode runtime with next-themes toggle

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,9 @@
     "@testing-library/jest-dom": "^6.9.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.575.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tailwind-merge": "^3.5.0"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { DM_Serif_Display, DM_Sans } from 'next/font/google'
+import { ThemeProvider } from 'next-themes'
 import { Header } from '@/components/Header'
 import { Footer } from '@/components/Footer'
 import { Container } from '@/components/ui/container'
@@ -31,15 +32,17 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className={`${dmSerifDisplay.variable} ${dmSans.variable}`}>
+    <html lang="en" className={`${dmSerifDisplay.variable} ${dmSans.variable}`} suppressHydrationWarning>
       <body className="antialiased min-h-screen flex flex-col">
-        <Header />
-        <main className="flex-1">
-          <Container className="py-8 md:py-12">
-            {children}
-          </Container>
-        </main>
-        <Footer />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <Header />
+          <main className="flex-1">
+            <Container className="py-8 md:py-12">
+              {children}
+            </Container>
+          </main>
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Navigation } from './Navigation'
 import { MobileNav } from './MobileNav'
+import { ThemeToggle } from './ThemeToggle'
 import { Container } from './ui/container'
 
 /**
@@ -24,13 +25,9 @@ export function Header() {
             Surfaced Art
           </Link>
 
-          {/* Right side: future sign-in placeholder + mobile nav */}
-          <div className="flex items-center gap-4">
-            {/* Sign-in placeholder -- uncomment when auth is ready
-            <Link href="/sign-in" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-              Sign In
-            </Link>
-            */}
+          {/* Right side: theme toggle + mobile nav */}
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
             <MobileNav />
           </div>
         </div>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { useTheme } from 'next-themes'
+import { Sun, Moon } from 'lucide-react'
+
+// Track client-side mount without useState/useEffect to satisfy React compiler
+const emptySubscribe = () => () => {}
+function useMounted() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  )
+}
+
+/**
+ * Minimal theme toggle for the site header.
+ * Cycles between light and dark mode.
+ * Uses useSyncExternalStore to handle SSR/client hydration boundary.
+ */
+export function ThemeToggle() {
+  const mounted = useMounted()
+  const { resolvedTheme, setTheme } = useTheme()
+
+  if (!mounted) {
+    // Placeholder to prevent layout shift before hydration
+    return <div className="w-9 h-9" />
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+      aria-label={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
+      className="inline-flex items-center justify-center w-9 h-9 rounded-md text-muted-foreground hover:text-foreground transition-colors"
+    >
+      {resolvedTheme === 'dark' ? (
+        <Sun className="h-5 w-5" />
+      ) : (
+        <Moon className="h-5 w-5" />
+      )}
+    </button>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,7 +494,9 @@
         "@testing-library/jest-dom": "^6.9.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.575.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "tailwind-merge": "^3.5.0"
@@ -9914,6 +9916,15 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.575.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
+      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -10214,6 +10225,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
## Summary
- Install `next-themes` and `lucide-react` dependencies
- Add `ThemeProvider` wrapper in `layout.tsx` with `attribute="class"`, `defaultTheme="system"`, `enableSystem`, `disableTransitionOnChange`
- Create `ThemeToggle` component with sun/moon icon toggle using `useSyncExternalStore` for hydration safety
- Add `suppressHydrationWarning` to `<html>` element
- Add theme toggle to site header

## Test plan
- [x] All quality gates pass (test, lint, typecheck, build)
- [x] Theme persists across page loads (localStorage)
- [x] No flash of wrong theme on initial load
- [x] Hydration mismatch handled with `useSyncExternalStore`

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add client-side theme provider and header toggle to support light/dark mode across the web app.

New Features:
- Introduce a global ThemeProvider to enable light, dark, and system themes using class-based theming.
- Add a ThemeToggle control in the site header to switch between light and dark modes with icon-based UI.

Enhancements:
- Wrap the application layout with the theme provider and suppress HTML hydration warnings to avoid SSR/client mismatches.

Build:
- Add next-themes and lucide-react dependencies to support theming and iconography.