### PR TITLE
fix(infra): add CLOUDFRONT_DOMAIN env var to Lambda API

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -253,6 +253,7 @@ module "lambda_api" {
   cognito_client_id          = module.cognito.client_id
   s3_bucket_name             = module.s3_cloudfront.bucket_name
   cloudfront_url             = module.s3_cloudfront.cloudfront_url
+  cloudfront_domain          = module.s3_cloudfront.cloudfront_domain_name
   ses_from_address           = "support@${var.ses_domain}"
   ses_configuration_set_name = module.ses.configuration_set_name
 

--- a/infrastructure/terraform/modules/lambda-api/main.tf
+++ b/infrastructure/terraform/modules/lambda-api/main.tf
@@ -60,6 +60,7 @@ resource "aws_lambda_function" "api" {
       COGNITO_CLIENT_ID     = var.cognito_client_id
       S3_BUCKET_NAME        = var.s3_bucket_name
       CLOUDFRONT_URL        = var.cloudfront_url
+      CLOUDFRONT_DOMAIN     = var.cloudfront_domain
       FRONTEND_URL          = var.frontend_url
       SES_FROM_ADDRESS      = var.ses_from_address
       SES_CONFIGURATION_SET = var.ses_configuration_set_name

--- a/infrastructure/terraform/modules/lambda-api/variables.tf
+++ b/infrastructure/terraform/modules/lambda-api/variables.tf
@@ -76,6 +76,11 @@ variable "cloudfront_url" {
   type        = string
 }
 
+variable "cloudfront_domain" {
+  description = "CloudFront distribution domain name for CDN URL validation"
+  type        = string
+}
+
 variable "placeholder_image_uri" {
   description = "Lambda base image URI used as a placeholder until CI/CD deploys the service image. Value is passed from the root module; source of truth is LAMBDA_BOOTSTRAP_IMAGE in .github/workflows/deploy.yml."
   type        = string


### PR DESCRIPTION
## Summary

The artist profile editor (PR #261) added CloudFront URL validation that requires a `CLOUDFRONT_DOMAIN` env var. This env var was never added to the Lambda Terraform module, so the profile image upload and process media photo endpoints would return 500 in production.

- Added `cloudfront_domain` variable to `lambda-api` module
- Added `CLOUDFRONT_DOMAIN` to Lambda environment variables
- Value sourced from existing `s3-cloudfront` module's `cloudfront_domain_name` output

3 files changed, 7 insertions.

## Test plan
- [x] `terraform validate` passes
- [x] All app quality gates pass (test, lint, typecheck, build)
- [ ] After deploy: `CLOUDFRONT_DOMAIN` env var visible on Lambda function in AWS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add CloudFront distribution domain configuration to the Lambda API infrastructure to support CDN URL validation.

Bug Fixes:
- Provide the CLOUDFRONT_DOMAIN environment variable to the Lambda API to prevent production 500 errors when validating CloudFront URLs.

Enhancements:
- Expose a cloudfront_domain variable in the lambda-api Terraform module and wire it to the existing s3-cloudfront module output.