### PR TITLE
feat(api,migrate): add /health/db endpoint and force-reapply-baseline command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,10 @@ When starting work on an issue:
 5. Run all quality gates
 6. Open a PR with "Closes #N" in the body
 7. Remove `in-progress` label: `gh issue edit <number> --remove-label "in-progress"`
+8. After the PR is merged, clean up the branch:
+   - Delete the remote branch: `git push origin --delete feat/<short-description>`
+   - Switch to dev: `git checkout dev && git pull`
+   - Delete the local branch: `git branch -d feat/<short-description>`
 
 ### For Every Task (implementation)
 

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('@surfaced-art/db', () => ({
   prisma: {
+    $queryRawUnsafe: vi.fn().mockResolvedValue([{ now: new Date() }]),
     artistProfile: {
       findUnique: vi.fn(),
+      findFirst: vi.fn().mockResolvedValue({ id: 'test-id' }),
     },
     listing: {
       findMany: vi.fn().mockResolvedValue([]),
@@ -36,6 +38,20 @@ describe('API', () => {
       const data = await res.json()
       expect(data).toHaveProperty('status', 'ok')
       expect(data).toHaveProperty('timestamp')
+    })
+  })
+
+  describe('GET /health/db', () => {
+    it('should return database health status', async () => {
+      const res = await app.request('/health/db')
+      expect(res.status).toBe(200)
+
+      const data = await res.json()
+      expect(data).toHaveProperty('status', 'ok')
+      expect(data).toHaveProperty('timestamp')
+      expect(data).toHaveProperty('durationMs')
+      expect(data.checks.connection.status).toBe('ok')
+      expect(data.checks.schema.status).toBe('ok')
     })
   })
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import { handle } from 'hono/aws-lambda'
 import { prisma } from '@surfaced-art/db'
 import { logger } from '@surfaced-art/utils'
 
-import { healthRoutes } from './routes/health'
+import { createHealthRoutes } from './routes/health'
 import { createArtistRoutes } from './routes/artists'
 import { createListingRoutes } from './routes/listings'
 import { createCategoryRoutes } from './routes/categories'
@@ -26,7 +26,7 @@ app.use(
 )
 
 // Mount routes
-app.route('/health', healthRoutes)
+app.route('/health', createHealthRoutes(prisma))
 app.route('/artists', createArtistRoutes(prisma))
 app.route('/listings', createListingRoutes(prisma))
 app.route('/categories', createCategoryRoutes(prisma))

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,14 +1,73 @@
 import { Hono } from 'hono'
+import type { PrismaClient } from '@surfaced-art/db'
 
-export const healthRoutes = new Hono()
+export function createHealthRoutes(prisma: PrismaClient) {
+  const health = new Hono()
 
-/**
- * GET /health
- * Health check endpoint for Lambda and monitoring
- */
-healthRoutes.get('/', (c) => {
-  return c.json({
-    status: 'ok',
-    timestamp: new Date().toISOString(),
+  /**
+   * GET /health
+   * Basic health check — confirms Lambda is running
+   */
+  health.get('/', (c) => {
+    return c.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    })
   })
-})
+
+  /**
+   * GET /health/db
+   * Database connectivity check — verifies Prisma can reach RDS
+   * and that the schema is applied (tables exist)
+   */
+  health.get('/db', async (c) => {
+    const start = Date.now()
+    const checks: Record<string, { status: string; error?: string }> = {}
+
+    // Check 1: Can we connect and run a raw query?
+    try {
+      const result = await prisma.$queryRawUnsafe<{ now: Date }[]>('SELECT NOW() as now')
+      checks.connection = { status: 'ok' }
+      if (result[0]) {
+        checks.connection.status = 'ok'
+      }
+    } catch (err) {
+      checks.connection = {
+        status: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      }
+    }
+
+    // Check 2: Do the expected tables exist?
+    try {
+      // Query a core table with a lightweight count-limited query
+      await prisma.artistProfile.findFirst({ select: { id: true } })
+      checks.schema = { status: 'ok' }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('does not exist')) {
+        checks.schema = {
+          status: 'error',
+          error: 'Tables missing — run migrations (force-reapply-baseline if needed)',
+        }
+      } else {
+        checks.schema = { status: 'error', error: message }
+      }
+    }
+
+    const allOk = Object.values(checks).every((c) => c.status === 'ok')
+    const durationMs = Date.now() - start
+
+    return c.json(
+      {
+        status: allOk ? 'ok' : 'degraded',
+        timestamp: new Date().toISOString(),
+        durationMs,
+        checks,
+      },
+      allOk ? 200 : 503
+    )
+  })
+
+  return health
+}

--- a/apps/api/src/test-helpers/create-test-app.ts
+++ b/apps/api/src/test-helpers/create-test-app.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import type { PrismaClient } from '@surfaced-art/db'
 
-import { healthRoutes } from '../routes/health.js'
+import { createHealthRoutes } from '../routes/health.js'
 import { createArtistRoutes } from '../routes/artists.js'
 import { createListingRoutes } from '../routes/listings.js'
 import { createCategoryRoutes } from '../routes/categories.js'
@@ -27,7 +27,7 @@ export function createTestApp(prisma: PrismaClient) {
   )
 
   // Mount routes with injected PrismaClient
-  app.route('/health', healthRoutes)
+  app.route('/health', createHealthRoutes(prisma))
   app.route('/artists', createArtistRoutes(prisma))
   app.route('/listings', createListingRoutes(prisma))
   app.route('/categories', createCategoryRoutes(prisma))


### PR DESCRIPTION
## Summary

- **`GET /health/db`** — New database health check endpoint that verifies both connectivity (`SELECT NOW()`) and schema presence (queries `artist_profiles` table). Returns `200` when healthy, `503` with structured check details when degraded.
- **`force-reapply-baseline`** — New migration Lambda command that fixes the scenario where `_prisma_migrations` records the baseline as "applied" but actual tables are missing. Deletes the stale record then re-runs `prisma migrate deploy`.
- Health route refactored from static export to factory pattern (`createHealthRoutes(prisma)`) for consistency with other routes.

## Why

All API endpoints except `/health` currently return 500 because the database tables don't exist — the `_prisma_migrations` table thinks the baseline is applied but the DDL was never executed. The existing `reset-baseline` command can't fix this because Prisma only allows `--rolled-back` on failed migrations, not applied ones.

After this merges to dev and is promoted to main:
1. CI deploys the updated migration Lambda
2. Invoke `{"command": "force-reapply-baseline"}` to create the tables
3. Invoke seed script if needed
4. All API endpoints come back to life
5. `/health/db` provides ongoing database health visibility

## Test plan

- [x] All quality gates pass (test, lint, typecheck, build)
- [x] Unit tests for `/health/db` endpoint (mocked Prisma)
- [x] Unit tests for `force-reapply-baseline` command (happy path + error)
- [ ] After deploy: invoke `force-reapply-baseline` and verify tables are created
- [ ] After deploy: hit `/health/db` and verify `200` with `status: ok`
- [ ] After deploy: verify `/artists`, `/categories`, `/listings` return data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add database-aware health checks and a recovery migration command to restore missing baseline tables.

New Features:
- Introduce a factory-based /health route that accepts a Prisma client and mounts health endpoints.
- Add a /health/db endpoint that reports database connectivity and schema status with structured check details and degraded responses when unhealthy.
- Extend the migrate Lambda with a force-reapply-baseline command to delete the baseline migration record and rerun migrations when tables are missing.

Enhancements:
- Refactor health route registration to use a createHealthRoutes(prisma) pattern consistent with other route factories.
- Document post-merge branch cleanup steps in the contributor guide.

Tests:
- Add unit tests for the /health/db endpoint to validate successful database health responses.
- Add unit tests for the force-reapply-baseline migration command covering success and failure paths.