### PR TITLE
Release: admin artist approval and rejection endpoints

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import { createWaitlistRoutes } from './routes/waitlist'
 import { createApplicationRoutes } from './routes/applications'
 import { createUploadRoutes } from './routes/uploads'
 import { createMeRoutes } from './routes/me'
+import { createAdminRoutes } from './routes/admin'
 
 // Create Hono app
 const app = new Hono()
@@ -51,6 +52,7 @@ app.use('/waitlist', rateLimiter({ maxRequests: 5, windowMs: 60_000 }))
 app.use('/artists/apply', rateLimiter({ maxRequests: 5, windowMs: 60_000 }))
 app.use('/uploads/*', rateLimiter({ maxRequests: 10, windowMs: 60_000 }))
 app.use('/me/*', rateLimiter({ maxRequests: 20, windowMs: 60_000 }))
+app.use('/admin/*', rateLimiter({ maxRequests: 20, windowMs: 60_000 }))
 
 // Mount routes — /artists/apply MUST be before /artists to avoid /:slug collision
 app.route('/health', createHealthRoutes(prisma))
@@ -61,6 +63,7 @@ app.route('/categories', createCategoryRoutes(prisma))
 app.route('/waitlist', createWaitlistRoutes(prisma))
 app.route('/uploads', createUploadRoutes(prisma))
 app.route('/me', createMeRoutes(prisma))
+app.route('/admin', createAdminRoutes(prisma))
 
 // Root route
 app.get('/', (c) => {

--- a/apps/api/src/routes/admin.integration.test.ts
+++ b/apps/api/src/routes/admin.integration.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import type { PrismaClient } from '@surfaced-art/db'
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+  cleanupDatabase,
+} from '@surfaced-art/db/test-helpers'
+import { createTestApp } from '../test-helpers/create-test-app.js'
+import { setVerifier, resetVerifier } from '../middleware/auth.js'
+import type { Hono } from 'hono'
+
+// Mock email module to avoid real SES calls
+vi.mock('@surfaced-art/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue({ success: true, messageId: 'test-msg' }),
+  ArtistAcceptance: vi.fn(() => null),
+  ArtistRejection: vi.fn(() => null),
+}))
+
+const ADMIN_COGNITO_ID = 'cognito-admin-integration'
+const ARTIST_COGNITO_ID = 'cognito-artist-integration'
+const ADMIN_EMAIL = 'admin@surfacedart.com'
+const ARTIST_EMAIL = 'artist@integration-test.com'
+
+describe('Admin routes — integration', () => {
+  let prisma: PrismaClient
+  let app: Hono
+  let adminUserId: string
+  let artistUserId: string
+
+  beforeAll(async () => {
+    prisma = await setupTestDatabase()
+    app = createTestApp(prisma)
+  })
+
+  afterAll(async () => {
+    resetVerifier()
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupDatabase(prisma)
+    vi.clearAllMocks()
+
+    // Create admin user with admin role
+    const adminUser = await prisma.user.create({
+      data: {
+        cognitoId: ADMIN_COGNITO_ID,
+        email: ADMIN_EMAIL,
+        fullName: 'Admin User',
+        roles: { create: [{ role: 'admin' }, { role: 'buyer' }] },
+      },
+    })
+    adminUserId = adminUser.id
+
+    // Create target user with buyer role
+    const targetUser = await prisma.user.create({
+      data: {
+        cognitoId: ARTIST_COGNITO_ID,
+        email: ARTIST_EMAIL,
+        fullName: 'Jane Artist',
+        roles: { create: { role: 'buyer' } },
+      },
+    })
+    artistUserId = targetUser.id
+
+    // Create pending application for the target user
+    await prisma.artistApplication.create({
+      data: {
+        email: ARTIST_EMAIL,
+        fullName: 'Jane Artist',
+        statement: 'I create unique ceramics inspired by nature and urban landscapes.',
+        categories: ['ceramics'],
+        status: 'pending',
+      },
+    })
+
+    // Set verifier to mock JWT — returns the admin user identity
+    setVerifier({
+      verify: vi.fn().mockResolvedValue({
+        sub: ADMIN_COGNITO_ID,
+        email: ADMIN_EMAIL,
+        name: 'Admin User',
+      }),
+    } as never)
+  })
+
+  describe('POST /admin/artists/:userId/approve', () => {
+    it('should create artist profile and role in a transaction', async () => {
+      const res = await app.request(`/admin/artists/${artistUserId}/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({ reviewNotes: 'Excellent portfolio' }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.message).toContain('approved')
+      expect(body.profile.displayName).toBe('Jane Artist')
+      expect(body.profile.slug).toBe('jane-artist')
+
+      // Verify application status was updated
+      const application = await prisma.artistApplication.findFirst({
+        where: { email: ARTIST_EMAIL },
+      })
+      expect(application?.status).toBe('approved')
+      expect(application?.reviewedBy).toBe(adminUserId)
+      expect(application?.reviewNotes).toBe('Excellent portfolio')
+
+      // Verify artist profile was created
+      const profile = await prisma.artistProfile.findUnique({
+        where: { userId: artistUserId },
+      })
+      expect(profile).not.toBeNull()
+      expect(profile?.displayName).toBe('Jane Artist')
+      expect(profile?.slug).toBe('jane-artist')
+      expect(profile?.bio).toBe('I create unique ceramics inspired by nature and urban landscapes.')
+
+      // Verify artist role was granted
+      const artistRole = await prisma.userRole.findFirst({
+        where: { userId: artistUserId, role: 'artist' },
+      })
+      expect(artistRole).not.toBeNull()
+      expect(artistRole?.grantedBy).toBe(adminUserId)
+    })
+
+    it('should generate unique slug when duplicate exists', async () => {
+      // Pre-create a profile with slug "jane-artist"
+      const otherUser = await prisma.user.create({
+        data: {
+          cognitoId: 'cognito-other',
+          email: 'other@example.com',
+          fullName: 'Other User',
+        },
+      })
+      await prisma.artistProfile.create({
+        data: {
+          userId: otherUser.id,
+          displayName: 'Jane Artist',
+          slug: 'jane-artist',
+          bio: 'Existing artist',
+          location: 'NYC',
+          originZip: '10001',
+        },
+      })
+
+      const res = await app.request(`/admin/artists/${artistUserId}/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // Should have a suffixed slug since "jane-artist" is taken
+      expect(body.profile.slug).toBe('jane-artist-2')
+    })
+
+    it('should return 409 if user already has artist role', async () => {
+      // Grant artist role first
+      await prisma.userRole.create({
+        data: { userId: artistUserId, role: 'artist', grantedBy: adminUserId },
+      })
+
+      const res = await app.request(`/admin/artists/${artistUserId}/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      expect(res.status).toBe(409)
+    })
+
+    it('should return 404 if no pending application', async () => {
+      // Remove the pending application
+      await prisma.artistApplication.deleteMany({ where: { email: ARTIST_EMAIL } })
+
+      const res = await app.request(`/admin/artists/${artistUserId}/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('POST /admin/artists/:userId/reject', () => {
+    it('should update application status to rejected', async () => {
+      const res = await app.request(`/admin/artists/${artistUserId}/reject`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({ reviewNotes: 'Not a fit at this time' }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.message).toContain('rejected')
+
+      // Verify application was rejected
+      const application = await prisma.artistApplication.findFirst({
+        where: { email: ARTIST_EMAIL },
+      })
+      expect(application?.status).toBe('rejected')
+      expect(application?.reviewedBy).toBe(adminUserId)
+      expect(application?.reviewNotes).toBe('Not a fit at this time')
+    })
+
+    it('should not create artist profile on rejection', async () => {
+      await app.request(`/admin/artists/${artistUserId}/reject`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      const profile = await prisma.artistProfile.findUnique({
+        where: { userId: artistUserId },
+      })
+      expect(profile).toBeNull()
+    })
+
+    it('should return 404 if application already rejected', async () => {
+      // First rejection
+      await app.request(`/admin/artists/${artistUserId}/reject`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      // Second rejection attempt
+      const res = await app.request(`/admin/artists/${artistUserId}/reject`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      // Should fail because application is now 'rejected', not 'pending'
+      expect(res.status).toBe(404)
+    })
+  })
+})

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+import { createAdminRoutes } from './admin'
+import { setVerifier, resetVerifier } from '../middleware/auth'
+import type { PrismaClient } from '@surfaced-art/db'
+
+// Mock email module
+vi.mock('@surfaced-art/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-123' }),
+  ArtistAcceptance: vi.fn(() => null),
+  ArtistRejection: vi.fn(() => null),
+}))
+
+// ─── Test helpers ────────────────────────────────────────────────────
+
+function createMockVerifier(sub = 'cognito-admin', email = 'admin@surfacedart.com', name = 'Admin User') {
+  return {
+    verify: vi.fn().mockResolvedValue({ sub, email, name }),
+  } as unknown as ReturnType<typeof setVerifier extends (v: infer T) => void ? () => T : never>
+}
+
+const ADMIN_USER_ID = 'admin-uuid-123'
+const TARGET_USER_ID = 'user-uuid-456'
+
+const mockAdminUser = {
+  id: ADMIN_USER_ID,
+  cognitoId: 'cognito-admin',
+  email: 'admin@surfacedart.com',
+  fullName: 'Admin User',
+  roles: [{ role: 'admin' }],
+}
+
+const mockTargetUser = {
+  id: TARGET_USER_ID,
+  cognitoId: 'cognito-target',
+  email: 'artist@example.com',
+  fullName: 'Jane Artist',
+  roles: [{ role: 'buyer' }],
+}
+
+const mockPendingApplication = {
+  id: 'app-uuid-789',
+  email: 'artist@example.com',
+  fullName: 'Jane Artist',
+  statement: 'I create beautiful ceramics.',
+  status: 'pending',
+  reviewedBy: null,
+  reviewedAt: null,
+  reviewNotes: null,
+}
+
+const mockCreatedProfile = {
+  id: 'profile-uuid-abc',
+  userId: TARGET_USER_ID,
+  displayName: 'Jane Artist',
+  slug: 'jane-artist',
+  bio: 'I create beautiful ceramics.',
+  location: '',
+  status: 'pending',
+}
+
+function createMockPrisma(overrides?: {
+  adminRoles?: string[]
+  targetUser?: unknown
+  application?: unknown
+  existingProfile?: unknown
+  createdProfile?: unknown
+  existingRole?: unknown
+}) {
+  const adminRoles = overrides?.adminRoles ?? ['admin']
+  const targetUser = overrides?.targetUser !== undefined ? overrides.targetUser : mockTargetUser
+  const application = overrides?.application !== undefined ? overrides.application : mockPendingApplication
+  const createdProfile = overrides?.createdProfile ?? mockCreatedProfile
+
+  const userFindUnique = vi.fn().mockImplementation(({ where }: { where: { cognitoId?: string; id?: string } }) => {
+    if (where.cognitoId === 'cognito-admin') {
+      return Promise.resolve({ ...mockAdminUser, roles: adminRoles.map((r) => ({ role: r })) })
+    }
+    if (where.id === TARGET_USER_ID) {
+      return Promise.resolve(targetUser)
+    }
+    return Promise.resolve(null)
+  })
+
+  return {
+    user: {
+      findUnique: userFindUnique,
+    },
+    artistApplication: {
+      findFirst: vi.fn().mockResolvedValue(application),
+      update: vi.fn().mockResolvedValue({ ...application, status: 'approved' }),
+    },
+    artistProfile: {
+      findUnique: vi.fn().mockResolvedValue(overrides?.existingProfile ?? null),
+      create: vi.fn().mockResolvedValue(createdProfile),
+    },
+    userRole: {
+      findUnique: vi.fn().mockResolvedValue(overrides?.existingRole ?? null),
+      create: vi.fn().mockResolvedValue({ userId: TARGET_USER_ID, role: 'artist', grantedBy: ADMIN_USER_ID }),
+    },
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const txPrisma = {
+        artistApplication: {
+          update: vi.fn().mockResolvedValue({ ...application, status: 'approved' }),
+        },
+        artistProfile: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue(createdProfile),
+        },
+        userRole: {
+          create: vi.fn().mockResolvedValue({ userId: TARGET_USER_ID, role: 'artist', grantedBy: ADMIN_USER_ID }),
+        },
+      }
+      return fn(txPrisma)
+    }),
+  } as unknown as PrismaClient
+}
+
+function createTestApp(prisma: PrismaClient) {
+  const app = new Hono()
+  app.route('/admin', createAdminRoutes(prisma))
+  return app
+}
+
+function approveArtist(
+  app: ReturnType<typeof createTestApp>,
+  userId: string,
+  body?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return app.request(`/admin/artists/${userId}/approve`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body ?? {}),
+  })
+}
+
+function rejectArtist(
+  app: ReturnType<typeof createTestApp>,
+  userId: string,
+  body?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return app.request(`/admin/artists/${userId}/reject`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body ?? {}),
+  })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe('POST /admin/artists/:userId/approve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setVerifier(createMockVerifier() as never)
+  })
+
+  afterEach(() => {
+    resetVerifier()
+  })
+
+  describe('authentication and authorization', () => {
+    it('should return 401 without auth token', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID)
+      expect(res.status).toBe(401)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('should return 403 without admin role', async () => {
+      const prisma = createMockPrisma({ adminRoles: ['buyer'] })
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(403)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  describe('validation', () => {
+    it('should return 404 if target user not found', async () => {
+      const prisma = createMockPrisma({ targetUser: null })
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(404)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('should return 404 if no pending application exists', async () => {
+      const prisma = createMockPrisma({ application: null })
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(404)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(body.error.message).toContain('pending application')
+    })
+
+    it('should return 409 if user already has artist role', async () => {
+      const targetWithArtistRole = { ...mockTargetUser, roles: [{ role: 'buyer' }, { role: 'artist' }] }
+      const prisma = createMockPrisma({ targetUser: targetWithArtistRole })
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(409)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('CONFLICT')
+    })
+  })
+
+  describe('successful approval', () => {
+    it('should return 200 with profile data', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.message).toContain('approved')
+      expect(body.profile).toEqual({
+        id: 'profile-uuid-abc',
+        slug: 'jane-artist',
+        displayName: 'Jane Artist',
+      })
+    })
+
+    it('should call $transaction to update application, create profile, and create role', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce()
+    })
+
+    it('should accept optional reviewNotes', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      const res = await approveArtist(app, TARGET_USER_ID, { reviewNotes: 'Great portfolio!' }, 'valid-token')
+      expect(res.status).toBe(200)
+    })
+
+    it('should send acceptance email', async () => {
+      const { sendEmail } = await import('@surfaced-art/email')
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      await approveArtist(app, TARGET_USER_ID, {}, 'valid-token')
+
+      expect(sendEmail).toHaveBeenCalledOnce()
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'artist@example.com',
+          subject: expect.stringContaining('Surfaced Art'),
+        })
+      )
+    })
+  })
+})
+
+describe('POST /admin/artists/:userId/reject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setVerifier(createMockVerifier() as never)
+  })
+
+  afterEach(() => {
+    resetVerifier()
+  })
+
+  describe('authentication and authorization', () => {
+    it('should return 401 without auth token', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      const res = await rejectArtist(app, TARGET_USER_ID)
+      expect(res.status).toBe(401)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('should return 403 without admin role', async () => {
+      const prisma = createMockPrisma({ adminRoles: ['buyer'] })
+      const app = createTestApp(prisma)
+
+      const res = await rejectArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(403)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  describe('validation', () => {
+    it('should return 404 if target user not found', async () => {
+      const prisma = createMockPrisma({ targetUser: null })
+      const app = createTestApp(prisma)
+
+      const res = await rejectArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(404)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('should return 404 if no pending application exists', async () => {
+      const prisma = createMockPrisma({ application: null })
+      const app = createTestApp(prisma)
+
+      const res = await rejectArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(404)
+
+      const body = await res.json()
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(body.error.message).toContain('pending application')
+    })
+  })
+
+  describe('successful rejection', () => {
+    it('should return 200 with success message', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      const res = await rejectArtist(app, TARGET_USER_ID, {}, 'valid-token')
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.message).toContain('rejected')
+    })
+
+    it('should update application status to rejected', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      await rejectArtist(app, TARGET_USER_ID, {}, 'valid-token')
+
+      expect(prisma.artistApplication.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: mockPendingApplication.id },
+          data: expect.objectContaining({
+            status: 'rejected',
+            reviewedBy: ADMIN_USER_ID,
+          }),
+        })
+      )
+    })
+
+    it('should accept optional reviewNotes', async () => {
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      const res = await rejectArtist(app, TARGET_USER_ID, { reviewNotes: 'Not a good fit at this time.' }, 'valid-token')
+      expect(res.status).toBe(200)
+    })
+
+    it('should send rejection email', async () => {
+      const { sendEmail } = await import('@surfaced-art/email')
+      const prisma = createMockPrisma()
+      const app = createTestApp(prisma)
+
+      await rejectArtist(app, TARGET_USER_ID, {}, 'valid-token')
+
+      expect(sendEmail).toHaveBeenCalledOnce()
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'artist@example.com',
+          subject: expect.stringContaining('Application'),
+        })
+      )
+    })
+  })
+})

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,238 @@
+import { Hono } from 'hono'
+import type { PrismaClient } from '@surfaced-art/db'
+import { logger, generateSlug } from '@surfaced-art/utils'
+import { adminReviewBody } from '@surfaced-art/types'
+import type { AdminApproveResponse, AdminRejectResponse } from '@surfaced-art/types'
+import { sendEmail, ArtistAcceptance, ArtistRejection } from '@surfaced-art/email'
+import { authMiddleware, requireRole, type AuthUser } from '../middleware/auth'
+import { notFound, conflict, validationError, internalError } from '../errors'
+import { createElement } from 'react'
+
+export function createAdminRoutes(prisma: PrismaClient) {
+  const admin = new Hono<{ Variables: { user: AuthUser } }>()
+
+  admin.use('*', authMiddleware(prisma))
+  admin.use('*', requireRole('admin'))
+
+  /**
+   * POST /admin/artists/:userId/approve
+   * Approve an artist application: update application status, create profile, grant role.
+   */
+  admin.post('/artists/:userId/approve', async (c) => {
+    const start = Date.now()
+    const adminUser = c.get('user')
+    const { userId } = c.req.param()
+
+    const body = await c.req.json().catch(() => ({}))
+    const parsed = adminReviewBody.safeParse(body)
+    if (!parsed.success) {
+      return validationError(c, parsed.error)
+    }
+
+    try {
+      // Look up the target user
+      const targetUser = await prisma.user.findUnique({
+        where: { id: userId },
+        include: { roles: true },
+      })
+
+      if (!targetUser) {
+        return notFound(c, 'User not found')
+      }
+
+      // Check if already an artist
+      if (targetUser.roles.some((r) => r.role === 'artist')) {
+        return conflict(c, 'User already has artist role')
+      }
+
+      // Find pending application by email match
+      const application = await prisma.artistApplication.findFirst({
+        where: { email: targetUser.email, status: 'pending' },
+      })
+
+      if (!application) {
+        return notFound(c, 'No pending application found for this user')
+      }
+
+      // Generate unique slug
+      const baseSlug = generateSlug(targetUser.fullName)
+      const slug = await ensureUniqueSlug(prisma, baseSlug)
+
+      // Execute approval in a transaction
+      const profile = await prisma.$transaction(async (tx) => {
+        // 1. Update application status
+        await tx.artistApplication.update({
+          where: { id: application.id },
+          data: {
+            status: 'approved',
+            reviewedBy: adminUser.id,
+            reviewedAt: new Date(),
+            reviewNotes: parsed.data.reviewNotes ?? null,
+          },
+        })
+
+        // 2. Create artist profile
+        const newProfile = await tx.artistProfile.create({
+          data: {
+            userId: targetUser.id,
+            displayName: targetUser.fullName,
+            slug,
+            bio: application.statement ?? '',
+            location: '',
+            originZip: '',
+          },
+        })
+
+        // 3. Grant artist role
+        await tx.userRole.create({
+          data: {
+            userId: targetUser.id,
+            role: 'artist',
+            grantedBy: adminUser.id,
+          },
+        })
+
+        return newProfile
+      })
+
+      logger.info('Artist application approved', {
+        userId: targetUser.id,
+        profileId: profile.id,
+        slug: profile.slug,
+        approvedBy: adminUser.id,
+        durationMs: Date.now() - start,
+      })
+
+      // Send acceptance email (fire-and-forget)
+      sendEmail({
+        to: targetUser.email,
+        subject: 'Welcome to Surfaced Art',
+        template: createElement(ArtistAcceptance, { artistName: targetUser.fullName }),
+      }).catch((err) => {
+        logger.error('Failed to send acceptance email', {
+          userId: targetUser.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+
+      const response: AdminApproveResponse = {
+        message: 'Artist application approved successfully',
+        profile: {
+          id: profile.id,
+          slug: profile.slug,
+          displayName: profile.displayName,
+        },
+      }
+
+      return c.json(response)
+    } catch (err) {
+      logger.error('Artist approval failed', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      })
+      return internalError(c)
+    }
+  })
+
+  /**
+   * POST /admin/artists/:userId/reject
+   * Reject an artist application: update application status and send notification.
+   */
+  admin.post('/artists/:userId/reject', async (c) => {
+    const start = Date.now()
+    const adminUser = c.get('user')
+    const { userId } = c.req.param()
+
+    const body = await c.req.json().catch(() => ({}))
+    const parsed = adminReviewBody.safeParse(body)
+    if (!parsed.success) {
+      return validationError(c, parsed.error)
+    }
+
+    try {
+      // Look up the target user
+      const targetUser = await prisma.user.findUnique({
+        where: { id: userId },
+      })
+
+      if (!targetUser) {
+        return notFound(c, 'User not found')
+      }
+
+      // Find pending application by email match
+      const application = await prisma.artistApplication.findFirst({
+        where: { email: targetUser.email, status: 'pending' },
+      })
+
+      if (!application) {
+        return notFound(c, 'No pending application found for this user')
+      }
+
+      // Update application status
+      await prisma.artistApplication.update({
+        where: { id: application.id },
+        data: {
+          status: 'rejected',
+          reviewedBy: adminUser.id,
+          reviewedAt: new Date(),
+          reviewNotes: parsed.data.reviewNotes ?? null,
+        },
+      })
+
+      logger.info('Artist application rejected', {
+        userId: targetUser.id,
+        applicationId: application.id,
+        rejectedBy: adminUser.id,
+        durationMs: Date.now() - start,
+      })
+
+      // Send rejection email (fire-and-forget)
+      sendEmail({
+        to: targetUser.email,
+        subject: 'Update on Your Surfaced Art Application',
+        template: createElement(ArtistRejection, { artistName: targetUser.fullName }),
+      }).catch((err) => {
+        logger.error('Failed to send rejection email', {
+          userId: targetUser.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+
+      const response: AdminRejectResponse = {
+        message: 'Artist application rejected',
+      }
+
+      return c.json(response)
+    } catch (err) {
+      logger.error('Artist rejection failed', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      })
+      return internalError(c)
+    }
+  })
+
+  return admin
+}
+
+/**
+ * Generate a unique slug by appending a numeric suffix if needed.
+ */
+async function ensureUniqueSlug(prisma: PrismaClient, baseSlug: string): Promise<string> {
+  let slug = baseSlug
+  let suffix = 1
+
+  while (true) {
+    const existing = await prisma.artistProfile.findUnique({
+      where: { slug },
+      select: { id: true },
+    })
+
+    if (!existing) return slug
+
+    suffix++
+    slug = `${baseSlug}-${suffix}`
+  }
+}

--- a/apps/api/src/test-helpers/create-test-app.ts
+++ b/apps/api/src/test-helpers/create-test-app.ts
@@ -9,6 +9,7 @@ import { createCategoryRoutes } from '../routes/categories.js'
 import { createWaitlistRoutes } from '../routes/waitlist.js'
 import { createApplicationRoutes } from '../routes/applications.js'
 import { createMeRoutes } from '../routes/me.js'
+import { createAdminRoutes } from '../routes/admin.js'
 
 /**
  * Create a Hono app instance with a test PrismaClient injected.
@@ -36,6 +37,7 @@ export function createTestApp(prisma: PrismaClient) {
   app.route('/categories', createCategoryRoutes(prisma))
   app.route('/waitlist', createWaitlistRoutes(prisma))
   app.route('/me', createMeRoutes(prisma))
+  app.route('/admin', createAdminRoutes(prisma))
 
   // Root route
   app.get('/', (c) => {

--- a/bruno/Admin/Approve Artist (Not Found).bru
+++ b/bruno/Admin/Approve Artist (Not Found).bru
@@ -1,0 +1,31 @@
+meta {
+  name: Approve Artist (Not Found)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{sa_baseUrl}}/admin/artists/00000000-0000-0000-0000-000000000000/approve
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_authToken}}
+}
+
+body:json {
+  {}
+}
+
+assert {
+  res.status: eq 404
+  res.body.error.code: eq NOT_FOUND
+}
+
+tests {
+  test("should return 404 for non-existent user", function() {
+    const body = res.getBody();
+    expect(body.error.code).to.equal("NOT_FOUND");
+  });
+}

--- a/bruno/Admin/Approve Artist.bru
+++ b/bruno/Admin/Approve Artist.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Approve Artist
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{sa_baseUrl}}/admin/artists/{{sa_targetUserId}}/approve
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_authToken}}
+}
+
+body:json {
+  {
+    "reviewNotes": "Excellent portfolio and artistic statement."
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.message: isDefined
+  res.body.profile: isDefined
+  res.body.profile.id: isDefined
+  res.body.profile.slug: isDefined
+  res.body.profile.displayName: isDefined
+}
+
+tests {
+  test("should return 200 with approved profile", function() {
+    const body = res.getBody();
+    expect(res.getStatus()).to.equal(200);
+    expect(body.message).to.include("approved");
+    expect(body.profile).to.have.property("id");
+    expect(body.profile).to.have.property("slug");
+    expect(body.profile).to.have.property("displayName");
+  });
+}

--- a/bruno/Admin/Reject Artist (Not Found).bru
+++ b/bruno/Admin/Reject Artist (Not Found).bru
@@ -1,0 +1,31 @@
+meta {
+  name: Reject Artist (Not Found)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{sa_baseUrl}}/admin/artists/00000000-0000-0000-0000-000000000000/reject
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_authToken}}
+}
+
+body:json {
+  {}
+}
+
+assert {
+  res.status: eq 404
+  res.body.error.code: eq NOT_FOUND
+}
+
+tests {
+  test("should return 404 for non-existent user", function() {
+    const body = res.getBody();
+    expect(body.error.code).to.equal("NOT_FOUND");
+  });
+}

--- a/bruno/Admin/Reject Artist.bru
+++ b/bruno/Admin/Reject Artist.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Reject Artist
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{sa_baseUrl}}/admin/artists/{{sa_targetUserId}}/reject
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_authToken}}
+}
+
+body:json {
+  {
+    "reviewNotes": "Not a fit for the gallery at this time."
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.message: isDefined
+}
+
+tests {
+  test("should return 200 with rejection message", function() {
+    const body = res.getBody();
+    expect(res.getStatus()).to.equal(200);
+    expect(body.message).to.include("rejected");
+  });
+}

--- a/bruno/Admin/folder.bru
+++ b/bruno/Admin/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Admin
+}

--- a/bruno/environments/Production.bru
+++ b/bruno/environments/Production.bru
@@ -4,6 +4,7 @@ vars {
   sa_artistSlug: karina-yanes
   sa_listingId: 
   sa_category: ceramics
+  sa_targetUserId:
 }
 vars:secret [
   sa_revalidationSecret,

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -18,6 +18,7 @@ export { checkRateLimit, configureRateLimit, resetRateLimit } from './rate-limit
 export { ArtistApplicationConfirmation } from './templates/artist-application-confirmation.js'
 export { ArtistAcceptance } from './templates/artist-acceptance.js'
 export { AdminApplicationNotification } from './templates/admin-application-notification.js'
+export { ArtistRejection } from './templates/artist-rejection.js'
 export { WaitlistWelcome } from './templates/waitlist-welcome.js'
 
 // Layout (for custom templates)

--- a/packages/email/src/templates/artist-rejection.tsx
+++ b/packages/email/src/templates/artist-rejection.tsx
@@ -1,0 +1,58 @@
+import { Section, Text } from '@react-email/components'
+import { Layout, BRAND } from './components/Layout.js'
+
+export interface ArtistRejectionProps {
+  artistName: string
+}
+
+export function ArtistRejection({ artistName }: ArtistRejectionProps) {
+  return (
+    <Layout preview="Update on Your Surfaced Art Application">
+      <Section>
+        <Text
+          style={{
+            fontFamily: BRAND.fonts.heading,
+            fontSize: '28px',
+            lineHeight: '1.2',
+            color: BRAND.colors.text,
+            margin: '0 0 24px 0',
+          }}
+        >
+          Application Update
+        </Text>
+        <Text style={bodyStyle}>Dear {artistName},</Text>
+        <Text style={bodyStyle}>
+          Thank you for applying to Surfaced Art. We truly appreciate the time
+          you took to share your work with us.
+        </Text>
+        <Text style={bodyStyle}>
+          After careful review, our curatorial team has decided not to move
+          forward with your application at this time. This does not reflect on
+          the quality of your work — our selections are based on the current
+          direction and capacity of our gallery.
+        </Text>
+        <Text style={bodyStyle}>
+          We encourage you to continue developing your practice and to
+          reapply in the future. Our curatorial needs evolve, and we would
+          welcome the opportunity to review your work again.
+        </Text>
+        <Text style={bodyStyle}>
+          If you have any questions, feel free to reply to this email.
+        </Text>
+        <Text style={bodyStyle}>
+          With appreciation,
+          <br />
+          The Surfaced Art Team
+        </Text>
+      </Section>
+    </Layout>
+  )
+}
+
+const bodyStyle = {
+  fontFamily: BRAND.fonts.body,
+  fontSize: '16px',
+  lineHeight: '1.65',
+  color: BRAND.colors.text,
+  margin: '0 0 16px 0',
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -55,6 +55,8 @@ export type {
   PresignedPostResponse,
   DashboardResponse,
   ProfileCompletionField,
+  AdminApproveResponse,
+  AdminRejectResponse,
 } from './interfaces'
 
 // Validation schemas
@@ -71,10 +73,12 @@ export {
   artistApplicationBody,
   checkEmailQuery,
   presignedUrlBody,
+  adminReviewBody,
   type ArtistsQuery,
   type ListingsQuery,
   type WaitlistBody,
   type ArtistApplicationBody,
   type CheckEmailQuery,
   type PresignedUrlBody,
+  type AdminReviewBody,
 } from './schemas'

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -438,6 +438,27 @@ export interface DashboardResponse {
   }
 }
 
+// ─── Admin API Response Types ────────────────────────────────────────
+
+/**
+ * Response from POST /admin/artists/:userId/approve
+ */
+export interface AdminApproveResponse {
+  message: string
+  profile: {
+    id: string
+    slug: string
+    displayName: string
+  }
+}
+
+/**
+ * Response from POST /admin/artists/:userId/reject
+ */
+export interface AdminRejectResponse {
+  message: string
+}
+
 // ─── API Error Types ──────────────────────────────────────────────────
 
 /**

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -158,6 +158,11 @@ export function sanitizeText(input: string): string {
   )
 }
 
+/** POST /admin/artists/:userId/approve or /reject body */
+export const adminReviewBody = z.object({
+  reviewNotes: z.string().max(2000, 'Review notes must be at most 2000 characters').optional(),
+})
+
 // ============================================================================
 // Inferred types (derive TypeScript types from schemas)
 // ============================================================================
@@ -168,3 +173,4 @@ export type WaitlistBody = z.infer<typeof waitlistBody>
 export type ArtistApplicationBody = z.infer<typeof artistApplicationBody>
 export type CheckEmailQuery = z.infer<typeof checkEmailQuery>
 export type PresignedUrlBody = z.infer<typeof presignedUrlBody>
+export type AdminReviewBody = z.infer<typeof adminReviewBody>


### PR DESCRIPTION
## Summary

- **Admin approve endpoint** (`POST /admin/artists/:userId/approve`) — approves a pending artist application in a single transaction: updates application status, creates artist profile with generated slug, grants artist role, sends acceptance email
- **Admin reject endpoint** (`POST /admin/artists/:userId/reject`) — rejects a pending application, updates status with reviewer notes, sends decline email
- **Rejection email template** — professional, encouraging tone matching the existing acceptance template pattern
- **Types and validation** — `adminReviewBody` Zod schema, `AdminApproveResponse`/`AdminRejectResponse` interfaces
- **Tests** — 17 unit tests (mocked Prisma), 7 integration tests (Testcontainers)
- **Bruno collection** — 5 new request files for admin endpoints

## Commits included

- `feat(api): add admin artist approval and rejection endpoints` (PR #253, closes #179)

## Test plan

- [x] 17 unit tests pass
- [x] 7 integration tests written (Testcontainers, pass in CI with Docker)
- [x] All quality gates pass: `npm run test`, `lint`, `typecheck`, `build`
- [ ] CI checks pass on this PR

**Important**: This is a dev → main merge. Use a **regular merge commit** (not squash) per project conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)