### PR TITLE
feat(web): create ListingCard, ArtistCard, and ProfilePhoto components

### DIFF
--- a/apps/web/src/components/ArtistCard.tsx
+++ b/apps/web/src/components/ArtistCard.tsx
@@ -6,7 +6,7 @@ import { ProfilePhoto } from './ProfilePhoto'
 import { Category } from '@surfaced-art/types'
 import type { CategoryType } from '@surfaced-art/types'
 
-const categoryLabels: Record<string, string> = Object.fromEntries(
+const categoryLabels = Object.fromEntries(
   Object.values(Category).map((c) => [
     c,
     c
@@ -14,7 +14,7 @@ const categoryLabels: Record<string, string> = Object.fromEntries(
       .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
       .join(' '),
   ])
-)
+) as Record<CategoryType, string>
 
 type ArtistCardProps = {
   artist: {

--- a/apps/web/src/components/ListingCard.tsx
+++ b/apps/web/src/components/ListingCard.tsx
@@ -15,7 +15,6 @@ type ListingCardProps = {
     primaryImageUrl: string | null
   }
   artistName: string
-  artistSlug: string
   variant?: 'browse' | 'profile'
   className?: string
 }
@@ -23,7 +22,6 @@ type ListingCardProps = {
 export function ListingCard({
   listing,
   artistName,
-  artistSlug,
   variant = 'browse',
   className,
 }: ListingCardProps) {

--- a/apps/web/src/components/ProfilePhoto.tsx
+++ b/apps/web/src/components/ProfilePhoto.tsx
@@ -41,7 +41,9 @@ export function ProfilePhoto({
         />
       ) : (
         <div className="flex size-full items-center justify-center text-muted-text">
-          <span className="font-serif text-lg">{alt.charAt(0)}</span>
+          <span className="font-serif text-lg">
+            {alt.trim().charAt(0).toUpperCase() || '?'}
+          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
Build the two primary reusable content card components used across all frontend pages, plus a reusable profile photo utility.

## New Components

### ListingCard (`src/components/ListingCard.tsx`)
- Displays: primary image (1:1 aspect), title, artist name, medium, price
- Two hover variants via `variant` prop:
  - `browse` (default): info overlay slides up from bottom with gradient
  - `profile`: image scales up slightly (1.02x)
- Sold indicator: red dot in upper-right + "Sold" text label
- Price formatting via `@surfaced-art/utils/formatCurrency`
- Links to `/listing/[id]`

### ArtistCard (`src/components/ArtistCard.tsx`)
- Cover image (16:9), overlapping circle profile photo
- Display name (serif font), location, category badges
- Uses Badge component from ShadCN components
- Links to `/artist/[slug]`

### ProfilePhoto (`src/components/ProfilePhoto.tsx`)
- Circle photo with sm (40px), md (48px), lg (120px) sizes
- Optional `bordered` prop for background ring when overlapping covers
- Fallback: shows first letter of alt text on surface background

## Design System Compliance
- All colors use CSS custom properties (no hardcoded hex except overlay gradient)
- Card hover: shadow-md + translate-y-0.5, 250ms ease-in-out
- Image: next/image with `unoptimized` prop
- Typography: serif for titles, muted-text for secondary info

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add reusable listing and artist card components along with a shared profile photo utility for the web app UI.

New Features:
- Introduce a ListingCard component to display artwork listings with image, metadata, price, and sold status with configurable hover variants.
- Add an ArtistCard component to showcase artist information including cover image, profile photo, location, and category badges.
- Create a reusable ProfilePhoto component for displaying circular profile images with size options, optional border ring, and text fallback.