### PR TITLE
feat(web): listing create/edit form (#273)

### DIFF
--- a/apps/web/src/app/dashboard/listings/[id]/edit/page.tsx
+++ b/apps/web/src/app/dashboard/listings/[id]/edit/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { ListingForm } from '../../components/listing-form'
+
+export default function EditListingPage() {
+  const params = useParams<{ id: string }>()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Edit Listing</h1>
+        <p className="text-muted-foreground mt-1">
+          Update your artwork listing
+        </p>
+      </div>
+      <ListingForm mode="edit" listingId={params.id} />
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/listings/__tests__/listing-form.test.tsx
+++ b/apps/web/src/app/dashboard/listings/__tests__/listing-form.test.tsx
@@ -1,0 +1,418 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { MyListingResponse } from '@surfaced-art/types'
+
+// Mock auth
+const mockGetIdToken = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    getIdToken: mockGetIdToken,
+  }),
+}))
+
+// Mock router
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+// Mock API
+const mockCreateMyListing = vi.fn()
+const mockUpdateMyListing = vi.fn()
+const mockGetMyListing = vi.fn()
+vi.mock('@/lib/api', () => ({
+  createMyListing: (...args: unknown[]) => mockCreateMyListing(...args),
+  updateMyListing: (...args: unknown[]) => mockUpdateMyListing(...args),
+  getMyListing: (...args: unknown[]) => mockGetMyListing(...args),
+}))
+
+import { ListingForm } from '../components/listing-form'
+
+const LISTING_ID = '11111111-1111-4111-8111-111111111111'
+
+const mockListingResponse: MyListingResponse = {
+  id: LISTING_ID,
+  type: 'standard',
+  title: 'Mountain Vase',
+  description: 'A beautiful handmade vase inspired by mountain landscapes.',
+  medium: 'Stoneware clay',
+  category: 'ceramics',
+  price: 15000,
+  status: 'available',
+  isDocumented: false,
+  quantityTotal: 1,
+  quantityRemaining: 1,
+  artworkLength: 8,
+  artworkWidth: 6,
+  artworkHeight: 12,
+  packedLength: 12,
+  packedWidth: 10,
+  packedHeight: 16,
+  packedWeight: 5.5,
+  editionNumber: null,
+  editionTotal: null,
+  reservedUntil: null,
+  createdAt: '2025-06-01T00:00:00.000Z',
+  updatedAt: '2025-06-01T00:00:00.000Z',
+  images: [],
+}
+
+const createdResponse: MyListingResponse = {
+  ...mockListingResponse,
+  id: '33333333-3333-4333-8333-333333333333',
+}
+
+describe('ListingForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetIdToken.mockResolvedValue('test-token')
+    mockCreateMyListing.mockResolvedValue(createdResponse)
+    mockUpdateMyListing.mockResolvedValue(mockListingResponse)
+    mockGetMyListing.mockResolvedValue(mockListingResponse)
+  })
+
+  describe('Create mode', () => {
+    it('should render all form fields', () => {
+      render(<ListingForm mode="create" />)
+
+      expect(screen.getByTestId('listing-form')).toBeInTheDocument()
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/medium/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/category/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/type/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/price/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/packed length/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/packed width/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/packed height/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/packed weight/i)).toBeInTheDocument()
+    })
+
+    it('should show "Create Listing" submit button', () => {
+      render(<ListingForm mode="create" />)
+      expect(screen.getByTestId('listing-form-submit')).toHaveTextContent('Create Listing')
+    })
+
+    it('should submit form with dollars converted to cents', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      // Fill required fields
+      await user.type(screen.getByLabelText(/title/i), 'Test Vase')
+      await user.type(screen.getByLabelText(/description/i), 'A beautiful vase')
+      await user.type(screen.getByLabelText(/medium/i), 'Stoneware')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'ceramics')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '150.00')
+      await user.type(screen.getByLabelText(/packed length/i), '12')
+      await user.type(screen.getByLabelText(/packed width/i), '10')
+      await user.type(screen.getByLabelText(/packed height/i), '8')
+      await user.type(screen.getByLabelText(/packed weight/i), '5')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockCreateMyListing).toHaveBeenCalledWith('test-token', expect.objectContaining({
+          title: 'Test Vase',
+          description: 'A beautiful vase',
+          medium: 'Stoneware',
+          category: 'ceramics',
+          type: 'standard',
+          price: 15000, // $150.00 → 15000 cents
+          packedLength: 12,
+          packedWidth: 10,
+          packedHeight: 8,
+          packedWeight: 5,
+        }))
+      })
+    })
+
+    it('should redirect to listings page on successful create', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      await user.type(screen.getByLabelText(/title/i), 'Test Vase')
+      await user.type(screen.getByLabelText(/description/i), 'A beautiful vase')
+      await user.type(screen.getByLabelText(/medium/i), 'Stoneware')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'ceramics')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '150')
+      await user.type(screen.getByLabelText(/packed length/i), '12')
+      await user.type(screen.getByLabelText(/packed width/i), '10')
+      await user.type(screen.getByLabelText(/packed height/i), '8')
+      await user.type(screen.getByLabelText(/packed weight/i), '5')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/dashboard/listings')
+      })
+    })
+
+    it('should show validation error for missing required fields', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      // Submit without filling anything
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('listing-form-error')).toBeInTheDocument()
+      })
+
+      expect(mockCreateMyListing).not.toHaveBeenCalled()
+    })
+
+    it('should include optional artwork dimensions when provided', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      await user.type(screen.getByLabelText(/title/i), 'Test Piece')
+      await user.type(screen.getByLabelText(/description/i), 'Artwork with dimensions')
+      await user.type(screen.getByLabelText(/medium/i), 'Clay')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'ceramics')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '100')
+      await user.type(screen.getByLabelText(/artwork length/i), '8')
+      await user.type(screen.getByLabelText(/artwork width/i), '6')
+      await user.type(screen.getByLabelText(/artwork height/i), '12')
+      await user.type(screen.getByLabelText(/packed length/i), '12')
+      await user.type(screen.getByLabelText(/packed width/i), '10')
+      await user.type(screen.getByLabelText(/packed height/i), '16')
+      await user.type(screen.getByLabelText(/packed weight/i), '5')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockCreateMyListing).toHaveBeenCalledWith('test-token', expect.objectContaining({
+          artworkLength: 8,
+          artworkWidth: 6,
+          artworkHeight: 12,
+        }))
+      })
+    })
+
+    it('should include edition info when provided', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      await user.type(screen.getByLabelText(/title/i), 'Limited Print')
+      await user.type(screen.getByLabelText(/description/i), 'Edition print')
+      await user.type(screen.getByLabelText(/medium/i), 'Ink on paper')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'print')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '75')
+      await user.type(screen.getByLabelText(/packed length/i), '20')
+      await user.type(screen.getByLabelText(/packed width/i), '16')
+      await user.type(screen.getByLabelText(/packed height/i), '2')
+      await user.type(screen.getByLabelText(/packed weight/i), '1')
+      await user.type(screen.getByLabelText(/edition number/i), '3')
+      await user.type(screen.getByLabelText(/edition total/i), '50')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockCreateMyListing).toHaveBeenCalledWith('test-token', expect.objectContaining({
+          editionNumber: 3,
+          editionTotal: 50,
+        }))
+      })
+    })
+
+    it('should show server error on API failure', async () => {
+      mockCreateMyListing.mockRejectedValue(new Error('Server error'))
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      await user.type(screen.getByLabelText(/title/i), 'Test')
+      await user.type(screen.getByLabelText(/description/i), 'Test description')
+      await user.type(screen.getByLabelText(/medium/i), 'Clay')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'ceramics')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '50')
+      await user.type(screen.getByLabelText(/packed length/i), '10')
+      await user.type(screen.getByLabelText(/packed width/i), '8')
+      await user.type(screen.getByLabelText(/packed height/i), '6')
+      await user.type(screen.getByLabelText(/packed weight/i), '3')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('listing-form-error')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText(/server error/i)).toBeInTheDocument()
+    })
+
+    it('should disable submit button while submitting', async () => {
+      mockCreateMyListing.mockReturnValue(new Promise(() => {}))
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      await user.type(screen.getByLabelText(/title/i), 'Test')
+      await user.type(screen.getByLabelText(/description/i), 'Test description')
+      await user.type(screen.getByLabelText(/medium/i), 'Clay')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'ceramics')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '50')
+      await user.type(screen.getByLabelText(/packed length/i), '10')
+      await user.type(screen.getByLabelText(/packed width/i), '8')
+      await user.type(screen.getByLabelText(/packed height/i), '6')
+      await user.type(screen.getByLabelText(/packed weight/i), '3')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('listing-form-submit')).toBeDisabled()
+      })
+      expect(screen.getByTestId('listing-form-submit')).toHaveTextContent(/saving/i)
+    })
+
+    it('should set quantity when provided', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="create" />)
+
+      await user.type(screen.getByLabelText(/title/i), 'Batch Item')
+      await user.type(screen.getByLabelText(/description/i), 'Multiple available')
+      await user.type(screen.getByLabelText(/medium/i), 'Clay')
+      await user.selectOptions(screen.getByLabelText(/category/i), 'ceramics')
+      await user.selectOptions(screen.getByLabelText(/type/i), 'standard')
+      await user.type(screen.getByLabelText(/price/i), '50')
+      await user.type(screen.getByLabelText(/packed length/i), '10')
+      await user.type(screen.getByLabelText(/packed width/i), '8')
+      await user.type(screen.getByLabelText(/packed height/i), '6')
+      await user.type(screen.getByLabelText(/packed weight/i), '3')
+
+      // Clear default value and type new quantity
+      const qtyInput = screen.getByLabelText(/quantity/i)
+      await user.clear(qtyInput)
+      await user.type(qtyInput, '5')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockCreateMyListing).toHaveBeenCalledWith('test-token', expect.objectContaining({
+          quantityTotal: 5,
+        }))
+      })
+    })
+  })
+
+  describe('Edit mode', () => {
+    it('should fetch and pre-fill listing data', async () => {
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toHaveValue('Mountain Vase')
+      })
+
+      expect(screen.getByLabelText(/description/i)).toHaveValue(
+        'A beautiful handmade vase inspired by mountain landscapes.'
+      )
+      expect(screen.getByLabelText(/medium/i)).toHaveValue('Stoneware clay')
+      expect(screen.getByLabelText(/category/i)).toHaveValue('ceramics')
+      expect(screen.getByLabelText(/type/i)).toHaveValue('standard')
+      // Price should be displayed in dollars (15000 cents → 150.00)
+      expect(screen.getByLabelText(/price/i)).toHaveValue(150)
+      expect(screen.getByLabelText(/packed length/i)).toHaveValue(12)
+      expect(screen.getByLabelText(/packed width/i)).toHaveValue(10)
+      expect(screen.getByLabelText(/packed height/i)).toHaveValue(16)
+      expect(screen.getByLabelText(/packed weight/i)).toHaveValue(5.5)
+
+      expect(mockGetMyListing).toHaveBeenCalledWith('test-token', LISTING_ID)
+    })
+
+    it('should pre-fill artwork dimensions', async () => {
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toHaveValue('Mountain Vase')
+      })
+
+      expect(screen.getByLabelText(/artwork length/i)).toHaveValue(8)
+      expect(screen.getByLabelText(/artwork width/i)).toHaveValue(6)
+      expect(screen.getByLabelText(/artwork height/i)).toHaveValue(12)
+    })
+
+    it('should show "Save Changes" submit button', async () => {
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toHaveValue('Mountain Vase')
+      })
+
+      expect(screen.getByTestId('listing-form-submit')).toHaveTextContent('Save Changes')
+    })
+
+    it('should call updateMyListing on submit', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toHaveValue('Mountain Vase')
+      })
+
+      // Change title
+      const titleInput = screen.getByLabelText(/title/i)
+      await user.clear(titleInput)
+      await user.type(titleInput, 'Updated Vase')
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockUpdateMyListing).toHaveBeenCalledWith(
+          'test-token',
+          LISTING_ID,
+          expect.objectContaining({
+            title: 'Updated Vase',
+          }),
+        )
+      })
+    })
+
+    it('should redirect to listings page on successful update', async () => {
+      const user = userEvent.setup()
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toHaveValue('Mountain Vase')
+      })
+
+      await user.click(screen.getByTestId('listing-form-submit'))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/dashboard/listings')
+      })
+    })
+
+    it('should show loading skeleton while fetching', () => {
+      mockGetMyListing.mockReturnValue(new Promise(() => {}))
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      expect(screen.getByTestId('listing-form-skeleton')).toBeInTheDocument()
+    })
+
+    it('should show error state on fetch failure', async () => {
+      mockGetMyListing.mockRejectedValue(new Error('Not found'))
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('listing-form-fetch-error')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText(/not found/i)).toBeInTheDocument()
+    })
+
+    it('should convert price from cents to dollars on load', async () => {
+      render(<ListingForm mode="edit" listingId={LISTING_ID} />)
+
+      await waitFor(() => {
+        // 15000 cents should display as 150 (the number input value)
+        expect(screen.getByLabelText(/price/i)).toHaveValue(150)
+      })
+    })
+  })
+})

--- a/apps/web/src/app/dashboard/listings/components/listing-form.tsx
+++ b/apps/web/src/app/dashboard/listings/components/listing-form.tsx
@@ -1,0 +1,524 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/lib/auth'
+import { createMyListing, updateMyListing, getMyListing } from '@/lib/api'
+import { dollarsToCents } from '@surfaced-art/utils'
+import type { CategoryType, ListingTypeType } from '@surfaced-art/types'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { CATEGORIES } from '@/lib/categories'
+
+interface FormData {
+  title: string
+  description: string
+  medium: string
+  category: CategoryType | ''
+  type: ListingTypeType | ''
+  price: string
+  quantityTotal: string
+  artworkLength: string
+  artworkWidth: string
+  artworkHeight: string
+  packedLength: string
+  packedWidth: string
+  packedHeight: string
+  packedWeight: string
+  editionNumber: string
+  editionTotal: string
+}
+
+const INITIAL_FORM: FormData = {
+  title: '',
+  description: '',
+  medium: '',
+  category: '',
+  type: '',
+  price: '',
+  quantityTotal: '1',
+  artworkLength: '',
+  artworkWidth: '',
+  artworkHeight: '',
+  packedLength: '',
+  packedWidth: '',
+  packedHeight: '',
+  packedWeight: '',
+  editionNumber: '',
+  editionTotal: '',
+}
+
+type FormState = 'idle' | 'submitting' | 'success' | 'error'
+
+interface ListingFormProps {
+  mode: 'create' | 'edit'
+  listingId?: string
+}
+
+export function ListingForm({ mode, listingId }: ListingFormProps) {
+  const { getIdToken } = useAuth()
+  const router = useRouter()
+  const [loading, setLoading] = useState(mode === 'edit')
+  const [formState, setFormState] = useState<FormState>('idle')
+  const [formData, setFormData] = useState<FormData>(INITIAL_FORM)
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+
+  const fetchListing = useCallback(async () => {
+    if (mode !== 'edit' || !listingId) return
+
+    try {
+      setLoading(true)
+      setFetchError(null)
+      const token = await getIdToken()
+      if (!token) {
+        setFetchError('Not authenticated')
+        setLoading(false)
+        return
+      }
+
+      const listing = await getMyListing(token, listingId)
+
+      setFormData({
+        title: listing.title,
+        description: listing.description,
+        medium: listing.medium,
+        category: listing.category,
+        type: listing.type,
+        price: String(listing.price / 100),
+        quantityTotal: String(listing.quantityTotal),
+        artworkLength: listing.artworkLength != null ? String(listing.artworkLength) : '',
+        artworkWidth: listing.artworkWidth != null ? String(listing.artworkWidth) : '',
+        artworkHeight: listing.artworkHeight != null ? String(listing.artworkHeight) : '',
+        packedLength: String(listing.packedLength),
+        packedWidth: String(listing.packedWidth),
+        packedHeight: String(listing.packedHeight),
+        packedWeight: String(listing.packedWeight),
+        editionNumber: listing.editionNumber != null ? String(listing.editionNumber) : '',
+        editionTotal: listing.editionTotal != null ? String(listing.editionTotal) : '',
+      })
+    } catch (err) {
+      setFetchError(err instanceof Error ? err.message : 'Failed to load listing')
+    } finally {
+      setLoading(false)
+    }
+  }, [getIdToken, listingId, mode])
+
+  useEffect(() => {
+    if (mode === 'edit') {
+      fetchListing()
+    }
+  }, [fetchListing, mode])
+
+  function updateField<K extends keyof FormData>(field: K, value: FormData[K]) {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+    if (formState === 'success' || formState === 'error') {
+      setFormState('idle')
+      setServerError(null)
+    }
+  }
+
+  function validate(): string | null {
+    if (!formData.title.trim()) return 'Title is required'
+    if (!formData.description.trim()) return 'Description is required'
+    if (!formData.medium.trim()) return 'Medium is required'
+    if (!formData.category) return 'Category is required'
+    if (!formData.type) return 'Type is required'
+
+    const price = parseFloat(formData.price)
+    if (!formData.price || isNaN(price) || price <= 0) return 'Price must be greater than zero'
+
+    if (!formData.packedLength || parseFloat(formData.packedLength) <= 0) return 'Packed length is required'
+    if (!formData.packedWidth || parseFloat(formData.packedWidth) <= 0) return 'Packed width is required'
+    if (!formData.packedHeight || parseFloat(formData.packedHeight) <= 0) return 'Packed height is required'
+    if (!formData.packedWeight || parseFloat(formData.packedWeight) <= 0) return 'Packed weight is required'
+
+    return null
+  }
+
+  function buildPayload() {
+    const price = dollarsToCents(parseFloat(formData.price))
+    const quantityTotal = parseInt(formData.quantityTotal, 10) || 1
+
+    const payload: Record<string, unknown> = {
+      title: formData.title.trim(),
+      description: formData.description.trim(),
+      medium: formData.medium.trim(),
+      category: formData.category,
+      type: formData.type,
+      price,
+      quantityTotal,
+      packedLength: parseFloat(formData.packedLength),
+      packedWidth: parseFloat(formData.packedWidth),
+      packedHeight: parseFloat(formData.packedHeight),
+      packedWeight: parseFloat(formData.packedWeight),
+    }
+
+    // Optional artwork dimensions
+    if (formData.artworkLength) payload.artworkLength = parseFloat(formData.artworkLength)
+    else payload.artworkLength = null
+
+    if (formData.artworkWidth) payload.artworkWidth = parseFloat(formData.artworkWidth)
+    else payload.artworkWidth = null
+
+    if (formData.artworkHeight) payload.artworkHeight = parseFloat(formData.artworkHeight)
+    else payload.artworkHeight = null
+
+    // Optional edition info
+    if (formData.editionNumber) payload.editionNumber = parseInt(formData.editionNumber, 10)
+    else payload.editionNumber = null
+
+    if (formData.editionTotal) payload.editionTotal = parseInt(formData.editionTotal, 10)
+    else payload.editionTotal = null
+
+    return payload
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    const validationError = validate()
+    if (validationError) {
+      setServerError(validationError)
+      setFormState('error')
+      return
+    }
+
+    setFormState('submitting')
+    setServerError(null)
+
+    try {
+      const token = await getIdToken()
+      if (!token) {
+        setServerError('Not authenticated')
+        setFormState('error')
+        return
+      }
+
+      const payload = buildPayload()
+
+      if (mode === 'create') {
+        await createMyListing(token, payload as Parameters<typeof createMyListing>[1])
+      } else {
+        await updateMyListing(token, listingId!, payload as Parameters<typeof updateMyListing>[2])
+      }
+
+      router.push('/dashboard/listings')
+    } catch (err) {
+      setServerError(err instanceof Error ? err.message : 'Failed to save listing')
+      setFormState('error')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div data-testid="listing-form-skeleton" className="space-y-6">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    )
+  }
+
+  if (fetchError) {
+    return (
+      <div data-testid="listing-form-fetch-error" role="alert" className="text-center py-8">
+        <p className="text-destructive mb-4">{fetchError}</p>
+        <Button
+          variant="outline"
+          onClick={() => {
+            setFetchError(null)
+            setLoading(true)
+            fetchListing()
+          }}
+        >
+          Try again
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <form data-testid="listing-form" onSubmit={handleSubmit} className="space-y-6">
+      {/* Basic Info */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic Information</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={formData.title}
+              onChange={(e) => updateField('title', e.target.value)}
+              maxLength={200}
+              placeholder="Artwork title"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={formData.description}
+              onChange={(e) => updateField('description', e.target.value)}
+              rows={4}
+              maxLength={5000}
+              placeholder="Describe your artwork..."
+            />
+            <p className="text-xs text-muted-foreground text-right">
+              {formData.description.length}/5000
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="medium">Medium</Label>
+            <Input
+              id="medium"
+              value={formData.medium}
+              onChange={(e) => updateField('medium', e.target.value)}
+              maxLength={200}
+              placeholder="e.g. Stoneware clay, Oil on canvas"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="category">Category</Label>
+              <select
+                id="category"
+                value={formData.category}
+                onChange={(e) => updateField('category', e.target.value as CategoryType)}
+                className="flex h-9 w-full rounded-md border border-border bg-background px-3 py-1 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="">Select category</option>
+                {CATEGORIES.map((cat) => (
+                  <option key={cat.slug} value={cat.slug}>
+                    {cat.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="type">Type</Label>
+              <select
+                id="type"
+                value={formData.type}
+                onChange={(e) => updateField('type', e.target.value as ListingTypeType)}
+                className="flex h-9 w-full rounded-md border border-border bg-background px-3 py-1 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="">Select type</option>
+                <option value="standard">Standard</option>
+                <option value="commission">Commission</option>
+              </select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Pricing & Quantity */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Pricing &amp; Quantity</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="price">Price ($)</Label>
+              <Input
+                id="price"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={formData.price}
+                onChange={(e) => updateField('price', e.target.value)}
+                placeholder="0.00"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="quantity">Quantity</Label>
+              <Input
+                id="quantity"
+                type="number"
+                min="1"
+                step="1"
+                value={formData.quantityTotal}
+                onChange={(e) => updateField('quantityTotal', e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="editionNumber">Edition Number</Label>
+              <Input
+                id="editionNumber"
+                type="number"
+                min="1"
+                step="1"
+                value={formData.editionNumber}
+                onChange={(e) => updateField('editionNumber', e.target.value)}
+                placeholder="Optional"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="editionTotal">Edition Total</Label>
+              <Input
+                id="editionTotal"
+                type="number"
+                min="1"
+                step="1"
+                value={formData.editionTotal}
+                onChange={(e) => updateField('editionTotal', e.target.value)}
+                placeholder="Optional"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Artwork Dimensions (Optional) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Artwork Dimensions</CardTitle>
+          <p className="text-sm text-muted-foreground">Optional — the piece itself, in inches</p>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="artworkLength">Artwork Length</Label>
+              <Input
+                id="artworkLength"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.artworkLength}
+                onChange={(e) => updateField('artworkLength', e.target.value)}
+                placeholder="in"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="artworkWidth">Artwork Width</Label>
+              <Input
+                id="artworkWidth"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.artworkWidth}
+                onChange={(e) => updateField('artworkWidth', e.target.value)}
+                placeholder="in"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="artworkHeight">Artwork Height</Label>
+              <Input
+                id="artworkHeight"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.artworkHeight}
+                onChange={(e) => updateField('artworkHeight', e.target.value)}
+                placeholder="in"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Packed Dimensions (Required) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Packed Dimensions</CardTitle>
+          <p className="text-sm text-muted-foreground">Required — shipping box, in inches/lbs</p>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="packedLength">Packed Length</Label>
+              <Input
+                id="packedLength"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.packedLength}
+                onChange={(e) => updateField('packedLength', e.target.value)}
+                placeholder="in"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="packedWidth">Packed Width</Label>
+              <Input
+                id="packedWidth"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.packedWidth}
+                onChange={(e) => updateField('packedWidth', e.target.value)}
+                placeholder="in"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="packedHeight">Packed Height</Label>
+              <Input
+                id="packedHeight"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.packedHeight}
+                onChange={(e) => updateField('packedHeight', e.target.value)}
+                placeholder="in"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="packedWeight">Packed Weight</Label>
+              <Input
+                id="packedWeight"
+                type="number"
+                min="0"
+                step="0.1"
+                value={formData.packedWeight}
+                onChange={(e) => updateField('packedWeight', e.target.value)}
+                placeholder="lbs"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Feedback */}
+      {formState === 'error' && serverError && (
+        <div data-testid="listing-form-error" role="alert" className="rounded-md bg-destructive/10 border border-destructive/30 p-4 text-sm text-destructive">
+          {serverError}
+        </div>
+      )}
+
+      {/* Submit */}
+      <Button
+        type="submit"
+        data-testid="listing-form-submit"
+        disabled={formState === 'submitting'}
+      >
+        {formState === 'submitting'
+          ? 'Saving...'
+          : mode === 'create'
+            ? 'Create Listing'
+            : 'Save Changes'}
+      </Button>
+    </form>
+  )
+}

--- a/apps/web/src/app/dashboard/listings/new/page.tsx
+++ b/apps/web/src/app/dashboard/listings/new/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { ListingForm } from '../components/listing-form'
+
+export default function NewListingPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">New Listing</h1>
+        <p className="text-muted-foreground mt-1">
+          Create a new artwork listing
+        </p>
+      </div>
+      <ListingForm mode="create" />
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,8 +12,10 @@ import type {
   CategoryWithCount,
   DashboardResponse,
   FeaturedArtistItem,
+  ListingCreateBody,
   ListingDetailResponse,
   ListingListItem,
+  ListingUpdateBody,
   MyListingListItem,
   MyListingResponse,
   PaginatedResponse,
@@ -310,5 +312,28 @@ export async function deleteMyListing(
   await apiFetch<void>(`/me/listings/${encodeURIComponent(id)}`, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export async function createMyListing(
+  token: string,
+  data: ListingCreateBody,
+): Promise<MyListingResponse> {
+  return apiFetch<MyListingResponse>('/me/listings', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function updateMyListing(
+  token: string,
+  id: string,
+  data: ListingUpdateBody,
+): Promise<MyListingResponse> {
+  return apiFetch<MyListingResponse>(`/me/listings/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify(data),
   })
 }

--- a/apps/web/src/test/mocks/next-navigation.ts
+++ b/apps/web/src/test/mocks/next-navigation.ts
@@ -26,6 +26,10 @@ export function usePathname() {
   return '/'
 }
 
+export function useParams() {
+  return {}
+}
+
 export function redirect(url: string) {
   throw new Error(`NEXT_REDIRECT:${url}`)
 }


### PR DESCRIPTION
## Summary
- Shared `ListingForm` component for create and edit modes
- Create page at `/dashboard/listings/new`
- Edit page at `/dashboard/listings/[id]/edit` with API pre-fill
- Dollar-to-cents price conversion using `dollarsToCents()` from utils
- Client-side validation matching Zod schemas
- API client functions: `createMyListing()`, `updateMyListing()`
- Added `useParams` to next/navigation mock

## Test plan
- [x] 18 TDD tests (10 create mode, 8 edit mode)
- [x] All quality gates pass (test, lint, typecheck, build)

Closes #273