### PR TITLE
feat(migrate): add safe seed command to migration Lambda

### DIFF
--- a/packages/db/prisma/seed-logic.ts
+++ b/packages/db/prisma/seed-logic.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared seed logic used by both seed.ts (local dev) and seed-safe.ts (Lambda).
+ *
+ * This module contains the pure seeding functions without any entrypoint
+ * side effects, so it can be imported safely by multiple scripts.
+ */
+import type { PrismaClient } from '../src/generated/prisma/client'
+import { cdnUrl } from './seed-data'
+import type { ArtistSeedConfig } from './seed-data'
+
+type TransactionClient = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
+
+export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) {
+  // Upsert user
+  const user = await tx.user.upsert({
+    where: { email: data.user.email },
+    update: {
+      cognitoId: data.user.cognitoId,
+      fullName: data.user.fullName,
+      avatarUrl: data.user.avatarUrl,
+    },
+    create: data.user,
+  })
+
+  // Upsert buyer role
+  await tx.userRole.upsert({
+    where: { userId_role: { userId: user.id, role: 'buyer' } },
+    update: {},
+    create: { userId: user.id, role: 'buyer' },
+  })
+
+  // Upsert artist role
+  await tx.userRole.upsert({
+    where: { userId_role: { userId: user.id, role: 'artist' } },
+    update: {},
+    create: { userId: user.id, role: 'artist' },
+  })
+
+  // Upsert artist profile
+  const profile = await tx.artistProfile.upsert({
+    where: { userId: user.id },
+    update: {
+      displayName: data.profile.displayName,
+      slug: data.profile.slug,
+      bio: data.profile.bio,
+      location: data.profile.location,
+      websiteUrl: data.profile.websiteUrl,
+      instagramUrl: data.profile.instagramUrl,
+      originZip: data.profile.originZip,
+      status: data.profile.status,
+      commissionsOpen: data.profile.commissionsOpen,
+      coverImageUrl: data.profile.coverImageUrl,
+      profileImageUrl: data.profile.profileImageUrl,
+      applicationSource: data.profile.applicationSource,
+    },
+    create: {
+      userId: user.id,
+      ...data.profile,
+    },
+  })
+
+  // Delete and re-create categories (no unique constraint on individual entries to upsert on)
+  await tx.artistCategory.deleteMany({ where: { artistId: profile.id } })
+  for (const category of data.categories) {
+    await tx.artistCategory.create({
+      data: { artistId: profile.id, category },
+    })
+  }
+
+  // Delete and re-create CV entries
+  await tx.artistCvEntry.deleteMany({ where: { artistId: profile.id } })
+  for (const entry of data.cvEntries) {
+    await tx.artistCvEntry.create({
+      data: { artistId: profile.id, ...entry },
+    })
+  }
+
+  // Delete and re-create process media
+  await tx.artistProcessMedia.deleteMany({ where: { artistId: profile.id } })
+  for (const media of data.processMedia) {
+    await tx.artistProcessMedia.create({
+      data: { artistId: profile.id, ...media },
+    })
+  }
+
+  // Delete and re-create listings (and their images cascade)
+  await tx.listing.deleteMany({ where: { artistId: profile.id } })
+  for (const listingData of data.listings) {
+    const listingSlug = listingData.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+
+    const listing = await tx.listing.create({
+      data: {
+        artistId: profile.id,
+        type: 'standard',
+        title: listingData.title,
+        description: listingData.description,
+        medium: listingData.medium,
+        category: listingData.category,
+        price: listingData.price,
+        status: listingData.status,
+        isDocumented: listingData.isDocumented,
+        quantityTotal: 1,
+        quantityRemaining: listingData.status === 'available' ? 1 : 0,
+        artworkLength: listingData.artworkLength,
+        artworkWidth: listingData.artworkWidth,
+        artworkHeight: listingData.artworkHeight,
+        packedLength: listingData.packedLength,
+        packedWidth: listingData.packedWidth,
+        packedHeight: listingData.packedHeight,
+        packedWeight: listingData.packedWeight,
+      },
+    })
+
+    // Create 2 images per listing: primary + one additional angle
+    // For documented listings, second image is a process photo
+    await tx.listingImage.create({
+      data: {
+        listingId: listing.id,
+        url: cdnUrl(`${data.profile.slug}/${listingSlug}-front.webp`),
+        isProcessPhoto: false,
+        sortOrder: 0,
+      },
+    })
+    await tx.listingImage.create({
+      data: {
+        listingId: listing.id,
+        url: cdnUrl(`${data.profile.slug}/${listingSlug}-angle.webp`),
+        isProcessPhoto: listingData.isDocumented,
+        sortOrder: 1,
+      },
+    })
+  }
+
+  return { user, profile }
+}

--- a/packages/db/prisma/seed-safe.ts
+++ b/packages/db/prisma/seed-safe.ts
@@ -1,0 +1,107 @@
+/**
+ * Safe seed wrapper for Lambda invocation.
+ *
+ * This script wraps the shared seed logic with a production safety check:
+ * before seeding, it queries the users table and aborts if any non-seed
+ * users exist (cognito_id NOT LIKE 'seed-%'). This prevents accidental
+ * overwrites once real users have signed up.
+ *
+ * The underlying seed logic uses upsert for users/profiles (idempotent)
+ * but deletes and re-creates listings, categories, CV entries, and process
+ * media per artist. That delete-recreate pattern is safe for seed data
+ * but would destroy real user-created listings — hence the safety guard.
+ */
+import { PrismaClient } from '../src/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { artistConfigs } from './seed-data'
+import { seedArtist } from './seed-logic'
+
+if (!process.env.DATABASE_URL) {
+  console.error('ERROR: DATABASE_URL is not set.')
+  process.exit(1)
+}
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+  // SSL config mirrors packages/db/src/index.ts — in Lambda the
+  // NODE_EXTRA_CA_CERTS env var handles RDS CA trust at the runtime level.
+  ssl:
+    process.env.NODE_ENV === 'development'
+      ? false
+      : process.env.DB_SSL_REJECT_UNAUTHORIZED === 'false'
+        ? { rejectUnauthorized: false }
+        : true,
+})
+
+const prisma = new PrismaClient({ adapter })
+
+// ============================================================================
+// Safety check
+// ============================================================================
+
+async function checkSafeToSeed(): Promise<{ safe: boolean; reason?: string }> {
+  try {
+    const realUsers = await prisma.user.count({
+      where: {
+        NOT: { cognitoId: { startsWith: 'seed-' } },
+      },
+    })
+
+    if (realUsers > 0) {
+      return {
+        safe: false,
+        reason:
+          `Found ${realUsers} non-seed user(s) in the database. ` +
+          'Seeding is blocked to prevent overwriting production data. ' +
+          'To re-seed, manually remove real users first or use a fresh database.',
+      }
+    }
+
+    return { safe: true }
+  } catch (err) {
+    // If the users table doesn't exist yet, seeding would fail anyway
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.includes('does not exist')) {
+      return {
+        safe: false,
+        reason: 'The users table does not exist. Run migrations first.',
+      }
+    }
+    return { safe: false, reason: `Safety check failed: ${message}` }
+  }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  console.log('Running production safety check...')
+  const { safe, reason } = await checkSafeToSeed()
+
+  if (!safe) {
+    console.error(`SEED BLOCKED: ${reason}`)
+    process.exit(1)
+  }
+
+  console.log('Safety check passed. Starting seed...')
+
+  for (const config of artistConfigs) {
+    const result = await prisma.$transaction(async (tx) => {
+      return seedArtist(tx, config)
+    })
+    console.log(`  Seeded artist: ${result.profile.displayName} (${result.profile.slug})`)
+  }
+
+  console.log('Seeding finished.')
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })

--- a/packages/db/prisma/seed.test.ts
+++ b/packages/db/prisma/seed.test.ts
@@ -132,6 +132,12 @@ describe('Seed Data Validation', () => {
       const ids = artistConfigs.map((c) => c.user.cognitoId)
       expect(new Set(ids).size).toBe(ids.length)
     })
+
+    it('should have cognitoIds prefixed with "seed-" (required by seed-safe.ts safety guard)', () => {
+      for (const config of artistConfigs) {
+        expect(config.user.cognitoId).toMatch(/^seed-/)
+      }
+    })
   })
 
   describe('CDN URLs', () => {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '../src/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
-import { artistConfigs, cdnUrl } from './seed-data'
-import type { ArtistSeedConfig } from './seed-data'
+import { artistConfigs } from './seed-data'
+import { seedArtist } from './seed-logic'
 
 // Validate DATABASE_URL before attempting connection
 if (!process.env.DATABASE_URL) {
@@ -18,139 +18,6 @@ const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
 })
 const prisma = new PrismaClient({ adapter })
-
-// ============================================================================
-// Seed function
-// ============================================================================
-
-type TransactionClient = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
-
-async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) {
-  // Upsert user
-  const user = await tx.user.upsert({
-    where: { email: data.user.email },
-    update: {
-      cognitoId: data.user.cognitoId,
-      fullName: data.user.fullName,
-      avatarUrl: data.user.avatarUrl,
-    },
-    create: data.user,
-  })
-
-  // Upsert buyer role
-  await tx.userRole.upsert({
-    where: { userId_role: { userId: user.id, role: 'buyer' } },
-    update: {},
-    create: { userId: user.id, role: 'buyer' },
-  })
-
-  // Upsert artist role
-  await tx.userRole.upsert({
-    where: { userId_role: { userId: user.id, role: 'artist' } },
-    update: {},
-    create: { userId: user.id, role: 'artist' },
-  })
-
-  // Upsert artist profile
-  const profile = await tx.artistProfile.upsert({
-    where: { userId: user.id },
-    update: {
-      displayName: data.profile.displayName,
-      slug: data.profile.slug,
-      bio: data.profile.bio,
-      location: data.profile.location,
-      websiteUrl: data.profile.websiteUrl,
-      instagramUrl: data.profile.instagramUrl,
-      originZip: data.profile.originZip,
-      status: data.profile.status,
-      commissionsOpen: data.profile.commissionsOpen,
-      coverImageUrl: data.profile.coverImageUrl,
-      profileImageUrl: data.profile.profileImageUrl,
-      applicationSource: data.profile.applicationSource,
-    },
-    create: {
-      userId: user.id,
-      ...data.profile,
-    },
-  })
-
-  // Delete and re-create categories (no unique constraint on individual entries to upsert on)
-  await tx.artistCategory.deleteMany({ where: { artistId: profile.id } })
-  for (const category of data.categories) {
-    await tx.artistCategory.create({
-      data: { artistId: profile.id, category },
-    })
-  }
-
-  // Delete and re-create CV entries
-  await tx.artistCvEntry.deleteMany({ where: { artistId: profile.id } })
-  for (const entry of data.cvEntries) {
-    await tx.artistCvEntry.create({
-      data: { artistId: profile.id, ...entry },
-    })
-  }
-
-  // Delete and re-create process media
-  await tx.artistProcessMedia.deleteMany({ where: { artistId: profile.id } })
-  for (const media of data.processMedia) {
-    await tx.artistProcessMedia.create({
-      data: { artistId: profile.id, ...media },
-    })
-  }
-
-  // Delete and re-create listings (and their images cascade)
-  await tx.listing.deleteMany({ where: { artistId: profile.id } })
-  for (const listingData of data.listings) {
-    const listingSlug = listingData.title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '')
-
-    const listing = await tx.listing.create({
-      data: {
-        artistId: profile.id,
-        type: 'standard',
-        title: listingData.title,
-        description: listingData.description,
-        medium: listingData.medium,
-        category: listingData.category,
-        price: listingData.price,
-        status: listingData.status,
-        isDocumented: listingData.isDocumented,
-        quantityTotal: 1,
-        quantityRemaining: listingData.status === 'available' ? 1 : 0,
-        artworkLength: listingData.artworkLength,
-        artworkWidth: listingData.artworkWidth,
-        artworkHeight: listingData.artworkHeight,
-        packedLength: listingData.packedLength,
-        packedWidth: listingData.packedWidth,
-        packedHeight: listingData.packedHeight,
-        packedWeight: listingData.packedWeight,
-      },
-    })
-
-    // Create 2 images per listing: primary + one additional angle
-    // For documented listings, second image is a process photo
-    await tx.listingImage.create({
-      data: {
-        listingId: listing.id,
-        url: cdnUrl(`${data.profile.slug}/${listingSlug}-front.webp`),
-        isProcessPhoto: false,
-        sortOrder: 0,
-      },
-    })
-    await tx.listingImage.create({
-      data: {
-        listingId: listing.id,
-        url: cdnUrl(`${data.profile.slug}/${listingSlug}-angle.webp`),
-        isProcessPhoto: listingData.isDocumented,
-        sortOrder: 1,
-      },
-    })
-  }
-
-  return { user, profile }
-}
 
 async function main() {
   console.log('Start seeding...')

--- a/tools/migrate/Dockerfile
+++ b/tools/migrate/Dockerfile
@@ -28,11 +28,18 @@ RUN npm ci
 # Root package.json "type": "module" (copied above) ensures ESM loading.
 COPY tools/migrate/dist/index.js ./index.js
 
-# Copy Prisma files needed by `prisma migrate deploy`:
-#   prisma/schema.prisma   - schema definition
-#   prisma/migrations/     - SQL migration files to apply
-#   prisma.config.ts       - Prisma 7 datasource config (reads DATABASE_URL)
+# Copy Prisma files needed by `prisma migrate deploy` and `seed`:
+#   prisma/schema.prisma     - schema definition
+#   prisma/migrations/       - SQL migration files to apply
+#   prisma/seed-safe.ts      - safe seed script (with production guard)
+#   prisma/seed-logic.ts     - shared seed functions
+#   prisma/seed-data.ts      - seed data configuration
+#   prisma.config.ts         - Prisma 7 datasource config (reads DATABASE_URL)
 COPY packages/db/prisma/ ./prisma/
 COPY packages/db/prisma.config.ts ./
+
+# Copy the generated Prisma client so seed-safe.ts (which runs via tsx
+# at runtime) can resolve its `../src/generated/prisma/client` import.
+COPY packages/db/src/generated/ ./src/generated/
 
 CMD ["index.handler"]


### PR DESCRIPTION
## Summary

- Adds a `seed` command to the migration Lambda handler that populates the database with initial artist/listing data
- **Production safety guard**: `seed-safe.ts` queries the `users` table before seeding and refuses to run if any non-seed users exist (cognito IDs not prefixed with `seed-`). Once real users sign up, seeding is blocked to prevent accidental data overwrites
- Refactors `seed.ts` to extract shared seeding logic into `seed-logic.ts`, eliminating duplication between the local dev seed script and the Lambda version
- Updates the Dockerfile to copy the generated Prisma client so `seed-safe.ts` can resolve its imports at runtime
- Adds test for the `seed-` prefix convention in seed data validation

## Files Changed

| File | Change |
|------|--------|
| `tools/migrate/src/index.ts` | Add `seed` command handler |
| `tools/migrate/src/index.test.ts` | Add tests for seed command (happy path, missing script, blocked) |
| `tools/migrate/Dockerfile` | Copy generated Prisma client for seed runtime |
| `packages/db/prisma/seed-logic.ts` | **New** — extracted shared seed functions |
| `packages/db/prisma/seed-safe.ts` | **New** — Lambda seed wrapper with safety check |
| `packages/db/prisma/seed.ts` | Refactored to import from `seed-logic.ts` |
| `packages/db/prisma/seed.test.ts` | Add `seed-` prefix convention test |

## Safety Design

The seed command uses a two-layer protection model:

1. **Cognito ID prefix check**: All seed users have `cognitoId` starting with `seed-`. Real users from Cognito will never have this prefix. Before seeding, the script counts users without the prefix — if any exist, it exits with error code 1.
2. **Test enforcement**: A new test validates that all seed data configs use the `seed-` prefix, so future seed data additions can't accidentally break the safety guard.

## Test plan

- [x] All existing tests pass (`npm run test`)
- [x] New seed command tests pass (happy path, missing script, safety block)
- [x] Seed data validation test for `seed-` prefix passes
- [x] Lint, typecheck, and build all pass
- [ ] After merge to main: invoke `{"command":"seed"}` on the migrate Lambda
- [ ] Verify API endpoints return seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a safe database seeding command to the migration Lambda and extract shared seed logic for reuse between local and Lambda seeding.

New Features:
- Introduce a `seed` command to the migrate Lambda to populate initial artist and listing data using a safe seed script.
- Add a Lambda-safe seed entrypoint that enforces a guard against seeding when non-seed users already exist in the database.

Enhancements:
- Extract shared seeding operations into a reusable `seed-logic` module consumed by both local and Lambda seed scripts.
- Update the migrate Docker image to include Prisma seed scripts and the generated Prisma client required at runtime for seeding.

Tests:
- Extend migration handler tests to cover the new seed command success and failure scenarios, including missing script and blocked seeds.
- Add a seed data validation test to enforce the `seed-` Cognito ID prefix convention required by the safety guard.