### PR TITLE
feat(web): migrate from build-time SSG to on-demand ISR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql://surfaced:surfaced_local@localhost:5432/surfaced
+REVALIDATION_SECRET=generate-a-random-secret-here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,7 @@ Required in `.env` files (never commit these):
 ```
 DATABASE_URL=postgresql://[user]:[password]@[host]:5432/[dbname]
 AWS_REGION=us-east-1
+REVALIDATION_SECRET=[random-secret]  # Vercel env var — protects POST /api/revalidate
 ```
 
 ## No Shortcuts Policy

--- a/apps/web/src/app/api/revalidate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/revalidate/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { revalidatePath } from 'next/cache'
+import { POST } from '../route'
+
+function makeRequest(body: unknown, authHeader?: string) {
+  const headers = new Headers({ 'Content-Type': 'application/json' })
+  if (authHeader) headers.set('Authorization', authHeader)
+  return new Request('http://localhost/api/revalidate', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('REVALIDATION_SECRET', 'test-secret')
+  })
+
+  describe('authentication', () => {
+    it('should return 401 when no authorization header is provided', async () => {
+      const response = await POST(makeRequest({ type: 'all' }))
+      expect(response.status).toBe(401)
+      const body = await response.json()
+      expect(body.error).toBe('Unauthorized')
+    })
+
+    it('should return 401 when the secret is wrong', async () => {
+      const response = await POST(makeRequest({ type: 'all' }, 'Bearer wrong-secret'))
+      expect(response.status).toBe(401)
+    })
+
+    it('should return 401 when REVALIDATION_SECRET is not configured', async () => {
+      vi.stubEnv('REVALIDATION_SECRET', '')
+      const response = await POST(makeRequest({ type: 'all' }, 'Bearer test-secret'))
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('path-based revalidation', () => {
+    it('should revalidate specific paths', async () => {
+      const paths = ['/artist/abbey-peters', '/listing/abc123']
+      const response = await POST(makeRequest({ paths }, 'Bearer test-secret'))
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.revalidated).toEqual(paths)
+      expect(revalidatePath).toHaveBeenCalledTimes(2)
+      expect(revalidatePath).toHaveBeenCalledWith('/artist/abbey-peters')
+      expect(revalidatePath).toHaveBeenCalledWith('/listing/abc123')
+    })
+
+    it('should reject non-array paths', async () => {
+      const response = await POST(makeRequest({ paths: '/artist/abbey-peters' }, 'Bearer test-secret'))
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('artist revalidation', () => {
+    it('should revalidate artist page, homepage, and all category pages', async () => {
+      const response = await POST(
+        makeRequest({ type: 'artist', slug: 'abbey-peters' }, 'Bearer test-secret')
+      )
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.revalidated).toContain('/artist/abbey-peters')
+      expect(body.revalidated).toContain('/')
+      // Should include all 9 category pages
+      expect(body.revalidated).toContain('/category/ceramics')
+      expect(body.revalidated).toContain('/category/painting')
+      expect(body.revalidated).toContain('/category/mixed_media')
+    })
+
+    it('should return 400 when slug is missing', async () => {
+      const response = await POST(makeRequest({ type: 'artist' }, 'Bearer test-secret'))
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('listing revalidation', () => {
+    it('should revalidate listing, homepage, and specified category page', async () => {
+      const response = await POST(
+        makeRequest({ type: 'listing', id: 'abc123', category: 'ceramics' }, 'Bearer test-secret')
+      )
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.revalidated).toContain('/listing/abc123')
+      expect(body.revalidated).toContain('/')
+      expect(body.revalidated).toContain('/category/ceramics')
+      // Should NOT include other category pages
+      expect(body.revalidated).not.toContain('/category/painting')
+    })
+
+    it('should revalidate all category pages when category is not specified', async () => {
+      const response = await POST(
+        makeRequest({ type: 'listing', id: 'abc123' }, 'Bearer test-secret')
+      )
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.revalidated).toContain('/category/ceramics')
+      expect(body.revalidated).toContain('/category/painting')
+      expect(body.revalidated).toContain('/category/mixed_media')
+    })
+
+    it('should return 400 when id is missing', async () => {
+      const response = await POST(makeRequest({ type: 'listing' }, 'Bearer test-secret'))
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('full revalidation', () => {
+    it('should revalidate all pages via layout', async () => {
+      const response = await POST(makeRequest({ type: 'all' }, 'Bearer test-secret'))
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(revalidatePath).toHaveBeenCalledWith('/', 'layout')
+    })
+  })
+
+  describe('invalid requests', () => {
+    it('should return 400 for unknown type', async () => {
+      const response = await POST(makeRequest({ type: 'unknown' }, 'Bearer test-secret'))
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.error).toBeDefined()
+    })
+
+    it('should return 400 for empty body', async () => {
+      const response = await POST(makeRequest({}, 'Bearer test-secret'))
+      expect(response.status).toBe(400)
+    })
+  })
+})

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+import { CATEGORIES } from '@/lib/categories'
+
+export async function POST(request: Request) {
+  const secret = process.env.REVALIDATION_SECRET
+  const authHeader = request.headers.get('authorization')
+
+  if (!secret || authHeader !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const revalidated: string[] = []
+
+  if (body.paths && Array.isArray(body.paths)) {
+    for (const path of body.paths) {
+      revalidatePath(path)
+      revalidated.push(path)
+    }
+  } else if (body.type === 'artist' && body.slug) {
+    revalidatePath(`/artist/${body.slug}`)
+    revalidatePath('/')
+    revalidated.push(`/artist/${body.slug}`, '/')
+    for (const cat of CATEGORIES) {
+      revalidatePath(`/category/${cat.slug}`)
+      revalidated.push(`/category/${cat.slug}`)
+    }
+  } else if (body.type === 'listing' && body.id) {
+    revalidatePath(`/listing/${body.id}`)
+    revalidatePath('/')
+    revalidated.push(`/listing/${body.id}`, '/')
+    if (body.category) {
+      revalidatePath(`/category/${body.category}`)
+      revalidated.push(`/category/${body.category}`)
+    } else {
+      for (const cat of CATEGORIES) {
+        revalidatePath(`/category/${cat.slug}`)
+        revalidated.push(`/category/${cat.slug}`)
+      }
+    }
+  } else if (body.type === 'all') {
+    revalidatePath('/', 'layout')
+    revalidated.push('/ (all pages via layout)')
+  } else {
+    return NextResponse.json(
+      { error: 'Invalid request. Provide "paths" array, or "type" with required fields.' },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json({ success: true, revalidated })
+}

--- a/apps/web/src/app/artist/[slug]/page.tsx
+++ b/apps/web/src/app/artist/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getArtistProfile, getFeaturedArtists, ApiError } from '@/lib/api'
+import { getArtistProfile, ApiError } from '@/lib/api'
 import { ProfilePhoto } from '@/components/ProfilePhoto'
 import { ListingCard } from '@/components/ListingCard'
 import { Badge } from '@/components/ui/badge'
@@ -14,13 +14,11 @@ import type { ArtistProfileResponse, CvEntryTypeType } from '@surfaced-art/types
 
 export const revalidate = 60
 
+// Return empty array so no artist pages are pre-rendered at build time.
+// Pages render on first visitor request and are cached via ISR (revalidate = 60).
+// Use POST /api/revalidate to bust the cache on demand after content changes.
 export async function generateStaticParams() {
-  try {
-    const artists = await getFeaturedArtists({ limit: 50 })
-    return artists.map((artist) => ({ slug: artist.slug }))
-  } catch {
-    return []
-  }
+  return []
 }
 
 const cvEntryTypeLabels: Record<CvEntryTypeType, string> = {

--- a/apps/web/src/app/category/[category]/page.tsx
+++ b/apps/web/src/app/category/[category]/page.tsx
@@ -7,7 +7,6 @@ import { CategoryBrowseView, type CategoryListingItem } from '@/components/Categ
 import { JsonLd } from '@/components/JsonLd'
 import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { SITE_URL } from '@/lib/site-config'
-import { CATEGORIES } from '@/lib/categories'
 import { Category } from '@surfaced-art/types'
 import type { CategoryType } from '@surfaced-art/types'
 
@@ -15,8 +14,11 @@ export const revalidate = 60
 
 const validCategories = new Set(Object.values(Category))
 
+// Return empty array so no category pages are pre-rendered at build time.
+// Pages render on first visitor request and are cached via ISR (revalidate = 60).
+// Use POST /api/revalidate to bust the cache on demand after content changes.
 export function generateStaticParams() {
-  return CATEGORIES.map((cat) => ({ category: cat.slug }))
+  return []
 }
 
 type Props = {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import type {
   ArtistProfileResponse,
   CategoryType,
@@ -48,9 +49,12 @@ export class ApiError extends Error {
   }
 }
 
-export async function getArtistProfile(slug: string): Promise<ArtistProfileResponse> {
+// Wrapped with React.cache() to deduplicate calls within a single request.
+// Both generateMetadata and the page component call getArtistProfile with the
+// same slug — cache() ensures only one API call is made per render.
+export const getArtistProfile = cache(async (slug: string): Promise<ArtistProfileResponse> => {
   return apiFetch<ArtistProfileResponse>(`/artists/${encodeURIComponent(slug)}`)
-}
+})
 
 export async function getFeaturedArtists(params?: {
   limit?: number
@@ -83,9 +87,12 @@ export async function getListings(params?: {
   return apiFetch<PaginatedResponse<ListingListItem>>(`/listings${query ? `?${query}` : ''}`)
 }
 
-export async function getListingDetail(id: string): Promise<ListingDetailResponse> {
+// Wrapped with React.cache() to deduplicate calls within a single request.
+// Both generateMetadata and the page component call getListingDetail with the
+// same id — cache() ensures only one API call is made per render.
+export const getListingDetail = cache(async (id: string): Promise<ListingDetailResponse> => {
   return apiFetch<ListingDetailResponse>(`/listings/${encodeURIComponent(id)}`)
-}
+})
 
 export async function joinWaitlist(email: string): Promise<{ message: string }> {
   return apiFetch<{ message: string }>('/waitlist', {

--- a/apps/web/src/test/mocks/next-cache.ts
+++ b/apps/web/src/test/mocks/next-cache.ts
@@ -1,0 +1,4 @@
+import { vi } from 'vitest'
+
+export const revalidatePath = vi.fn()
+export const revalidateTag = vi.fn()

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       'next/link': path.resolve(__dirname, './src/test/mocks/next-link.tsx'),
       'next/image': path.resolve(__dirname, './src/test/mocks/next-image.tsx'),
+      'next/cache': path.resolve(__dirname, './src/test/mocks/next-cache.ts'),
     },
   },
 })

--- a/bruno/Revalidation/Revalidate All.bru
+++ b/bruno/Revalidation/Revalidate All.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Revalidate All
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{sa_frontendUrl}}/api/revalidate
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_revalidationSecret}}
+}
+
+body:json {
+  {
+    "type": "all"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.success: eq true
+}
+
+tests {
+  test("should revalidate all pages", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.revalidated).to.be.an("array");
+  });
+}

--- a/bruno/Revalidation/Revalidate Artist.bru
+++ b/bruno/Revalidation/Revalidate Artist.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Revalidate Artist
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{sa_frontendUrl}}/api/revalidate
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_revalidationSecret}}
+}
+
+body:json {
+  {
+    "type": "artist",
+    "slug": "{{sa_artistSlug}}"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.success: eq true
+}
+
+tests {
+  test("should revalidate artist and related pages", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.revalidated).to.include("/artist/" + bru.getEnvVar("sa_artistSlug"));
+    expect(body.revalidated).to.include("/");
+  });
+}

--- a/bruno/Revalidation/Revalidate Listing.bru
+++ b/bruno/Revalidation/Revalidate Listing.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Revalidate Listing
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{sa_frontendUrl}}/api/revalidate
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_revalidationSecret}}
+}
+
+body:json {
+  {
+    "type": "listing",
+    "id": "{{sa_listingId}}",
+    "category": "{{sa_category}}"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.success: eq true
+}
+
+tests {
+  test("should revalidate listing and related pages", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.revalidated).to.include("/listing/" + bru.getEnvVar("sa_listingId"));
+    expect(body.revalidated).to.include("/");
+  });
+}

--- a/bruno/Revalidation/Revalidate Paths.bru
+++ b/bruno/Revalidation/Revalidate Paths.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Revalidate Paths
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{sa_frontendUrl}}/api/revalidate
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_revalidationSecret}}
+}
+
+body:json {
+  {
+    "paths": ["/artist/{{sa_artistSlug}}", "/"]
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.success: eq true
+}
+
+tests {
+  test("should revalidate specified paths", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.revalidated).to.have.lengthOf(2);
+  });
+}

--- a/bruno/Revalidation/Revalidate Unauthorized.bru
+++ b/bruno/Revalidation/Revalidate Unauthorized.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Revalidate Unauthorized
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{sa_frontendUrl}}/api/revalidate
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "type": "all"
+  }
+}
+
+assert {
+  res.status: eq 401
+  res.body.error: eq Unauthorized
+}
+
+tests {
+  test("should reject unauthenticated request", function() {
+    expect(res.getStatus()).to.equal(401);
+    expect(res.getBody().error).to.equal("Unauthorized");
+  });
+}

--- a/bruno/Revalidation/folder.bru
+++ b/bruno/Revalidation/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Revalidation
+}

--- a/bruno/environments/Production.bru
+++ b/bruno/environments/Production.bru
@@ -1,6 +1,8 @@
 vars {
   sa_baseUrl: https://xl3aiyolr6.execute-api.us-east-1.amazonaws.com
+  sa_frontendUrl: https://surfaced.art
   sa_artistSlug: abbey-peters
   sa_listingId:
   sa_category: ceramics
+  sa_revalidationSecret:
 }

--- a/docs/decisions/006-on-demand-isr.md
+++ b/docs/decisions/006-on-demand-isr.md
@@ -1,0 +1,28 @@
+# ADR-006: On-demand ISR over build-time SSG
+
+**Status:** Accepted
+**Date:** 2026-02-26
+
+**Context:** Vercel builds pre-render all pages via `generateStaticParams`, causing hundreds of concurrent API Lambda invocations. Each Lambda opens a DB connection, and with only 4 seed artists + 9 categories, the build hit 276 concurrent executions and 107 DB connections — exceeding the db.t3.micro limit of ~87. This scales linearly with content (1,000 artists = thousands of build-time API calls) and would require increasingly expensive infrastructure to sustain.
+
+**Decision:** Migrate from build-time SSG to on-demand ISR:
+
+1. `generateStaticParams` returns `[]` for artist and category pages — nothing is pre-rendered at build time
+2. Pages render on first visitor request and are cached via ISR (`revalidate = 60`)
+3. A `POST /api/revalidate` endpoint allows manual or webhook-triggered cache invalidation
+4. `React.cache()` wraps data-fetching functions called by both `generateMetadata` and page components to deduplicate API calls within a single render
+5. Lambda concurrency is capped at 40 (`reserved_concurrent_executions`) and each instance holds max 1 DB connection
+
+**Alternatives considered:**
+
+- **Keep SSG with connection pooling only**: Would still hammer the API during builds. Connection pooling limits damage but doesn't fix the root cause. Doesn't scale.
+- **Pre-render a subset (top N artists)**: Partially reduces build load but still grows with content. Adds complexity deciding which pages to pre-render.
+- **`revalidateTag` instead of `revalidatePath`**: More granular (invalidate "all pages showing artist X" by tag), but requires modifying every `fetch()` call to include tags. Not worth the complexity at current scale. Can be added later.
+
+**Consequences:**
+
+- Builds make near-zero API calls (only homepage + sitemap at most)
+- First visitor to an uncached page sees a slightly slower response (server render). All subsequent visitors get cached static HTML.
+- SEO is unaffected — pages render full HTML with meta tags and JSON-LD on first request. Sitemap lists all URLs.
+- Cache invalidation requires calling the `/api/revalidate` endpoint (manually or via webhook). The 60-second `revalidate` fallback ensures pages refresh even without explicit invalidation.
+- Future work (issue #230): wire backend webhooks to the revalidation endpoint for automatic invalidation on content changes.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,3 +34,4 @@ This directory contains Architecture Decision Records (ADRs) for the Surfaced Ar
 | [003](./003-hono-over-express.md) | Hono over Express for Lambda backend | Accepted | 2026-02-24 |
 | [004](./004-postgresql-fulltext-search.md) | PostgreSQL full-text search over dedicated search service | Accepted | 2026-02-24 |
 | [005](./005-prisma-driver-adapter-pattern.md) | Prisma driver adapter pattern (@prisma/adapter-pg) | Accepted | 2026-02-24 |
+| [006](./006-on-demand-isr.md) | On-demand ISR over build-time SSG | Accepted | 2026-02-26 |

--- a/infrastructure/terraform/modules/lambda-api/main.tf
+++ b/infrastructure/terraform/modules/lambda-api/main.tf
@@ -36,6 +36,12 @@ resource "aws_lambda_function" "api" {
   memory_size   = var.memory_size
   timeout       = var.timeout
 
+  # Cap concurrent instances to prevent DB connection exhaustion.
+  # Each instance holds 1 DB connection (max: 1 in pg pool config).
+  # db.t3.micro supports ~87 connections; 40 leaves headroom for
+  # the migrate Lambda, image processor, and admin queries.
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+
   # Public placeholder for initial Terraform apply before the ECR image exists.
   # CI/CD pipeline manages actual image deployments via aws lambda update-function-code.
   image_uri = var.placeholder_image_uri

--- a/infrastructure/terraform/modules/lambda-api/variables.tf
+++ b/infrastructure/terraform/modules/lambda-api/variables.tf
@@ -91,3 +91,9 @@ variable "log_retention_days" {
   type        = number
   default     = 30
 }
+
+variable "reserved_concurrent_executions" {
+  description = "Maximum concurrent Lambda instances. Limits DB connections: db.t3.micro supports ~87, so cap this below that to leave headroom for migrations and admin. Set to -1 to disable (unreserved)."
+  type        = number
+  default     = 40
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -45,6 +45,13 @@ function createPrismaClient() {
   const adapter = new PrismaPg({
     connectionString: process.env.DATABASE_URL,
     ssl: buildSslConfig(),
+    // Limit each Lambda instance to a single DB connection.
+    // db.t3.micro supports ~87 connections; without this cap, a Vercel build
+    // can spawn hundreds of concurrent Lambda invocations, each opening a
+    // connection and exhausting the pool.
+    max: 1,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 5_000,
   })
   return new PrismaClient({
     adapter,


### PR DESCRIPTION
## Summary

- **Add on-demand ISR revalidation endpoint** (`POST /api/revalidate`) with Bearer token auth, supporting path-based, entity-type (artist/listing/all), and full-site cache invalidation
- **Remove build-time pre-rendering** from artist and category pages (`generateStaticParams` returns `[]`) — pages render on first visit and cache via ISR with `revalidate = 60`
- **Deduplicate API calls** by wrapping `getArtistProfile` and `getListingDetail` with `React.cache()` to prevent duplicate fetches between `generateMetadata` and page components
- **Add DB connection guardrails**: PrismaPg pool capped at 1 connection per Lambda instance, API Lambda concurrency capped at 40 via `reserved_concurrent_executions`

### Why

Vercel builds pre-render all pages via `generateStaticParams`, spawning hundreds of concurrent API Lambda invocations that exhaust the RDS `db.t3.micro` connection limit (~87). With only 4 seed artists the build hit 276 concurrent executions and 107 DB connections. This scales linearly with content — untenable as the catalog grows.

On-demand ISR is the industry-standard approach for content-heavy Next.js sites: pre-render nothing at build, let pages render on first visitor request, and bust the cache via a revalidation endpoint when content changes.

### New files
- `apps/web/src/app/api/revalidate/route.ts` — revalidation endpoint
- `apps/web/src/app/api/revalidate/__tests__/route.test.ts` — 13 test cases (TDD)
- `apps/web/src/test/mocks/next-cache.ts` — mock for `next/cache`
- `docs/decisions/006-on-demand-isr.md` — ADR
- `bruno/Revalidation/` — 5 Bruno request files for manual revalidation

### Modified files
- `apps/web/src/app/artist/[slug]/page.tsx` — `generateStaticParams` returns `[]`
- `apps/web/src/app/category/[category]/page.tsx` — `generateStaticParams` returns `[]`
- `apps/web/src/lib/api.ts` — `React.cache()` wrappers
- `apps/web/vitest.config.ts` — `next/cache` mock alias
- `packages/db/src/index.ts` — PrismaPg `max: 1` pool config
- `infrastructure/terraform/modules/lambda-api/main.tf` — `reserved_concurrent_executions`
- `infrastructure/terraform/modules/lambda-api/variables.tf` — new variable
- `.env.example`, `CLAUDE.md`, `bruno/environments/Production.bru`, `docs/decisions/README.md`

## Test plan

- [x] 13 new tests for revalidation endpoint (auth, paths, artist, listing, all, invalid body)
- [x] All 96 tests pass
- [x] Lint, typecheck, and build all pass
- [x] Build output confirms artist/category pages are not pre-rendered (0 SSG entries)
- [ ] After deploy: set `REVALIDATION_SECRET` in Vercel env vars
- [ ] After deploy: verify build no longer spawns hundreds of API Lambda invocations
- [ ] After deploy: test `POST /api/revalidate` with `{"type": "all"}` and confirm pages re-render

Closes the DB connection exhaustion issue discovered during deploy. Related: issue #230 (webhook-triggered revalidation — future work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate the web app from build-time static generation to on-demand ISR with a secure revalidation endpoint and guardrails to prevent DB connection exhaustion.

New Features:
- Add a protected POST /api/revalidate endpoint supporting targeted, entity-based, and full-site cache revalidation for ISR pages.

Enhancements:
- Stop pre-rendering artist and category pages at build time so they render on first request and are cached with ISR.
- Wrap artist and listing detail fetchers with React.cache to deduplicate API calls within a single render.
- Document the decision to use on-demand ISR over build-time SSG in a new ADR.

Build:
- Expose REVALIDATION_SECRET in environment configuration to secure revalidation requests.

Deployment:
- Limit Prisma PostgreSQL connections and cap API Lambda reserved concurrency to align with the DB instance connection capacity.

Documentation:
- Update architecture decision records and contributor docs to cover the on-demand ISR strategy and required revalidation secret.

Tests:
- Add comprehensive tests and test utilities for the revalidation endpoint, including auth, payload validation, and revalidation behavior.

Chores:
- Add Bruno collections and environment variables to simplify manual testing of the revalidation endpoint.