### PR TITLE
fix(api): require complete ID list in reorder endpoints

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1453,6 +1453,20 @@ describe('PUT /me/cv-entries/reorder', () => {
     expect(res.status).toBe(400)
   })
 
+  it('should return 400 when orderedIds is a partial list', async () => {
+    const entries = [mockCvEntry, mockCvEntry2]
+    const prisma = createMockPrisma({ cvEntries: entries })
+    ;(prisma.artistCvEntry.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(entries)
+    const app = createTestApp(prisma)
+
+    const res = await putCvEntryReorder(app, {
+      orderedIds: [CV_ENTRY_ID_1],
+    }, 'valid-token')
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.message).toContain('all entry IDs')
+  })
+
   it('should return the reordered entries', async () => {
     const entries = [mockCvEntry, mockCvEntry2]
     const reordered = [
@@ -1766,6 +1780,19 @@ describe('PUT /me/process-media/reorder', () => {
       orderedIds: [PROCESS_MEDIA_ID_1, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'],
     }, 'valid-token')
     expect(res.status).toBe(400)
+  })
+
+  it('should return 400 when orderedIds is a partial list', async () => {
+    const media = [mockProcessMediaPhoto, mockProcessMediaVideo]
+    const prisma = createMockPrisma({ processMedia: media })
+    ;(prisma.artistProcessMedia.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(media)
+    const app = createTestApp(prisma)
+    const res = await putProcessMediaReorder(app, {
+      orderedIds: [PROCESS_MEDIA_ID_1],
+    }, 'valid-token')
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.message).toContain('all media IDs')
   })
 
   it('should return the reordered process media', async () => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -376,6 +376,10 @@ export function createMeRoutes(prisma: PrismaClient) {
       return badRequest(c, 'Some entry IDs do not belong to this artist')
     }
 
+    if (parsed.data.orderedIds.length !== existingEntries.length) {
+      return badRequest(c, 'Must provide all entry IDs for reordering')
+    }
+
     // Update sortOrder in a transaction
     await prisma.$transaction(
       parsed.data.orderedIds.map((id, index) =>
@@ -665,6 +669,10 @@ export function createMeRoutes(prisma: PrismaClient) {
 
     if (invalidIds.length > 0) {
       return badRequest(c, 'Some media IDs do not belong to this artist')
+    }
+
+    if (parsed.data.orderedIds.length !== existingEntries.length) {
+      return badRequest(c, 'Must provide all media IDs for reordering')
     }
 
     // Update sortOrder in a transaction


### PR DESCRIPTION
## Summary

Addresses Greptile review comment on PR #260: reorder endpoints accepted partial ID lists, which would leave duplicate `sortOrder` values.

- Added length validation to CV entry reorder (`PUT /me/cv-entries/reorder`)
- Added length validation to process media reorder (`PUT /me/process-media/reorder`)
- Both now return 400 if `orderedIds.length !== existingEntries.length`
- Added 2 new tests (one per endpoint)

## Test plan
- [x] All 280 tests pass
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes

Closes review comment from Greptile on #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce complete ID lists for CV entry and process media reorder endpoints to prevent inconsistent sort orders.

Bug Fixes:
- Validate that CV entry reorder requests include all existing entry IDs and return 400 otherwise.
- Validate that process media reorder requests include all existing media IDs and return 400 otherwise.

Tests:
- Add coverage to ensure both reorder endpoints reject partial orderedIds lists with appropriate error messages.