### PR TITLE
feat(ci): add visual QA Playwright test suite

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -178,10 +178,56 @@ jobs:
         if: steps.plan.outcome == 'failure'
         run: exit 1
 
+  visual-qa:
+    name: Visual QA
+    runs-on: ubuntu-latest
+    needs: [build-and-test]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Wait for Vercel preview deployment
+        id: vercel-preview
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 300
+          check_interval: 15
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: apps/web
+
+      - name: Run visual QA tests
+        run: npx playwright test --config=e2e/visual-qa.config.ts
+        working-directory: apps/web
+        env:
+          VISUAL_QA_BASE_URL: ${{ steps.vercel-preview.outputs.url }}
+
+      - name: Upload visual QA artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-qa-${{ github.sha }}
+          path: |
+            apps/web/e2e/visual-qa/results/
+            apps/web/e2e/visual-qa/report/
+          retention-days: 14
+
   notify-actions-pr:
     name: Notify Actions (PR)
     runs-on: ubuntu-latest
-    needs: [build-and-test, security-scan, terraform-plan]
+    needs: [build-and-test, security-scan, terraform-plan, visual-qa]
     if: always()
     continue-on-error: true
     timeout-minutes: 2
@@ -194,8 +240,9 @@ jobs:
           BUILD_RESULT="${{ needs.build-and-test.result }}"
           SECURITY_RESULT="${{ needs.security-scan.result }}"
           TF_RESULT="${{ needs.terraform-plan.result }}"
+          VISUAL_QA_RESULT="${{ needs.visual-qa.result }}"
 
-          if [ "$BUILD_RESULT" = "failure" ] || [ "$SECURITY_RESULT" = "failure" ] || [ "$TF_RESULT" = "failure" ]; then
+          if [ "$BUILD_RESULT" = "failure" ] || [ "$SECURITY_RESULT" = "failure" ] || [ "$TF_RESULT" = "failure" ] || [ "$VISUAL_QA_RESULT" = "failure" ]; then
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "emoji=❌" >> "$GITHUB_OUTPUT"
           else

--- a/apps/web/e2e/visual-qa/page-rendering.spec.ts
+++ b/apps/web/e2e/visual-qa/page-rendering.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test'
+
+// Seed data references — keep in sync with packages/db/prisma/seed-data.ts
+const SEED_ARTISTS = [
+  { slug: 'abbey-peters', displayName: 'Abbey Peters' },
+  { slug: 'david-morrison', displayName: 'David Morrison' },
+  { slug: 'karina-yanes', displayName: 'Karina Yanes' },
+]
+
+const CATEGORIES = [
+  'ceramics',
+  'painting',
+  'print',
+  'jewelry',
+  'illustration',
+  'photography',
+  'woodworking',
+  'fibers',
+  'mixed-media',
+]
+
+test.describe('Page Rendering — Homepage', () => {
+  test('homepage renders with all sections', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByTestId('hero')).toBeVisible()
+    await expect(page.getByTestId('featured-artists')).toBeVisible()
+
+    // At least one artist card rendered
+    const artistCards = page.getByTestId('artist-card')
+    await expect(artistCards.first()).toBeVisible()
+
+    await expect(page.getByTestId('featured-listings')).toBeVisible()
+
+    // At least one listing card rendered
+    const listingCards = page.getByTestId('listing-card')
+    await expect(listingCards.first()).toBeVisible()
+
+    // Category grid rendered (lives inside the CategoryGrid component)
+    await expect(page.getByTestId('category-grid')).toBeVisible()
+
+    await expect(page.getByTestId('waitlist')).toBeVisible()
+
+    await page.screenshot({
+      path: `results/homepage-${test.info().project.name}.png`,
+      fullPage: true,
+    })
+  })
+})
+
+test.describe('Page Rendering — Artist Profiles', () => {
+  for (const artist of SEED_ARTISTS) {
+    test(`artist profile renders: ${artist.displayName}`, async ({ page }) => {
+      await page.goto(`/artist/${artist.slug}`)
+      await page.waitForLoadState('networkidle')
+
+      // Did not 404
+      await expect(page).not.toHaveTitle(/404|not found/i)
+
+      await expect(page.getByTestId('artist-hero')).toBeVisible()
+      await expect(page.getByTestId('artist-name')).toContainText(
+        artist.displayName
+      )
+      await expect(page.getByTestId('artist-bio')).toBeVisible()
+      await expect(page.getByTestId('available-work')).toBeVisible()
+
+      await page.screenshot({
+        path: `results/artist-${artist.slug}-${test.info().project.name}.png`,
+        fullPage: true,
+      })
+    })
+  }
+})
+
+test.describe('Page Rendering — Listing Detail', () => {
+  test('listing detail renders after clicking through from artist profile', async ({
+    page,
+  }) => {
+    await page.goto(`/artist/${SEED_ARTISTS[0].slug}`)
+    await page.waitForLoadState('networkidle')
+
+    // Click first listing card in the available work section
+    const firstListing = page
+      .getByTestId('available-work')
+      .getByTestId('listing-card')
+      .first()
+    await expect(firstListing).toBeVisible()
+    await firstListing.click()
+    await page.waitForLoadState('networkidle')
+
+    expect(page.url()).toContain('/listing/')
+
+    await expect(page.getByTestId('listing-title')).toBeVisible()
+    await expect(page.getByTestId('listing-price')).toBeVisible()
+    await expect(page.getByTestId('listing-images')).toBeVisible()
+    await expect(page.getByTestId('listing-description')).toBeVisible()
+    await expect(page.getByTestId('artist-card')).toBeVisible()
+
+    // Price must be formatted as $X.XX — not raw cents
+    const priceText = await page.getByTestId('listing-price').textContent()
+    expect(priceText).toMatch(/\$[\d,]+\.\d{2}/)
+
+    await page.screenshot({
+      path: `results/listing-detail-${test.info().project.name}.png`,
+      fullPage: true,
+    })
+  })
+})
+
+test.describe('Page Rendering — Category Pages', () => {
+  for (const category of CATEGORIES) {
+    test(`category page renders: ${category}`, async ({ page }) => {
+      await page.goto(`/category/${category}`)
+      await page.waitForLoadState('networkidle')
+
+      await expect(page).not.toHaveTitle(/404|not found/i)
+      await expect(page.getByTestId('category-header')).toBeVisible()
+      await expect(page.getByTestId('category-content')).toBeVisible()
+
+      await page.screenshot({
+        path: `results/category-${category}-${test.info().project.name}.png`,
+        fullPage: true,
+      })
+    })
+  }
+})

--- a/apps/web/e2e/visual-qa/responsive.spec.ts
+++ b/apps/web/e2e/visual-qa/responsive.spec.ts
@@ -1,0 +1,86 @@
+import { test } from '@playwright/test'
+
+// Breakpoints matching Tailwind defaults + key real devices
+const BREAKPOINTS = [
+  { name: 'mobile-sm', width: 375, height: 812 },
+  { name: 'mobile-lg', width: 428, height: 926 },
+  { name: 'tablet-portrait', width: 768, height: 1024 },
+  { name: 'tablet-landscape', width: 1024, height: 768 },
+  { name: 'desktop-sm', width: 1280, height: 800 },
+  { name: 'desktop-lg', width: 1440, height: 900 },
+  { name: 'desktop-xl', width: 1920, height: 1080 },
+]
+
+// Pages to capture — keep in sync with deployed seed data
+const PAGES = [
+  { name: 'homepage', path: '/' },
+  { name: 'artist-profile', path: '/artist/abbey-peters' },
+  { name: 'category-ceramics', path: '/category/ceramics' },
+]
+
+for (const bp of BREAKPOINTS) {
+  for (const pg of PAGES) {
+    test(`${pg.name} at ${bp.name} (${bp.width}x${bp.height})`, async ({
+      browser,
+    }) => {
+      const context = await browser.newContext({
+        viewport: { width: bp.width, height: bp.height },
+      })
+      const page = await context.newPage()
+
+      await page.goto(pg.path)
+      await page.waitForLoadState('networkidle')
+
+      // Full-page screenshot
+      await page.screenshot({
+        path: `results/responsive/${pg.name}-${bp.name}.png`,
+        fullPage: true,
+      })
+
+      // Above-the-fold screenshot (what the user sees without scrolling)
+      await page.screenshot({
+        path: `results/responsive/${pg.name}-${bp.name}-fold.png`,
+        fullPage: false,
+      })
+
+      await context.close()
+    })
+  }
+}
+
+// Listing detail captured by navigating through an artist profile (click-through, not direct URL)
+for (const bp of BREAKPOINTS) {
+  test(`listing-detail at ${bp.name} (${bp.width}x${bp.height})`, async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: bp.width, height: bp.height },
+    })
+    const page = await context.newPage()
+
+    await page.goto('/artist/abbey-peters')
+    await page.waitForLoadState('networkidle')
+
+    const firstListing = page
+      .getByTestId('available-work')
+      .getByTestId('listing-card')
+      .first()
+
+    if (await firstListing.isVisible()) {
+      await firstListing.click()
+      await page.waitForLoadState('networkidle')
+
+      await page.screenshot({
+        path: `results/responsive/listing-detail-${bp.name}.png`,
+        fullPage: true,
+      })
+
+      await page.screenshot({
+        path: `results/responsive/listing-detail-${bp.name}-fold.png`,
+        fullPage: false,
+      })
+    }
+
+    await context.close()
+  })
+}

--- a/apps/web/e2e/visual-qa/runtime-health.spec.ts
+++ b/apps/web/e2e/visual-qa/runtime-health.spec.ts
@@ -5,9 +5,12 @@ import {
   EXPECTED_CDN_HOSTNAME,
 } from './helpers'
 
-// Pages to test — update as new pages are deployed
+// Pages to test — keep in sync with deployed seed data
 const PAGES = [
   { name: 'homepage', path: '/' },
+  { name: 'artist-abbey-peters', path: '/artist/abbey-peters' },
+  { name: 'artist-david-morrison', path: '/artist/david-morrison' },
+  { name: 'artist-karina-yanes', path: '/artist/karina-yanes' },
   { name: 'category-ceramics', path: '/category/ceramics' },
   { name: 'category-painting', path: '/category/painting' },
 ]

--- a/apps/web/e2e/visual-qa/seo-metadata.spec.ts
+++ b/apps/web/e2e/visual-qa/seo-metadata.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '@playwright/test'
+
+// Seed data references — keep in sync with packages/db/prisma/seed-data.ts
+const SEED_ARTIST_SLUG = 'abbey-peters'
+const SEED_ARTIST_NAME = 'Abbey Peters'
+
+test.describe('SEO Metadata — Homepage', () => {
+  test('homepage has correct meta tags', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const title = await page.title()
+    expect(title).not.toBe('Create Next App')
+    expect(title.length).toBeGreaterThan(10)
+    expect(title.length).toBeLessThan(70)
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute('content')
+    expect(description).toBeTruthy()
+    expect(description!.length).toBeGreaterThan(50)
+    expect(description!.length).toBeLessThan(160)
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      /.+/
+    )
+    await expect(
+      page.locator('meta[property="og:description"]')
+    ).toHaveAttribute('content', /.+/)
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+      'content',
+      /^https?:\/\//
+    )
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+      'content',
+      'website'
+    )
+
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      /^https?:\/\//
+    )
+  })
+})
+
+test.describe('SEO Metadata — Artist Profile', () => {
+  test('artist profile has dynamic meta tags', async ({ page }) => {
+    await page.goto(`/artist/${SEED_ARTIST_SLUG}`)
+    await page.waitForLoadState('networkidle')
+
+    const title = await page.title()
+    expect(title.toLowerCase()).toContain(SEED_ARTIST_NAME.toLowerCase())
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute('content')
+    expect(description).toBeTruthy()
+    expect(description!.length).toBeGreaterThan(30)
+
+    const ogTitle = await page
+      .locator('meta[property="og:title"]')
+      .getAttribute('content')
+    expect(ogTitle!.toLowerCase()).toContain(SEED_ARTIST_NAME.toLowerCase())
+
+    // OG image should be real — not a placeholder
+    const ogImage = await page
+      .locator('meta[property="og:image"]')
+      .getAttribute('content')
+    expect(ogImage).toMatch(/^https?:\/\//)
+    expect(ogImage).not.toContain('placeholder')
+  })
+})
+
+test.describe('SEO Metadata — Listing Detail', () => {
+  test('listing detail has dynamic meta tags', async ({ page }) => {
+    // Navigate via click-through, same as a real user
+    await page.goto(`/artist/${SEED_ARTIST_SLUG}`)
+    await page.waitForLoadState('networkidle')
+
+    const firstListing = page
+      .getByTestId('available-work')
+      .getByTestId('listing-card')
+      .first()
+    await expect(firstListing).toBeVisible()
+    await firstListing.click()
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      /.+/
+    )
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+      'content',
+      /^https?:\/\//
+    )
+
+    // If JSON-LD Product schema is present, verify it has a price
+    const jsonLdEl = page.locator('script[type="application/ld+json"]')
+    if ((await jsonLdEl.count()) > 0) {
+      const jsonLd = await jsonLdEl.first().textContent()
+      if (jsonLd) {
+        const structured = JSON.parse(jsonLd)
+        if (structured['@type'] === 'Product') {
+          expect(structured.offers).toBeTruthy()
+          expect(structured.offers.price).toBeTruthy()
+        }
+      }
+    }
+  })
+})
+
+test.describe('SEO Metadata — Category Page', () => {
+  test('category page has correct meta tags', async ({ page }) => {
+    await page.goto('/category/ceramics')
+    await page.waitForLoadState('networkidle')
+
+    const title = await page.title()
+    expect(title.toLowerCase()).toContain('ceramics')
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute('content')
+    expect(description).toBeTruthy()
+  })
+})
+
+test.describe('SEO Metadata — Integrity Checks', () => {
+  const PAGES_TO_CHECK = [
+    '/',
+    `/artist/${SEED_ARTIST_SLUG}`,
+    '/category/ceramics',
+  ]
+
+  for (const path of PAGES_TO_CHECK) {
+    test(`no duplicate or missing meta tags on ${path}`, async ({ page }) => {
+      await page.goto(path)
+      await page.waitForLoadState('networkidle')
+
+      // Exactly one title tag
+      expect(await page.locator('title').count()).toBe(1)
+
+      // Exactly one meta description
+      expect(
+        await page.locator('meta[name="description"]').count()
+      ).toBe(1)
+
+      // Exactly one canonical
+      expect(await page.locator('link[rel="canonical"]').count()).toBe(1)
+
+      // No @vercel references (Vercel discipline)
+      const pageContent = await page.content()
+      expect(pageContent).not.toContain('@vercel')
+    })
+  }
+
+  test('static pages return 200 with HTML content type', async ({ page }) => {
+    const response = await page.goto(`/artist/${SEED_ARTIST_SLUG}`)
+    expect(response!.status()).toBe(200)
+    expect(response!.headers()['content-type']).toContain('text/html')
+  })
+})

--- a/apps/web/e2e/visual-qa/waitlist-flow.spec.ts
+++ b/apps/web/e2e/visual-qa/waitlist-flow.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Waitlist Flow — Email Capture', () => {
+  test('valid email submission shows success state', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const waitlistSection = page.getByTestId('waitlist')
+    await expect(waitlistSection).toBeVisible()
+
+    // Use a timestamp-based email to avoid collisions between test runs
+    const testEmail = `visual-qa-${Date.now()}@example.com`
+    await page.getByTestId('waitlist-email-input').fill(testEmail)
+    await page.getByTestId('waitlist-submit').click()
+
+    await expect(page.getByTestId('waitlist-success')).toBeVisible({
+      timeout: 5000,
+    })
+  })
+
+  test('invalid email shows error state', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await page.getByTestId('waitlist-email-input').fill('not-an-email')
+    await page.getByTestId('waitlist-submit').click()
+
+    await expect(page.getByTestId('waitlist-error')).toBeVisible({
+      timeout: 3000,
+    })
+  })
+
+  test('empty submission does not show success', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await page.getByTestId('waitlist-submit').click()
+
+    // Either client-side validation prevents submission or an error is shown —
+    // the success state must not appear either way
+    await expect(page.getByTestId('waitlist-success')).not.toBeVisible()
+  })
+
+  test('duplicate email submission does not show an error', async ({ page }) => {
+    const testEmail = `visual-qa-dup-${Date.now()}@example.com`
+
+    // First submission
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('waitlist-email-input').fill(testEmail)
+    await page.getByTestId('waitlist-submit').click()
+    await expect(page.getByTestId('waitlist-success')).toBeVisible({
+      timeout: 5000,
+    })
+
+    // Second submission with the same email
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('waitlist-email-input').fill(testEmail)
+    await page.getByTestId('waitlist-submit').click()
+
+    // Must not show an error — the API handles duplicates gracefully
+    await page.waitForTimeout(3000)
+    await expect(page.getByTestId('waitlist-error')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Implements the full Playwright visual QA suite defined in `docs/Visual_QA_Automation.md`. Closes all five visual QA issues as a batch.

- Adds four new test files covering page rendering, SEO metadata, responsive screenshots, and the waitlist flow
- Expands the existing `runtime-health.spec.ts` to cover all three seed artist profile pages
- Adds a `visual-qa` CI job to `pr.yml` that runs the suite against Vercel preview deployments and uploads screenshots and HTML reports as artifacts

## What was added

**`page-rendering.spec.ts`** — Visits every page type (homepage, all 3 seed artists, all 9 categories, listing detail via click-through) and verifies key `data-testid` sections are visible and no 404s occur. Captures full-page screenshots for human review.

**`seo-metadata.spec.ts`** — Checks title, meta description, OG tags, and canonical URL on homepage, artist profile, listing detail, and category pages. Also verifies no duplicate tags and no `@vercel` references.

**`responsive.spec.ts`** — Screenshot-capture-only test at 7 breakpoints (375px, 428px, 768px, 1024px, 1280px, 1440px, 1920px) for homepage, artist profile, category page, and listing detail. Generates both full-page and above-the-fold variants.

**`waitlist-flow.spec.ts`** — Verifies valid submission → success state, invalid email → error state, empty submission → no success, duplicate email → no error (graceful/privacy-preserving handling).

**CI job (`pr.yml`)** — Uses `patrickedqvist/wait-for-vercel-preview` to poll the GitHub Deployments API for the Vercel preview URL (no extra tokens needed, uses `GITHUB_TOKEN`), then runs the full suite against it. Screenshots and HTML report uploaded as `visual-qa-{sha}` artifact with 14-day retention. `notify-actions-pr` updated to include `visual-qa` in its failure check.

## Closes

Closes #110, #111, #112, #113, #114

## Test plan

- [ ] All four quality gates pass (confirmed locally)
- [ ] On first PR to `main`, verify the `visual-qa` CI job appears and waits for the Vercel preview
- [ ] Download the artifact and review screenshots for visual correctness
- [ ] Confirm the HTML report is readable and shows pass/fail per test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Playwright-based visual QA suite and integrate it into the PR CI workflow against Vercel preview deployments.

CI:
- Introduce a `visual-qa` GitHub Actions job that waits for the Vercel preview URL, runs Playwright visual QA tests, and uploads screenshots and HTML reports as artifacts.
- Update the PR notification job to depend on the visual QA job and treat its failures as overall PR failures.

Tests:
- Expand the runtime health Playwright test to cover all seed artist profile pages.
- Add Playwright visual QA specs for page rendering coverage, SEO metadata validation, responsive screenshots at multiple breakpoints, and the waitlist signup flow.