### PR TITLE
ci: add dev-to-main promotion and sync workflows

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -44,19 +44,63 @@ jobs:
           script: |
             const commits = process.env.COMMITS || '';
 
-            const fence = '```';
+            // Parse commits into { type -> [subject, ...] } groups.
+            // Conventional commit format: "sha type(scope): subject"
+            const TYPE_LABELS = {
+              feat:     'Features',
+              fix:      'Bug Fixes',
+              refactor: 'Refactoring',
+              test:     'Tests',
+              ci:       'CI / Automation',
+              chore:    'Chores',
+              docs:     'Documentation',
+              perf:     'Performance',
+              build:    'Build',
+            };
+
+            const groups = {};
+            const other = [];
+
+            for (const line of commits.split('\n').filter(Boolean)) {
+              // Strip leading SHA (first token)
+              const message = line.replace(/^[0-9a-f]+\s+/, '');
+              const match = message.match(/^(\w+)(?:\([^)]+\))?!?:\s+(.+)/);
+              if (match) {
+                const type = match[1];
+                const subject = match[2];
+                const label = TYPE_LABELS[type];
+                // Unknown conventional types go into other[] to avoid a
+                // duplicate "Other" section alongside the fallback array.
+                if (!label) {
+                  other.push(subject);
+                } else {
+                  groups[label] = groups[label] || [];
+                  groups[label].push(subject);
+                }
+              } else {
+                other.push(message);
+              }
+            }
+
+            const totalCommits = commits.split('\n').filter(Boolean).length;
+            const title = `release: dev to main (${totalCommits} change${totalCommits === 1 ? '' : 's'})`;
+
+            const sections = [];
+            for (const [label, subjects] of Object.entries(groups)) {
+              sections.push(`### ${label}\n${subjects.map(s => `- ${s}`).join('\n')}`);
+            }
+            if (other.length) {
+              sections.push(`### Other\n${other.map(s => `- ${s}`).join('\n')}`);
+            }
+
             const hr = '---';
             const body = [
-              '## Pending changes',
+              '## Summary',
               '',
-              'The following commits on `dev` are not yet on `main`:',
-              '',
-              fence,
-              commits,
-              fence,
+              ...sections,
               '',
               hr,
-              '_This PR is maintained automatically. Merge with **rebase** to keep a linear history on `main`. After merging, `dev` will be fast-forwarded automatically._',
+              '_Auto-generated. This PR is updated on every push to `dev` and reflects all changes not yet on `main`._',
             ].join('\n');
 
             const { data: pulls } = await github.rest.pulls.list({
@@ -73,16 +117,17 @@ jobs:
                 repo: context.repo.repo,
                 head: 'dev',
                 base: 'main',
-                title: 'chore: promote dev to main',
+                title,
                 body,
               });
-              console.log('Created new dev to main PR.');
+              console.log('Created new dev to main PR: ' + title);
             } else {
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pulls[0].number,
+                title,
                 body,
               });
-              console.log('Updated PR #' + pulls[0].number + '.');
+              console.log('Updated PR #' + pulls[0].number + ': ' + title);
             }

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -30,7 +30,11 @@ jobs:
 
       - name: Fast-forward dev to main
         run: |
-          git checkout dev
+          if git show-ref --verify --quiet refs/remotes/origin/dev; then
+            git checkout dev
+          else
+            git checkout -B dev origin/main
+          fi
           if ! git merge --ff-only origin/main; then
             echo "::error::Fast-forward failed — dev has diverged from main."
             echo "::error::This should not happen in normal flow. Investigate before force-pushing."


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to automate the dev/main branch relationship. Replaces the conflicted PR #150 with a clean single commit on top of current \`dev\`.

### \`promote.yml\`
Triggers on every push to \`dev\`. Ensures a PR from \`dev\` → \`main\` always exists:
- Creates the PR if none is open; updates the body if one exists
- Short-circuits with no-op when \`dev\` has no commits ahead of \`main\`
- **Title**: \`release: dev to main (N changes)\` — reflects intent, not mechanism
- **Body**: commits grouped by conventional type (Features, Bug Fixes, CI / Automation, etc.) with bullet points per subject; unknown types and non-conventional messages collapse into a single Other section (no duplicate sections)
- Title also updated on each run as more commits accumulate before merging

### \`sync-dev.yml\`
Triggers on every push to \`main\`. Fast-forwards \`dev\` to \`main\` after a PR is merged:
- Creates \`dev\` from \`main\` if the branch doesn't yet exist
- Fails explicitly on divergence rather than force-pushing

## Review feedback addressed
- Removed unused \`execSync\` import (Sourcery)
- Fixed duplicate "Other" section bug: unknown conventional types now route to \`other[]\` instead of \`groups['Other']\` (Sourcery)
- Added missing \`dev\` branch guard in \`sync-dev.yml\` (Sourcery)

## Summary by Sourcery

Automate and stabilize the dev↔main branch promotion and synchronization flows in GitHub Actions.

CI:
- Enhance the dev→main promotion workflow to derive an auto-updated PR title and summary body from conventional commit messages, grouping commits by type and aggregating uncategorized changes under a single Other section.
- Improve the main→dev sync workflow to safely handle missing dev branches by creating them from main and to continue explicitly failing on non–fast-forward merges.