### PR TITLE
feat(web,api): Phase 2 QA polish, featured artists, and E2E tests

### DIFF
--- a/apps/web/e2e/artist-profile.spec.ts
+++ b/apps/web/e2e/artist-profile.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+// Seed data references — update if seed data changes
+const SEED_ARTIST_SLUG = 'abbey-peters'
+const SEED_ARTIST_NAME = 'Abbey Peters'
+
+test.describe('E2E: Artist Profile Browsing → Listing Detail → Navigate Back', () => {
+  test('full artist profile browsing journey', async ({ page }) => {
+    // Step 1: Navigate to artist profile
+    await page.goto(`/artist/${SEED_ARTIST_SLUG}`)
+    await page.waitForLoadState('networkidle')
+
+    // Step 2: Verify profile renders
+    await expect(page.getByTestId('artist-hero')).toBeVisible()
+    await expect(page.getByTestId('artist-name')).toBeVisible()
+    await expect(page.getByTestId('artist-name')).toContainText(SEED_ARTIST_NAME)
+    await expect(page.getByTestId('artist-bio')).toBeVisible()
+
+    // Step 3: Verify listings section renders with at least one listing card
+    await expect(page.getByTestId('available-work')).toBeVisible()
+    const listingCards = page.getByTestId('listing-card')
+    await expect(listingCards.first()).toBeVisible()
+    const listingCount = await listingCards.count()
+    expect(listingCount).toBeGreaterThan(0)
+
+    // Step 4: Verify CV/history section renders (if artist has CV entries)
+    const cvSection = page.getByTestId('cv-section')
+    // CV section may or may not exist depending on seed data
+    if (await cvSection.isVisible()) {
+      await expect(cvSection).toBeVisible()
+    }
+
+    // Step 5: Click a listing card in the "Available Work" section
+    const firstListingCard = listingCards.first()
+    const listingHref = await firstListingCard.getAttribute('href')
+    expect(listingHref).toBeTruthy()
+    await firstListingCard.click()
+    await page.waitForLoadState('networkidle')
+
+    // Step 6: Verify listing detail page renders
+    expect(page.url()).toContain('/listing/')
+    await expect(page.getByTestId('listing-title')).toBeVisible()
+    await expect(page.getByTestId('listing-price')).toBeVisible()
+    // Price should be formatted as $X.XX, not raw cents
+    const priceText = await page.getByTestId('listing-price').textContent()
+    expect(priceText).toMatch(/\$[\d,]+\.\d{2}/)
+    await expect(page.getByTestId('listing-images')).toBeVisible()
+
+    // Step 7: Navigate back to the artist profile
+    await page.goBack()
+    await page.waitForLoadState('networkidle')
+
+    // Step 8: Verify artist profile still renders correctly (no broken state)
+    await expect(page.getByTestId('artist-hero')).toBeVisible()
+    await expect(page.getByTestId('artist-name')).toContainText(SEED_ARTIST_NAME)
+    await expect(page.getByTestId('available-work')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/category-browse.spec.ts
+++ b/apps/web/e2e/category-browse.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+// Seed data references — update if seed data changes
+const SEED_CATEGORY = 'ceramics'
+const SEED_CATEGORY_LABEL = 'Ceramics'
+
+test.describe('E2E: Category Browsing → Listing Detail', () => {
+  test('browse category and navigate to listing detail', async ({ page }) => {
+    // Step 1: Navigate to category page
+    await page.goto(`/category/${SEED_CATEGORY}`)
+    await page.waitForLoadState('networkidle')
+
+    // Step 2: Verify category page renders
+    await expect(page.getByTestId('category-header')).toBeVisible()
+    await expect(page.getByTestId('category-header')).toContainText(SEED_CATEGORY_LABEL)
+
+    // Step 3: Verify listing grid is visible with listing cards
+    await expect(page.getByTestId('category-content')).toBeVisible()
+    const listingCards = page.getByTestId('listing-card')
+    await expect(listingCards.first()).toBeVisible()
+    const listingCount = await listingCards.count()
+    expect(listingCount).toBeGreaterThan(0)
+
+    // Step 4: Verify listing cards show expected content (image, title, price via card info)
+    const firstCard = listingCards.first()
+    // Card should have an image (either an <img> or a placeholder div)
+    const cardImage = firstCard.locator('img')
+    const hasImage = await cardImage.count()
+    if (hasImage > 0) {
+      await expect(cardImage.first()).toBeVisible()
+    }
+
+    // Step 5: Click a listing card
+    await firstCard.click()
+    await page.waitForLoadState('networkidle')
+
+    // Step 6: Verify listing detail page renders correctly
+    expect(page.url()).toContain('/listing/')
+    await expect(page.getByTestId('listing-title')).toBeVisible()
+    await expect(page.getByTestId('listing-price')).toBeVisible()
+    // Price should be formatted as $X.XX
+    const priceText = await page.getByTestId('listing-price').textContent()
+    expect(priceText).toMatch(/\$[\d,]+\.\d{2}/)
+    await expect(page.getByTestId('listing-images')).toBeVisible()
+    await expect(page.getByTestId('listing-description')).toBeVisible()
+
+    // Step 7: Verify artist card on listing detail links to artist profile
+    const artistCard = page.getByTestId('artist-card')
+    await expect(artistCard).toBeVisible()
+    const artistLink = artistCard.locator('a[href*="/artist/"]')
+    if (await artistLink.count() > 0) {
+      const href = await artistLink.first().getAttribute('href')
+      expect(href).toMatch(/\/artist\/[\w-]+/)
+    }
+  })
+})

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * E2E acceptance tests for Phase 2.
+ * These test critical user journeys against a running dev server with seeded data.
+ *
+ * Usage:
+ *   npx playwright test --config=e2e/playwright.config.ts
+ *
+ * Requires:
+ *   - Next.js dev server running (or use webServer config below)
+ *   - API server running with seeded database
+ */
+export default defineConfig({
+  testDir: './',
+  testMatch: '*.spec.ts',
+  testIgnore: ['visual-qa/**'],
+  timeout: 30_000,
+  retries: 1,
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  reporter: [['list'], ['html', { outputFolder: './e2e-report', open: 'never' }]],
+})

--- a/apps/web/e2e/waitlist-signup.spec.ts
+++ b/apps/web/e2e/waitlist-signup.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+
+// Generate a unique email for each test run to avoid conflicts
+function uniqueEmail(): string {
+  const timestamp = Date.now()
+  const random = Math.random().toString(36).substring(2, 8)
+  return `e2e-test-${timestamp}-${random}@example.com`
+}
+
+test.describe('E2E: Waitlist Signup', () => {
+  test('submit waitlist form and verify success', async ({ page }) => {
+    const testEmail = uniqueEmail()
+
+    // Step 1: Navigate to homepage
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // Step 2: Locate the waitlist signup form
+    const waitlistSection = page.getByTestId('waitlist')
+    await expect(waitlistSection).toBeVisible()
+
+    // Step 3: Enter a valid email address
+    const emailInput = page.getByTestId('waitlist-email-input')
+    await expect(emailInput).toBeVisible()
+    await emailInput.fill(testEmail)
+
+    // Step 4: Submit the form
+    const submitButton = page.getByTestId('waitlist-submit')
+    await expect(submitButton).toBeVisible()
+    await submitButton.click()
+
+    // Step 5: Verify success state is displayed
+    const successMessage = page.getByTestId('waitlist-success')
+    await expect(successMessage).toBeVisible({ timeout: 10_000 })
+
+    // Step 6: Navigate away and back to reset form state, then try same email
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // Step 7: Attempt to submit the same email again
+    const emailInputAgain = page.getByTestId('waitlist-email-input')
+    await emailInputAgain.fill(testEmail)
+    const submitButtonAgain = page.getByTestId('waitlist-submit')
+    await submitButtonAgain.click()
+
+    // Step 8: Verify appropriate feedback is shown (either success or "already signed up" — not a crash)
+    // The form should respond gracefully — either show success again or an informational message
+    await page.waitForTimeout(3000)
+    // Verify no uncaught errors — page should still be functional
+    const waitlistSectionStillVisible = page.getByTestId('waitlist')
+    await expect(waitlistSectionStillVisible).toBeVisible()
+    // Should see either success message or an error message — not a blank/broken state
+    const hasSuccess = await page.getByTestId('waitlist-success').isVisible()
+    const hasError = await page.getByTestId('waitlist-error').isVisible()
+    expect(hasSuccess || hasError).toBeTruthy()
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "test:visual-qa": "playwright test --config=e2e/visual-qa.config.ts",
     "test:visual-qa:desktop": "playwright test --config=e2e/visual-qa.config.ts --project=desktop",
     "test:visual-qa:tablet": "playwright test --config=e2e/visual-qa.config.ts --project=tablet",

--- a/apps/web/src/app/category/[category]/page.tsx
+++ b/apps/web/src/app/category/[category]/page.tsx
@@ -61,7 +61,7 @@ export default async function CategoryBrowsePage({ params }: Props) {
       </section>
 
       {/* Category Navigation */}
-      <nav aria-label="Category navigation" className="flex flex-wrap gap-2">
+      <nav data-testid="category-nav" aria-label="Category navigation" className="flex flex-wrap gap-2">
         {CATEGORIES.map((cat) => (
           <Link
             key={cat.slug}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center text-center">
+      <h1 className="font-serif text-4xl text-foreground">Page not found</h1>
+      <p className="mt-4 max-w-md text-muted-text">
+        The page you&apos;re looking for doesn&apos;t exist or has been moved.
+      </p>
+      <Link
+        href="/"
+        className="mt-6 text-sm text-muted-text transition-colors hover:text-foreground"
+      >
+        &larr; Back to gallery
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 vi.mock('@/lib/api', () => ({
   getCategories: vi.fn().mockResolvedValue([]),
   getListings: vi.fn().mockResolvedValue({ data: [], meta: { page: 1, limit: 6, total: 0, totalPages: 0 } }),
+  getFeaturedArtists: vi.fn().mockResolvedValue([]),
 }))
 
 import Home from './page'

--- a/apps/web/src/components/ArtistCard.tsx
+++ b/apps/web/src/components/ArtistCard.tsx
@@ -26,12 +26,14 @@ type ArtistCardProps = {
     categories: CategoryType[]
   }
   className?: string
+  'data-testid'?: string
 }
 
-export function ArtistCard({ artist, className }: ArtistCardProps) {
+export function ArtistCard({ artist, className, 'data-testid': testId }: ArtistCardProps) {
   return (
     <Link
       href={`/artist/${artist.slug}`}
+      data-testid={testId}
       className={cn(
         'group block rounded-md bg-surface overflow-hidden transition-[box-shadow,transform] duration-250 ease-in-out hover:shadow-md hover:-translate-y-0.5',
         className

--- a/apps/web/src/components/ListingCard.tsx
+++ b/apps/web/src/components/ListingCard.tsx
@@ -31,6 +31,7 @@ export function ListingCard({
   return (
     <Link
       href={href}
+      data-testid="listing-card"
       className={cn(
         'group block rounded-md bg-surface transition-[box-shadow,transform] duration-250 ease-in-out hover:shadow-md hover:-translate-y-0.5',
         className

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   ArtistProfileResponse,
   CategoryWithCount,
+  FeaturedArtistItem,
   ListingDetailResponse,
   ListingListItem,
   PaginatedResponse,
@@ -48,6 +49,11 @@ export class ApiError extends Error {
 
 export async function getArtistProfile(slug: string): Promise<ArtistProfileResponse> {
   return apiFetch<ArtistProfileResponse>(`/artists/${encodeURIComponent(slug)}`)
+}
+
+export async function getFeaturedArtists(limit?: number): Promise<FeaturedArtistItem[]> {
+  const params = limit ? `?limit=${limit}` : ''
+  return apiFetch<FeaturedArtistItem[]>(`/artists${params}`)
 }
 
 export async function getCategories(): Promise<CategoryWithCount[]> {

--- a/apps/web/src/test/mocks/next-image.tsx
+++ b/apps/web/src/test/mocks/next-image.tsx
@@ -1,0 +1,14 @@
+/**
+ * Mock for next/image used in Vitest tests.
+ * Renders a plain <img> tag with src, alt, and common props.
+ * Next.js-specific props (fill, unoptimized) are accepted but ignored.
+ */
+import React from 'react'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function Image({ src, alt, fill, unoptimized, ...props }: Record<string, unknown>) {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img src={src as string} alt={alt as string} {...props} />
+}
+
+export default Image

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       'next/link': path.resolve(__dirname, './src/test/mocks/next-link.tsx'),
+      'next/image': path.resolve(__dirname, './src/test/mocks/next-image.tsx'),
     },
   },
 })

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -42,6 +42,7 @@ export type {
   ArtistProfileResponse,
   ArtistSummary,
   ArtistSummaryWithCategories,
+  FeaturedArtistItem,
   CategoryWithCount,
   ListingListItem,
   ListingDetailResponse,

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -283,6 +283,19 @@ export interface ArtistProfileResponse extends Omit<ArtistProfile, 'userId' | 's
   listings: ListingWithImages[]
 }
 
+/**
+ * Lightweight artist item for featured artists list on homepage.
+ * Returned by GET /artists?featured=true
+ */
+export interface FeaturedArtistItem {
+  slug: string
+  displayName: string
+  location: string
+  profileImageUrl: string | null
+  coverImageUrl: string | null
+  categories: CategoryType[]
+}
+
 // ─── Categories API Response Types ─────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Closes #44 (Phase 2 QA, polish, and exit criteria verification) and Closes #65 (Phase 2 Playwright acceptance tests).

This PR completes the Phase 2 QA pass by filling in the last missing feature (Featured Artists section), adding all required `data-testid` attributes, writing the three E2E acceptance tests, and fixing test infrastructure issues.

### Changes

**New feature: Featured Artists on homepage**
- Added `GET /artists` API endpoint returning approved artists with categories, cover images, and profile images (supports `?limit=N` query param)
- Added `FeaturedArtistItem` type to `@surfaced-art/types`
- Added `getFeaturedArtists()` to the frontend API client
- Added "Featured Artists" section to the homepage between hero and featured listings, rendering `ArtistCard` components in a responsive grid

**data-testid completeness**
- Added `data-testid="listing-card"` to `ListingCard` component
- Added `data-testid` prop support to `ArtistCard` component
- Added `data-testid="category-nav"` to category browse page navigation
- Added `data-testid="category-grid-section"` to homepage category section
- Added `data-testid="artist-card"` to featured artist cards on homepage

**E2E Playwright acceptance tests (3 spec files)**
- `artist-profile.spec.ts` — Artist profile → listing detail → navigate back
- `category-browse.spec.ts` — Category page → listing detail → verify artist link
- `waitlist-signup.spec.ts` — Submit waitlist → verify success → duplicate submission handling
- Added `apps/web/e2e/playwright.config.ts` for E2E test configuration
- Added `test:e2e` script to `apps/web/package.json`

**QA fixes**
- Added custom 404 page (`apps/web/src/app/not-found.tsx`) for clean invalid route handling
- Added `next/image` mock for Vitest (fixes pre-existing test infrastructure issue)
- Added `next/image` alias to `vitest.config.ts`
- Added `getFeaturedArtists` mock to homepage test

**Unit tests**
- 7 new unit tests for `GET /artists` endpoint (happy path, categories flattening, limit param, cap at 20, empty results)

## Test plan

- [x] `npm run test` — 11 tasks pass (all unit + integration tests including 7 new)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — all packages pass
- [x] `npm run build` — successful, `/_not-found` route now included
- [ ] Run `npm run test:e2e` against a deployed preview URL to verify E2E tests pass
- [ ] Visual review of homepage Featured Artists section on preview deploy
- [ ] Verify 404 page renders cleanly at an invalid route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a featured artists experience to the homepage, expose it via a new artists list API, and back it with E2E and unit tests plus QA-focused polish.

New Features:
- Expose a GET /artists endpoint returning lightweight featured artist data with optional limiting for homepage consumption.
- Add a Featured Artists section to the homepage that displays artists in a responsive grid using ArtistCard components.
- Introduce a typed FeaturedArtistItem model and frontend API client helper for fetching featured artists.

Bug Fixes:
- Provide a custom Next.js 404 page for cleaner handling of invalid routes.

Enhancements:
- Add data-testid attributes and support to key UI components and sections to enable robust E2E and integration testing coverage.
- Improve Vitest configuration by aliasing next/image to a local mock to stabilize frontend unit tests.
- Extend ArtistCard and ListingCard link elements with test IDs for better selectors in automated tests.

Tests:
- Add comprehensive unit tests for the new GET /artists list endpoint including shape, category flattening, limit handling, and empty states.
- Introduce Playwright E2E specs covering artist profile to listing journeys, category browsing to listing detail, and waitlist signup behavior.
- Add a dedicated Playwright E2E config and npm script for running Phase 2 acceptance tests.