### PR TITLE
ci: add dev-to-main promotion and post-merge sync workflows

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -27,19 +27,21 @@ jobs:
         id: commits
         run: |
           COMMITS=$(git log origin/main..origin/dev --oneline)
-          if [ -z "$COMMITS" ]; then
-            COMMITS="No commits ahead of main."
-          fi
           printf 'commits<<EOF\n%s\nEOF\n' "$COMMITS" >> "$GITHUB_OUTPUT"
+          if [ -z "$COMMITS" ]; then
+            echo "has_commits=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_commits=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create or update dev to main PR
+        if: steps.commits.outputs.has_commits == 'true'
         uses: actions/github-script@v8
         env:
           COMMITS: ${{ steps.commits.outputs.commits }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { execSync } = require('child_process');
             const commits = process.env.COMMITS || '';
 
             const fence = '```';


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows that automate the dev/main branch sync, eliminating the recurring drift where \`main\` accumulated merge commits that \`dev\` never received.

## Changes

**\`promote.yml\`** — triggers on every push to \`dev\`:
- Checks for an existing open PR from \`dev\` → \`main\`
- Creates one if none exists, with a body listing all pending commits
- Updates the PR body if one already exists (stays fresh after each merge to \`dev\`)
- Never merges — human approves and clicks merge with **rebase**

**\`sync-dev.yml\`** — triggers on every push to \`main\`:
- Fast-forwards \`dev\` to \`main\` after a PR is merged
- Fails loudly (does not force-push) if fast-forward is not possible

## Process note

The initial broken version was committed directly to \`dev\` (bypassing the feature branch process). This PR corrects that and fixes the YAML syntax error in the original \`promote.yml\` (backticks and \`---\` inside the inline script were being parsed as YAML; moved them into JS string variables).

## One manual step required

In **GitHub → repo Settings → General → Pull Requests**, uncheck **Allow merge commits** and leave squash and rebase enabled. This removes the merge strategy that caused the original drift. The PAT lacks \`Administration: write\` to do this via API.

## Summary by Sourcery

Automate maintenance of the dev-to-main promotion pull request using GitHub Script instead of shell and gh CLI.

CI:
- Refine the dev-to-main promotion workflow to generate the PR body and create or update the promotion PR via actions/github-script.
- Rename the workflow and job labels from using an arrow symbol to plain 'dev to main' wording for better clarity and compatibility.