### PR TITLE
fix(db,infra): use proper RDS CA verification instead of disabling SSL checks

### DIFF
--- a/infrastructure/terraform/modules/lambda-api/main.tf
+++ b/infrastructure/terraform/modules/lambda-api/main.tf
@@ -55,6 +55,12 @@ resource "aws_lambda_function" "api" {
       S3_BUCKET_NAME       = var.s3_bucket_name
       CLOUDFRONT_URL       = var.cloudfront_url
       FRONTEND_URL         = var.frontend_url
+
+      # Add Amazon RDS CA certificates to Node.js trust store so the pg driver
+      # can verify RDS server certificates. The Lambda base image ships this
+      # bundle at /var/runtime/ca-cert.pem; Node 20+ no longer loads it
+      # automatically, so it must be set explicitly.
+      NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
     }
   }
 

--- a/infrastructure/terraform/modules/lambda-migrate/main.tf
+++ b/infrastructure/terraform/modules/lambda-migrate/main.tf
@@ -50,8 +50,9 @@ resource "aws_lambda_function" "migrate" {
 
   environment {
     variables = {
-      NODE_ENV     = var.environment
-      DATABASE_URL = var.database_url
+      NODE_ENV            = var.environment
+      DATABASE_URL        = var.database_url
+      NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
     }
   }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs'
 import { PrismaClient } from './generated/prisma/client.js'
 import { PrismaPg } from '@prisma/adapter-pg'
 
@@ -6,15 +7,44 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
+/**
+ * Build the SSL configuration for the pg driver adapter.
+ *
+ * Strategy (in priority order):
+ * 1. Development — no SSL (local PostgreSQL doesn't use it)
+ * 2. Explicit CA bundle — if DB_SSL_CA_PATH is set, load it and enable full
+ *    certificate verification. In Lambda, NODE_EXTRA_CA_CERTS achieves the
+ *    same thing at the runtime level; this option exists for non-Lambda
+ *    environments or when finer control is needed.
+ * 3. DB_SSL_REJECT_UNAUTHORIZED=false — opt-in escape hatch to disable
+ *    certificate verification. This is a deliberate security trade-off:
+ *    traffic is still TLS-encrypted but vulnerable to MITM if routing is
+ *    compromised. Acceptable in tightly-controlled VPC environments where
+ *    CA management is impractical, but not a blanket recommendation.
+ * 4. Default — SSL enabled with full certificate verification. Requires
+ *    NODE_EXTRA_CA_CERTS to be set in the Lambda environment so Node.js
+ *    trusts the Amazon RDS CA certificates.
+ */
+function buildSslConfig(): boolean | { rejectUnauthorized: boolean; ca?: string } {
+  if (process.env.NODE_ENV === 'development') {
+    return false
+  }
+
+  if (process.env.DB_SSL_CA_PATH) {
+    return { rejectUnauthorized: true, ca: readFileSync(process.env.DB_SSL_CA_PATH, 'utf8') }
+  }
+
+  if (process.env.DB_SSL_REJECT_UNAUTHORIZED === 'false') {
+    return { rejectUnauthorized: false }
+  }
+
+  return true
+}
+
 function createPrismaClient() {
   const adapter = new PrismaPg({
     connectionString: process.env.DATABASE_URL,
-    // AWS RDS uses Amazon-issued certificates not in Node.js's default trust store.
-    // The pg driver validates certificates by default (rejectUnauthorized: true),
-    // causing P1010 DatabaseAccessDenied errors. Since Lambda and RDS communicate
-    // within the same private VPC, disabling certificate validation is safe —
-    // traffic is still TLS-encrypted, just without certificate pinning.
-    ssl: process.env.NODE_ENV !== 'development' ? { rejectUnauthorized: false } : false,
+    ssl: buildSslConfig(),
   })
   return new PrismaClient({
     adapter,


### PR DESCRIPTION
## Summary

Addresses code review feedback on PR #159 — replaces the blanket `rejectUnauthorized: false` with proper certificate verification.

## Changes

### Infrastructure (Terraform)
- Added `NODE_EXTRA_CA_CERTS=/var/runtime/ca-cert.pem` to both API and migration Lambda env vars
- The Lambda Node.js 20 base image ships this Amazon CA bundle; Node 20+ requires it to be set explicitly (it was auto-loaded in Node 18)

### Database client (`packages/db/src/index.ts`)
- Replaced hard-coded `rejectUnauthorized: false` with a layered `buildSslConfig()` strategy:

| Priority | Condition | SSL Behavior |
|---|---|---|
| 1 | `NODE_ENV === 'development'` | `false` — no SSL for local PostgreSQL |
| 2 | `DB_SSL_CA_PATH` is set | `{ rejectUnauthorized: true, ca: <file contents> }` — explicit CA bundle |
| 3 | `DB_SSL_REJECT_UNAUTHORIZED=false` | `{ rejectUnauthorized: false }` — opt-in escape hatch |
| 4 | Default | `true` — full SSL verification via NODE_EXTRA_CA_CERTS |

- Updated comments to frame disabled verification as a deliberate trade-off rather than claiming it's "safe"

## Why this works

The `public.ecr.aws/lambda/nodejs:20` base image includes `/var/runtime/ca-cert.pem` containing all Amazon CA certificates (including RDS CAs). Setting `NODE_EXTRA_CA_CERTS` adds them to Node.js's trust store, so `ssl: true` (the default path) succeeds with full certificate verification.

## Test plan

- [x] All quality gates pass (test, lint, typecheck, build)
- [ ] After merge + deploy: `GET /listings` returns 200 with full SSL verification
- [ ] After merge + deploy: `GET /categories` returns 200
- [ ] After merge + deploy: `GET /artists/abbey-peters` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce proper SSL verification for PostgreSQL connections and configure Lambda environments to trust Amazon RDS CA certificates.

Enhancements:
- Introduce a configurable SSL configuration builder for the PostgreSQL client with environment-based behavior and an explicit escape hatch for disabling verification.
- Update Lambda API and migration Terraform modules to set NODE_EXTRA_CA_CERTS so Node.js trusts the bundled Amazon RDS CA certificates.