### PR TITLE
fix(image-processor): externalize Node.js built-ins for ESM Lambda

### DIFF
--- a/apps/image-processor/tsup.config.ts
+++ b/apps/image-processor/tsup.config.ts
@@ -1,3 +1,4 @@
+import { builtinModules } from 'node:module'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
@@ -8,10 +9,12 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   dts: false,
-  // Bundle dependencies for Lambda deployment — except sharp which has
-  // native binaries that must be installed via npm in the Docker image.
+  // Bundle dependencies for Lambda deployment — except sharp (native binaries
+  // installed via npm in the Docker image) and Node.js built-ins (resolved at
+  // runtime, and bundling them causes "Dynamic require of X is not supported"
+  // errors in ESM mode).
   noExternal: [/.*/],
-  external: ['sharp'],
+  external: ['sharp', ...builtinModules, ...builtinModules.map((m) => `node:${m}`)],
   minify: true,
   // Emit a single index.js — the Dockerfile copies only this file into
   // the Lambda container. Splitting would create chunk-*.js files that


### PR DESCRIPTION
## Summary
- Externalizes Node.js built-in modules (`util`, `path`, `fs`, etc.) from the tsup bundle so they resolve at runtime from the Node.js standard library
- Fixes `Dynamic require of "util" is not supported` crash in the Lambda container — the AWS SDK internally uses `require()` for built-ins, which esbuild's ESM polyfill rejects when bundled

## Context
PR #213 fixed chunk splitting but the Lambda still crashed because built-in modules were being bundled. This is the second of two bundling fixes needed to get the image processor running.

## Test plan
- [ ] CI passes (test, lint, typecheck, build)
- [ ] After merge + deploy, re-trigger S3 events and verify Lambda logs show `Processed N variant(s)` instead of errors
- [ ] Verify WebP variants exist in S3