### PR TITLE
fix: address code review feedback on docs, tests, and Bruno assertions

### DIFF
--- a/apps/api/src/routes/artists.ts
+++ b/apps/api/src/routes/artists.ts
@@ -9,7 +9,7 @@ export function createArtistRoutes(prisma: PrismaClient) {
 
   /**
    * GET /artists
-   * Returns a list of featured (approved) artists for the homepage.
+   * Returns a list of approved artists for the homepage.
    * Query params:
    *   - limit: max number of artists to return (default 4, max 20)
    */

--- a/apps/web/e2e/artist-profile.spec.ts
+++ b/apps/web/e2e/artist-profile.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-// Seed data references — update if seed data changes
+// Seed data references — keep in sync with packages/db/prisma/seed-data.ts
 const SEED_ARTIST_SLUG = 'abbey-peters'
 const SEED_ARTIST_NAME = 'Abbey Peters'
 

--- a/apps/web/e2e/category-browse.spec.ts
+++ b/apps/web/e2e/category-browse.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-// Seed data references — update if seed data changes
+// Seed data references — keep in sync with packages/db/prisma/seed-data.ts
 const SEED_CATEGORY = 'ceramics'
 const SEED_CATEGORY_LABEL = 'Ceramics'
 

--- a/bruno/Categories/List Categories.bru
+++ b/bruno/Categories/List Categories.bru
@@ -24,7 +24,7 @@ tests {
   test("each category should have category name and count", function() {
     const categories = res.getBody();
     categories.forEach(function(cat) {
-      expect(cat).to.have.property("sa_category");
+      expect(cat).to.have.property("category");
       expect(cat).to.have.property("count");
       expect(cat.count).to.be.a("number");
       expect(cat.count).to.be.at.least(0);

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -284,8 +284,8 @@ export interface ArtistProfileResponse extends Omit<ArtistProfile, 'userId' | 's
 }
 
 /**
- * Lightweight artist item for featured artists list on homepage.
- * Returned by GET /artists?featured=true
+ * Lightweight artist item for the artists list on the homepage.
+ * Returned by GET /artists (approved artists, optional `?limit=N`).
  */
 export interface FeaturedArtistItem {
   slug: string


### PR DESCRIPTION
## Summary
- Fix `FeaturedArtistItem` JSDoc: remove incorrect `?featured=true` reference, document actual `GET /artists?limit=N` behavior
- Fix Bruno `List Categories` test: `sa_category` → `category` to match actual API response shape (`CategoryWithCount` interface)
- Update E2E spec seed data comments to reference source file (`packages/db/prisma/seed-data.ts`)

## Test plan
- [x] All quality gates pass (test, lint, typecheck, build)
- [ ] Bruno `List Categories` assertions match live API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align artist listing docs and tests with actual API behavior and data shapes.

Bug Fixes:
- Correct FeaturedArtistItem JSDoc and artists route comments to describe the approved-artist list and optional limit parameter.
- Fix Bruno 'List Categories' test to assert the correct 'category' field in the API response instead of 'sa_category'.

Enhancements:
- Clarify E2E seed data comments to reference the canonical seed-data source file for easier maintenance.

Tests:
- Update Bruno category list assertions to match the current API response schema.