### PR TITLE
fix(web): add CloudFront remotePatterns to next.config.ts

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "dmfu4c7s6z2cc.cloudfront.net", // prod CDN
+      },
+      {
+        protocol: "https",
+        hostname: "d2agn4aoo0e7ji.cloudfront.net", // dev CDN
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Add `remotePatterns` for prod and dev CloudFront domains to `apps/web/next.config.ts`
- Fixes all broken images across the site (homepage, listing detail, artist profile, category browse)

## Root Cause

`next.config.ts` was empty. Next.js Image blocks external URLs without explicit `remotePatterns` configuration, even when the `unoptimized` prop is used. All seed images served from `dmfu4c7s6z2cc.cloudfront.net` were silently rejected.

## Test plan

- [ ] Homepage featured artists and listings show real images
- [ ] Listing detail gallery and thumbnails load
- [ ] Artist profile cover, profile photo, and listing cards all load
- [ ] All quality gates pass

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure Next.js image handling to allow loading images from the production and development CloudFront CDNs.

New Features:
- Allow the web app to load images from the production CloudFront domain via Next.js image remote patterns.
- Allow the web app to load images from the development CloudFront domain via Next.js image remote patterns.