### PR TITLE
fix(db): align seed image URLs with image processor output paths

### DIFF
--- a/packages/db/prisma/seed-data.ts
+++ b/packages/db/prisma/seed-data.ts
@@ -22,7 +22,7 @@ export interface SeedUser {
   cognitoId: string
   email: string
   fullName: string
-  avatarUrl: string
+  avatarUrl: string | null
 }
 
 export interface SeedProfile {
@@ -87,8 +87,20 @@ export interface ArtistSeedConfig {
 // Production CloudFront CDN for seed images (surfaced-art-prod-media bucket)
 export const CDN_BASE = 'https://dmfu4c7s6z2cc.cloudfront.net'
 
-export function cdnUrl(path: string): string {
-  return `${CDN_BASE}/seed/${path}`
+/**
+ * Builds a CDN URL for an image processor variant.
+ *
+ * @param s3KeyBase - S3 key without extension, e.g.
+ *   'uploads/seed/artists/abbey-peters/cover'
+ * @param width - Target width variant (default 1200 — largest variant)
+ */
+export function cdnUrl(s3KeyBase: string, width: number = 1200): string {
+  return `${CDN_BASE}/${s3KeyBase}/${width}w.webp`
+}
+
+/** Shorthand for building seed artist image S3 key bases. */
+function seedKey(slug: string, path: string): string {
+  return `uploads/seed/artists/${slug}/${path}`
 }
 
 // ============================================================================
@@ -100,7 +112,7 @@ const abbeyConfig: ArtistSeedConfig = {
     cognitoId: 'seed-abbey-peters-cognito',
     email: 'abbey@abbey-peters.com',
     fullName: 'Abbey Peters',
-    avatarUrl: cdnUrl('abbey-peters/profile.webp'),
+    avatarUrl: cdnUrl(seedKey('abbey-peters', 'profile')),
   },
   profile: {
     displayName: 'Abbey Peters',
@@ -112,8 +124,8 @@ const abbeyConfig: ArtistSeedConfig = {
     originZip: '80210',
     status: 'approved',
     commissionsOpen: false,
-    coverImageUrl: cdnUrl('abbey-peters/cover.webp'),
-    profileImageUrl: cdnUrl('abbey-peters/profile.webp'),
+    coverImageUrl: cdnUrl(seedKey('abbey-peters', 'cover')),
+    profileImageUrl: cdnUrl(seedKey('abbey-peters', 'profile')),
     applicationSource: 'advisor_network',
   },
   categories: ['ceramics', 'mixed_media'],
@@ -233,8 +245,8 @@ const abbeyConfig: ArtistSeedConfig = {
     },
   ],
   processMedia: [
-    { type: 'photo', url: cdnUrl('abbey-peters/process-studio.webp'), sortOrder: 0 },
-    { type: 'photo', url: cdnUrl('abbey-peters/process-kiln.webp'), sortOrder: 1 },
+    { type: 'photo', url: cdnUrl(seedKey('abbey-peters', 'process/studio')), sortOrder: 0 },
+    { type: 'photo', url: cdnUrl(seedKey('abbey-peters', 'process/kiln')), sortOrder: 1 },
   ],
 }
 
@@ -247,7 +259,7 @@ const davidConfig: ArtistSeedConfig = {
     cognitoId: 'seed-david-morrison-cognito',
     email: 'davidmorrison167@gmail.com',
     fullName: 'David Morrison',
-    avatarUrl: cdnUrl('david-morrison/profile.webp'),
+    avatarUrl: cdnUrl(seedKey('david-morrison', 'profile')),
   },
   profile: {
     displayName: 'David Morrison',
@@ -259,8 +271,8 @@ const davidConfig: ArtistSeedConfig = {
     originZip: '05404',
     status: 'approved',
     commissionsOpen: false,
-    coverImageUrl: cdnUrl('david-morrison/cover.webp'),
-    profileImageUrl: cdnUrl('david-morrison/profile.webp'),
+    coverImageUrl: cdnUrl(seedKey('david-morrison', 'cover')),
+    profileImageUrl: cdnUrl(seedKey('david-morrison', 'profile')),
     applicationSource: 'advisor_network',
   },
   categories: ['ceramics', 'mixed_media'],
@@ -356,7 +368,7 @@ const davidConfig: ArtistSeedConfig = {
     },
   ],
   processMedia: [
-    { type: 'photo', url: cdnUrl('david-morrison/process-studio.webp'), sortOrder: 0 },
+    { type: 'photo', url: cdnUrl(seedKey('david-morrison', 'process/studio')), sortOrder: 0 },
   ],
 }
 
@@ -369,7 +381,7 @@ const karinaConfig: ArtistSeedConfig = {
     cognitoId: 'seed-karina-yanes-cognito',
     email: 'karina@karinayanesceramics.com',
     fullName: 'Karina Yanes',
-    avatarUrl: cdnUrl('karina-yanes/profile.webp'),
+    avatarUrl: cdnUrl(seedKey('karina-yanes', 'profile')),
   },
   profile: {
     displayName: 'Karina Yanes',
@@ -381,8 +393,8 @@ const karinaConfig: ArtistSeedConfig = {
     originZip: '32601',
     status: 'approved',
     commissionsOpen: false,
-    coverImageUrl: cdnUrl('karina-yanes/cover.webp'),
-    profileImageUrl: cdnUrl('karina-yanes/profile.webp'),
+    coverImageUrl: cdnUrl(seedKey('karina-yanes', 'cover')),
+    profileImageUrl: cdnUrl(seedKey('karina-yanes', 'profile')),
     applicationSource: 'advisor_network',
   },
   categories: ['ceramics', 'mixed_media'],
@@ -472,7 +484,7 @@ const karinaConfig: ArtistSeedConfig = {
     },
   ],
   processMedia: [
-    { type: 'photo', url: cdnUrl('karina-yanes/process-studio.webp'), sortOrder: 0 },
+    { type: 'photo', url: cdnUrl(seedKey('karina-yanes', 'process/studio')), sortOrder: 0 },
   ],
 }
 
@@ -485,7 +497,7 @@ const makoConfig: ArtistSeedConfig = {
     cognitoId: 'seed-mako-sandusky-cognito',
     email: 'macaylasandusky@gmail.com',
     fullName: 'Macayla Sandusky',
-    avatarUrl: cdnUrl('mako-sandusky/profile.webp'),
+    avatarUrl: null, // No images uploaded yet (blocked on artist providing photos)
   },
   profile: {
     displayName: 'Mako Sandusky',
@@ -497,8 +509,8 @@ const makoConfig: ArtistSeedConfig = {
     originZip: '52240',
     status: 'approved',
     commissionsOpen: false,
-    coverImageUrl: cdnUrl('mako-sandusky/cover.webp'),
-    profileImageUrl: cdnUrl('mako-sandusky/profile.webp'),
+    coverImageUrl: null, // No images uploaded yet
+    profileImageUrl: null, // No images uploaded yet
     applicationSource: 'advisor_network',
   },
   categories: ['ceramics', 'mixed_media'],
@@ -578,9 +590,7 @@ const makoConfig: ArtistSeedConfig = {
       packedWeight: 3,
     },
   ],
-  processMedia: [
-    { type: 'photo', url: cdnUrl('mako-sandusky/process-studio.webp'), sortOrder: 0 },
-  ],
+  processMedia: [], // No images uploaded yet
 }
 
 // ============================================================================

--- a/packages/db/prisma/seed-logic.ts
+++ b/packages/db/prisma/seed-logic.ts
@@ -116,10 +116,12 @@ export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) 
 
     // Create 2 images per listing: primary + one additional angle
     // For documented listings, second image is a process photo
+    // S3 key structure: uploads/seed/artists/{slug}/listings/{listing-slug}/front
+    const listingImageBase = `uploads/seed/artists/${data.profile.slug}/listings/${listingSlug}`
     await tx.listingImage.create({
       data: {
         listingId: listing.id,
-        url: cdnUrl(`${data.profile.slug}/${listingSlug}-front.webp`),
+        url: cdnUrl(`${listingImageBase}/front`),
         isProcessPhoto: false,
         sortOrder: 0,
       },
@@ -127,7 +129,7 @@ export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) 
     await tx.listingImage.create({
       data: {
         listingId: listing.id,
-        url: cdnUrl(`${data.profile.slug}/${listingSlug}-angle.webp`),
+        url: cdnUrl(`${listingImageBase}/angle`),
         isProcessPhoto: listingData.isDocumented,
         sortOrder: 1,
       },

--- a/packages/db/prisma/seed.test.ts
+++ b/packages/db/prisma/seed.test.ts
@@ -69,8 +69,11 @@ describe('Seed Data Validation', () => {
   })
 
   describe('process media', () => {
-    it('should have at least 1 process media entry per artist', () => {
-      for (const config of artistConfigs) {
+    it('should have at least 1 process media entry for artists with images', () => {
+      const artistsWithImages = artistConfigs.filter(
+        (c) => c.profile.coverImageUrl !== null
+      )
+      for (const config of artistsWithImages) {
         expect(config.processMedia.length).toBeGreaterThanOrEqual(1)
       }
     })


### PR DESCRIPTION
## Summary

- Updated `cdnUrl()` helper in `seed-data.ts` to generate URLs matching the image processor's actual output structure (`uploads/seed/artists/{slug}/{path}/{width}w.webp`)
- Updated all seed data call sites for Abbey Peters, David Morrison, and Karina Yanes
- Updated listing image URL patterns in `seed-logic.ts` to match S3 key structure
- Set Mako Sandusky image URLs to `null` (no S3 images exist — blocked on artist providing photos)
- Adjusted seed test to skip process media validation for artists without images

## Context

The image processor Lambda generates width-variant WebP files (400w, 800w, 1200w) from uploaded JPGs, but the seed data referenced flat `.webp` files at non-existent paths. Even after the processor runs, the DB URLs wouldn't match the actual S3 keys.

This PR also triggers a CI deploy that will push the correct image processor container to ECR (currently running the API container image by mistake).

## After merge to main

1. CI deploys the correct image processor container
2. Re-trigger S3 events to process existing JPGs into WebP variants
3. Re-seed the production DB with the new URLs

## Test plan

- [x] All quality gates pass
- [ ] After main deploy: verify image processor logs show variant generation
- [ ] After re-seed: verify images load on live site

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align seeded image URLs and tests with the image processor’s S3 key structure and support artists without images.

Bug Fixes:
- Update CDN URL generation to match image processor variant output paths for artist and listing images.

Enhancements:
- Allow seed user avatar URLs to be nullable to represent artists without images.
- Introduce a helper for constructing seed artist S3 key bases and reuse it across artist seed configs.

Tests:
- Relax process media seed test to only require entries for artists that have cover images.