### PR TITLE
fix(web): address auth UI code review feedback

### DIFF
--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -18,6 +18,7 @@ vi.mock('next/server', () => ({
 }))
 
 import { middleware, config } from '../middleware'
+import { AUTH_COOKIE_NAME } from '@/lib/auth/constants'
 
 function createRequest(url: string, cookies: Record<string, string> = {}) {
   const fullUrl = new URL(url, 'https://surfaced.art')
@@ -57,7 +58,7 @@ describe('Auth middleware', () => {
 
   it('should allow /dashboard access when auth token exists', () => {
     const request = createRequest('/dashboard', {
-      'cognito-id-token': 'some-jwt-token',
+      [AUTH_COOKIE_NAME]: '1',
     })
     middleware(request)
 

--- a/apps/web/src/lib/__tests__/security-headers.test.ts
+++ b/apps/web/src/lib/__tests__/security-headers.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect } from 'vitest'
-import { SECURITY_HEADERS } from '../security-headers'
+import { describe, it, expect, vi } from 'vitest'
 
 const REQUIRED_HEADERS = [
   { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
@@ -10,46 +9,95 @@ const REQUIRED_HEADERS = [
   { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
 ]
 
+/** Import (or re-import) the module so env var changes take effect. */
+async function loadHeaders() {
+  const mod = await import('../security-headers')
+  return mod.SECURITY_HEADERS
+}
+
 describe('security headers config', () => {
   for (const { key, value } of REQUIRED_HEADERS) {
-    it(`should include ${key} header with correct value`, () => {
-      const header = SECURITY_HEADERS.find((h) => h.key === key)
+    it(`should include ${key} header with correct value`, async () => {
+      const headers = await loadHeaders()
+      const header = headers.find((h) => h.key === key)
       expect(header).toBeDefined()
       expect(header!.value).toBe(value)
     })
   }
 
-  it('should include Content-Security-Policy header', () => {
-    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')
+  it('should include Content-Security-Policy header', async () => {
+    const headers = await loadHeaders()
+    const csp = headers.find((h) => h.key === 'Content-Security-Policy')
     expect(csp).toBeDefined()
     expect(csp!.value).toContain("default-src 'self'")
     expect(csp!.value).toContain("frame-ancestors 'none'")
   })
 
-  it('CSP should allow CloudFront CDN domains for images', () => {
-    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+  it('CSP should allow CloudFront CDN domains for images by default', async () => {
+    const headers = await loadHeaders()
+    const csp = headers.find((h) => h.key === 'Content-Security-Policy')!
     expect(csp.value).toContain('dmfu4c7s6z2cc.cloudfront.net')
     expect(csp.value).toContain('d2agn4aoo0e7ji.cloudfront.net')
   })
 
-  it('CSP should allow Google Fonts for font loading', () => {
-    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+  it('CSP should allow Google Fonts for font loading', async () => {
+    const headers = await loadHeaders()
+    const csp = headers.find((h) => h.key === 'Content-Security-Policy')!
     expect(csp.value).toContain('fonts.googleapis.com')
     expect(csp.value).toContain('fonts.gstatic.com')
   })
 
-  it('CSP should allow API domain for fetch requests', () => {
-    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+  it('CSP should allow API domain for fetch requests by default', async () => {
+    const headers = await loadHeaders()
+    const csp = headers.find((h) => h.key === 'Content-Security-Policy')!
     expect(csp.value).toContain('api.surfaced.art')
   })
 
-  it('CSP should allow Cognito IDP for authentication', () => {
-    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+  it('CSP should allow Cognito IDP for authentication by default', async () => {
+    const headers = await loadHeaders()
+    const csp = headers.find((h) => h.key === 'Content-Security-Policy')!
     expect(csp.value).toContain('cognito-idp.us-east-1.amazonaws.com')
   })
 
-  it('CSP should disallow framing (clickjacking protection)', () => {
-    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+  it('CSP should disallow framing (clickjacking protection)', async () => {
+    const headers = await loadHeaders()
+    const csp = headers.find((h) => h.key === 'Content-Security-Policy')!
     expect(csp.value).toContain("frame-ancestors 'none'")
+  })
+})
+
+describe('CSP environment overrides', () => {
+  it('should use NEXT_PUBLIC_CDN_DOMAINS for img-src when set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CDN_DOMAINS', 'https://staging-cdn.example.com')
+    // Re-import to pick up new env
+    vi.resetModules()
+    const { SECURITY_HEADERS } = await import('../security-headers')
+    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+    expect(csp.value).toContain('staging-cdn.example.com')
+    expect(csp.value).not.toContain('dmfu4c7s6z2cc.cloudfront.net')
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('should use NEXT_PUBLIC_API_URL for connect-src when set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.staging.surfaced.art')
+    vi.resetModules()
+    const { SECURITY_HEADERS } = await import('../security-headers')
+    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+    expect(csp.value).toContain('api.staging.surfaced.art')
+    expect(csp.value).not.toContain('api.surfaced.art')
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('should use NEXT_PUBLIC_COGNITO_IDP for connect-src when set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_COGNITO_IDP', 'https://cognito-idp.eu-west-1.amazonaws.com')
+    vi.resetModules()
+    const { SECURITY_HEADERS } = await import('../security-headers')
+    const csp = SECURITY_HEADERS.find((h) => h.key === 'Content-Security-Policy')!
+    expect(csp.value).toContain('cognito-idp.eu-west-1.amazonaws.com')
+    expect(csp.value).not.toContain('cognito-idp.us-east-1.amazonaws.com')
+    vi.unstubAllEnvs()
+    vi.resetModules()
   })
 })

--- a/apps/web/src/lib/auth/constants.ts
+++ b/apps/web/src/lib/auth/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared auth constants used by both the AuthProvider (client) and
+ * Next.js middleware (edge runtime). Keep this file free of browser-only
+ * or Node-only APIs so it can be imported in both contexts.
+ */
+
+/**
+ * Non-sensitive marker cookie name checked by Next.js middleware.
+ * The cookie value is always "1" — it does NOT contain the JWT.
+ * Actual token validation happens on the API via the Authorization header.
+ */
+export const AUTH_COOKIE_NAME = 'sa-auth'

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -1,15 +1,36 @@
 /**
  * Security headers for all Next.js responses.
  * Extracted into a shared module so both next.config.ts and tests can use it.
+ *
+ * CSP domains are driven by environment variables so staging/preview
+ * environments work without code changes:
+ *
+ *   NEXT_PUBLIC_CDN_DOMAINS  — space-separated CloudFront (or other CDN) origins for img-src
+ *   NEXT_PUBLIC_API_URL      — API origin for connect-src
+ *   NEXT_PUBLIC_COGNITO_IDP  — Cognito IDP origin for connect-src
  */
+
+const CDN_DOMAINS = (
+  process.env.NEXT_PUBLIC_CDN_DOMAINS ??
+  'https://dmfu4c7s6z2cc.cloudfront.net https://d2agn4aoo0e7ji.cloudfront.net'
+).trim()
+
+const API_ORIGIN = (
+  process.env.NEXT_PUBLIC_API_URL ?? 'https://api.surfaced.art'
+).trim()
+
+const COGNITO_IDP = (
+  process.env.NEXT_PUBLIC_COGNITO_IDP ??
+  'https://cognito-idp.us-east-1.amazonaws.com'
+).trim()
 
 const CSP_DIRECTIVES = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
-  "img-src 'self' data: https://dmfu4c7s6z2cc.cloudfront.net https://d2agn4aoo0e7ji.cloudfront.net",
-  "connect-src 'self' https://api.surfaced.art https://cognito-idp.us-east-1.amazonaws.com",
+  `img-src 'self' data: ${CDN_DOMAINS}`,
+  `connect-src 'self' ${API_ORIGIN} ${COGNITO_IDP}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,16 +1,17 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { AUTH_COOKIE_NAME } from '@/lib/auth/constants'
 
 /**
  * Middleware to protect /dashboard routes.
- * Checks for a cognito-id-token cookie — if missing, redirects to /sign-in.
+ * Checks for the auth marker cookie — if missing, redirects to /sign-in.
  *
  * Note: This is a client-side guard only. The actual JWT validation happens
  * on the API side via the auth middleware. This prevents unauthenticated
  * users from seeing the dashboard skeleton before the API rejects them.
  */
 export function middleware(request: NextRequest) {
-  const token = request.cookies.get('cognito-id-token')
+  const token = request.cookies.get(AUTH_COOKIE_NAME)
 
   if (!token) {
     const signInUrl = new URL('/sign-in', request.url)


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #241 on the auth UI implementation:

- **Marker cookie instead of JWT**: Replaced storing the full Cognito ID token in a cookie with a non-sensitive marker (`sa-auth=1`). The cookie is only used as a client-side routing guard by Next.js middleware — actual JWT validation happens server-side via the Authorization header. This eliminates XSS token exposure risk.
- **Centralized cookie constant**: Extracted `AUTH_COOKIE_NAME` into a shared `constants.ts` module that both the middleware (edge runtime) and AuthProvider (client) import, preventing name drift.
- **Environment-driven CSP domains**: CSP directives for CDN (`img-src`), API (`connect-src`), and Cognito IDP (`connect-src`) are now driven by `NEXT_PUBLIC_CDN_DOMAINS`, `NEXT_PUBLIC_API_URL`, and `NEXT_PUBLIC_COGNITO_IDP` environment variables with production defaults. Staging/preview environments work without code changes.

## Test plan

- [x] All 155 tests pass (including 3 new CSP env override tests)
- [x] Lint clean
- [x] Typecheck clean
- [x] Build succeeds
- [ ] Verify auth flow still works on production Cognito after deploy

## Summary by Sourcery

Replace sensitive auth cookie usage with a non-sensitive marker cookie and make security headers configurable via environment-driven CSP settings.

Bug Fixes:
- Prevent exposure of Cognito ID tokens in browser cookies by using a minimal auth marker cookie checked by middleware instead.

Enhancements:
- Centralize the auth marker cookie name in a shared constants module used by both the client AuthProvider and Next.js middleware.
- Drive CSP img-src and connect-src domains from environment variables with sensible production defaults to better support staging and preview environments.

Tests:
- Expand security headers tests to cover CSP environment overrides and update existing expectations to work with dynamic CSP configuration.