### PR TITLE
feat(migrate): add reset-baseline command for table recovery

### DIFF
--- a/tools/migrate/src/index.test.ts
+++ b/tools/migrate/src/index.test.ts
@@ -112,6 +112,34 @@ describe('migrate handler', () => {
     })
   })
 
+  it('should run reset-baseline command', async () => {
+    mockedExecSync.mockReturnValue('')
+
+    const result = await handler({ command: 'reset-baseline' })
+
+    expect(result).toEqual({ success: true })
+    expect(mockedExecSync).toHaveBeenCalledTimes(1)
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'migrate resolve --rolled-back 20250101000000_baseline'
+      ),
+      expect.objectContaining({ encoding: 'utf-8' })
+    )
+  })
+
+  it('should return error when reset-baseline fails', async () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      throw new Error('resolve --rolled-back failed')
+    })
+
+    const result = await handler({ command: 'reset-baseline' })
+
+    expect(result).toEqual({
+      success: false,
+      error: 'resolve --rolled-back failed',
+    })
+  })
+
   it('should return ENOENT-specific error when prisma binary missing at runtime', async () => {
     mockedExecSync
       .mockReturnValueOnce('')


### PR DESCRIPTION
## Summary

Adds a `reset-baseline` command to the migration Lambda to fix a production issue where the `_prisma_migrations` table records the baseline as applied but the actual database tables don't exist.

## Context

After the SSL fix deployed (PR #160), the API can now connect to the database. But the error changed from "User was denied access" to **"The table `public.listings` does not exist"**. The migration Lambda reports "No pending migrations to apply" because the baseline is recorded as applied.

This means the baseline migration was marked as applied (via `prisma migrate resolve --applied`) without the SQL ever running. The tables were never created.

## What changed

- Added `reset-baseline` command to migration handler that runs `prisma migrate resolve --rolled-back` on the baseline migration
- Added 2 test cases for the new command
- Event type updated to accept `'migrate' | 'reset-baseline'`

## Recovery steps (after deploy)

```bash
# Step 1: Mark baseline as rolled back
aws lambda invoke --function-name surfaced-art-prod-migrate   --payload '{"command":"reset-baseline"}' response.json

# Step 2: Re-run migrations (baseline SQL will execute this time)
aws lambda invoke --function-name surfaced-art-prod-migrate   --payload '{"command":"migrate"}' response.json

# Step 3: Seed the database
# (need to run seed script or invoke via another mechanism)
```

## Test plan

- [x] All quality gates pass (test, lint, typecheck, build)
- [x] 10/10 migration tests pass including 2 new reset-baseline tests
- [ ] After deploy: invoke `reset-baseline` then `migrate`, verify tables exist
- [ ] After seeding: all API endpoints return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new reset-baseline command to the migration Lambda to allow recovering from a mistakenly applied baseline migration without corresponding database tables.

New Features:
- Introduce a reset-baseline command to mark the baseline Prisma migration as rolled back so it can be re-applied by the migrate flow.

Tests:
- Add tests covering successful execution and failure handling of the new reset-baseline command in the migration handler.