### PR TITLE
feat(web): listing image management + availability toggle (#274)

### DIFF
--- a/apps/web/src/app/dashboard/listings/__tests__/availability-toggle.test.tsx
+++ b/apps/web/src/app/dashboard/listings/__tests__/availability-toggle.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { MyListingListItem } from '@surfaced-art/types'
+
+// Mock auth
+const mockGetIdToken = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    getIdToken: mockGetIdToken,
+  }),
+}))
+
+// Mock router
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+// Mock API
+const mockGetMyListings = vi.fn()
+const mockDeleteMyListing = vi.fn()
+const mockUpdateListingAvailability = vi.fn()
+vi.mock('@/lib/api', () => ({
+  getMyListings: (...args: unknown[]) => mockGetMyListings(...args),
+  deleteMyListing: (...args: unknown[]) => mockDeleteMyListing(...args),
+  updateListingAvailability: (...args: unknown[]) => mockUpdateListingAvailability(...args),
+}))
+
+import { ListingsTable } from '../components/listings-table'
+
+const mockListings: MyListingListItem[] = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    type: 'standard',
+    title: 'Mountain Vase',
+    medium: 'Stoneware clay',
+    category: 'ceramics',
+    price: 15000,
+    status: 'available',
+    isDocumented: false,
+    quantityTotal: 1,
+    quantityRemaining: 1,
+    createdAt: '2025-06-01T00:00:00.000Z',
+    updatedAt: '2025-06-01T00:00:00.000Z',
+    primaryImage: null,
+  },
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    type: 'standard',
+    title: 'Sold Piece',
+    medium: 'Porcelain',
+    category: 'ceramics',
+    price: 8500,
+    status: 'sold',
+    isDocumented: false,
+    quantityTotal: 1,
+    quantityRemaining: 0,
+    createdAt: '2025-05-15T00:00:00.000Z',
+    updatedAt: '2025-05-20T00:00:00.000Z',
+    primaryImage: null,
+  },
+  {
+    id: '33333333-3333-4333-8333-333333333333',
+    type: 'standard',
+    title: 'Reserved Vase',
+    medium: 'Clay',
+    category: 'ceramics',
+    price: 12000,
+    status: 'reserved_artist',
+    isDocumented: false,
+    quantityTotal: 1,
+    quantityRemaining: 1,
+    createdAt: '2025-05-10T00:00:00.000Z',
+    updatedAt: '2025-05-10T00:00:00.000Z',
+    primaryImage: null,
+  },
+]
+
+describe('ListingsTable — Availability Toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetIdToken.mockResolvedValue('test-token')
+    mockGetMyListings.mockResolvedValue({
+      data: mockListings,
+      meta: { page: 1, limit: 20, total: 3, totalPages: 1 },
+    })
+    mockDeleteMyListing.mockResolvedValue(undefined)
+    mockUpdateListingAvailability.mockResolvedValue({
+      ...mockListings[0],
+      status: 'reserved_artist',
+    })
+  })
+
+  it('should show availability toggle for available listings', async () => {
+    render(<ListingsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Mountain Vase')).toBeInTheDocument()
+    })
+
+    const toggleButtons = screen.getAllByTestId('availability-toggle')
+    // Available and reserved_artist should have toggle buttons; sold should not
+    expect(toggleButtons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should not show availability toggle for sold listings', async () => {
+    render(<ListingsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Mountain Vase')).toBeInTheDocument()
+    })
+
+    // Find the sold listing row and verify no toggle
+    const rows = screen.getAllByTestId('listing-row')
+    const soldRow = rows.find((r) => r.textContent?.includes('Sold Piece'))
+    expect(soldRow).toBeDefined()
+
+    // The sold row should not contain an availability toggle
+    const allToggles = screen.getAllByTestId('availability-toggle')
+    // Mountain Vase (available) and Reserved Vase (reserved_artist) have toggles = 2
+    // Sold Piece does not = 0 toggle in that row
+    expect(allToggles).toHaveLength(2)
+  })
+
+  it('should toggle available listing to reserved', async () => {
+    const user = userEvent.setup()
+    render(<ListingsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Mountain Vase')).toBeInTheDocument()
+    })
+
+    // Click toggle on the available listing (first toggle)
+    const toggleButtons = screen.getAllByTestId('availability-toggle')
+    await user.click(toggleButtons[0])
+
+    await waitFor(() => {
+      expect(mockUpdateListingAvailability).toHaveBeenCalledWith(
+        'test-token',
+        '11111111-1111-4111-8111-111111111111',
+        { status: 'reserved_artist' },
+      )
+    })
+  })
+
+  it('should toggle reserved listing to available', async () => {
+    mockUpdateListingAvailability.mockResolvedValue({
+      ...mockListings[2],
+      status: 'available',
+    })
+
+    const user = userEvent.setup()
+    render(<ListingsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Reserved Vase')).toBeInTheDocument()
+    })
+
+    // Click toggle on the reserved listing (second toggle)
+    const toggleButtons = screen.getAllByTestId('availability-toggle')
+    await user.click(toggleButtons[1])
+
+    await waitFor(() => {
+      expect(mockUpdateListingAvailability).toHaveBeenCalledWith(
+        'test-token',
+        '33333333-3333-4333-8333-333333333333',
+        { status: 'available' },
+      )
+    })
+  })
+
+  it('should show "Reserve" text for available listings and "Unreserve" for reserved', async () => {
+    render(<ListingsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Mountain Vase')).toBeInTheDocument()
+    })
+
+    const toggleButtons = screen.getAllByTestId('availability-toggle')
+    expect(toggleButtons[0]).toHaveTextContent('Reserve')
+    expect(toggleButtons[1]).toHaveTextContent('Unreserve')
+  })
+})

--- a/apps/web/src/app/dashboard/listings/__tests__/listing-images.test.tsx
+++ b/apps/web/src/app/dashboard/listings/__tests__/listing-images.test.tsx
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { MyListingImageResponse } from '@surfaced-art/types'
+
+// Mock auth
+const mockGetIdToken = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    getIdToken: mockGetIdToken,
+  }),
+}))
+
+// Mock API
+const mockAddListingImage = vi.fn()
+const mockDeleteListingImage = vi.fn()
+const mockReorderListingImages = vi.fn()
+const mockGetPresignedUrl = vi.fn()
+vi.mock('@/lib/api', () => ({
+  addListingImage: (...args: unknown[]) => mockAddListingImage(...args),
+  deleteListingImage: (...args: unknown[]) => mockDeleteListingImage(...args),
+  reorderListingImages: (...args: unknown[]) => mockReorderListingImages(...args),
+  getPresignedUrl: (...args: unknown[]) => mockGetPresignedUrl(...args),
+}))
+
+// Mock upload utils
+const mockValidateFile = vi.fn()
+const mockUploadToS3 = vi.fn()
+vi.mock('@/lib/upload', () => ({
+  validateFile: (...args: unknown[]) => mockValidateFile(...args),
+  uploadToS3: (...args: unknown[]) => mockUploadToS3(...args),
+  UploadError: class extends Error {
+    code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  },
+}))
+
+import { ListingImages } from '../components/listing-images'
+
+const LISTING_ID = '11111111-1111-4111-8111-111111111111'
+
+const mockImages: MyListingImageResponse[] = [
+  {
+    id: 'img-1',
+    url: 'https://cdn.example.com/image1.jpg',
+    isProcessPhoto: false,
+    sortOrder: 0,
+    createdAt: '2025-06-01T00:00:00.000Z',
+  },
+  {
+    id: 'img-2',
+    url: 'https://cdn.example.com/image2.jpg',
+    isProcessPhoto: true,
+    sortOrder: 1,
+    createdAt: '2025-06-02T00:00:00.000Z',
+  },
+]
+
+describe('ListingImages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetIdToken.mockResolvedValue('test-token')
+    mockDeleteListingImage.mockResolvedValue(undefined)
+    mockReorderListingImages.mockResolvedValue(mockImages)
+
+    // Mock environment variable
+    vi.stubEnv('NEXT_PUBLIC_CLOUDFRONT_DOMAIN', 'cdn.example.com')
+  })
+
+  it('should render images passed as props', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    const imageItems = screen.getAllByTestId('listing-image-item')
+    expect(imageItems).toHaveLength(2)
+  })
+
+  it('should show empty state when no images', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={[]}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('listing-images-empty')).toBeInTheDocument()
+  })
+
+  it('should show process photo badge for process photos', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    const processPhotoBadges = screen.getAllByText('Process')
+    expect(processPhotoBadges).toHaveLength(1)
+  })
+
+  it('should delete image with confirmation', async () => {
+    const onImagesChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={onImagesChange}
+      />,
+    )
+
+    // Click delete on first image
+    const deleteButtons = screen.getAllByTestId('image-delete-button')
+    await user.click(deleteButtons[0])
+
+    // Confirm
+    const confirmButton = screen.getByTestId('image-delete-confirm')
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(mockDeleteListingImage).toHaveBeenCalledWith('test-token', LISTING_ID, 'img-1')
+    })
+
+    expect(onImagesChange).toHaveBeenCalledWith([mockImages[1]])
+  })
+
+  it('should cancel delete', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    const deleteButtons = screen.getAllByTestId('image-delete-button')
+    await user.click(deleteButtons[0])
+
+    // Cancel
+    const cancelButton = screen.getByText('Cancel')
+    await user.click(cancelButton)
+
+    expect(screen.queryByTestId('image-delete-confirm')).not.toBeInTheDocument()
+    expect(mockDeleteListingImage).not.toHaveBeenCalled()
+  })
+
+  it('should move image up', async () => {
+    const onImagesChange = vi.fn()
+    const user = userEvent.setup()
+
+    mockReorderListingImages.mockResolvedValue([mockImages[1], mockImages[0]])
+
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={onImagesChange}
+      />,
+    )
+
+    // Move second image up
+    const moveUpButtons = screen.getAllByLabelText('Move up')
+    await user.click(moveUpButtons[1])
+
+    await waitFor(() => {
+      expect(mockReorderListingImages).toHaveBeenCalledWith(
+        'test-token',
+        LISTING_ID,
+        ['img-2', 'img-1'],
+      )
+    })
+  })
+
+  it('should move image down', async () => {
+    const onImagesChange = vi.fn()
+    const user = userEvent.setup()
+
+    mockReorderListingImages.mockResolvedValue([mockImages[1], mockImages[0]])
+
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={onImagesChange}
+      />,
+    )
+
+    // Move first image down
+    const moveDownButtons = screen.getAllByLabelText('Move down')
+    await user.click(moveDownButtons[0])
+
+    await waitFor(() => {
+      expect(mockReorderListingImages).toHaveBeenCalledWith(
+        'test-token',
+        LISTING_ID,
+        ['img-2', 'img-1'],
+      )
+    })
+  })
+
+  it('should disable move up on first image', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    const moveUpButtons = screen.getAllByLabelText('Move up')
+    expect(moveUpButtons[0]).toBeDisabled()
+  })
+
+  it('should disable move down on last image', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    const moveDownButtons = screen.getAllByLabelText('Move down')
+    expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled()
+  })
+
+  it('should show upload button', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('image-upload-input')).toBeInTheDocument()
+  })
+
+  it('should mark first image as thumbnail', () => {
+    render(
+      <ListingImages
+        listingId={LISTING_ID}
+        images={mockImages}
+        onImagesChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Thumbnail')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/dashboard/listings/components/listing-form.tsx
+++ b/apps/web/src/app/dashboard/listings/components/listing-form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useAuth } from '@/lib/auth'
 import { createMyListing, updateMyListing, getMyListing } from '@/lib/api'
 import { dollarsToCents } from '@surfaced-art/utils'
-import type { CategoryType, ListingTypeType } from '@surfaced-art/types'
+import type { CategoryType, ListingTypeType, MyListingImageResponse } from '@surfaced-art/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { CATEGORIES } from '@/lib/categories'
+import { ListingImages } from './listing-images'
 
 interface FormData {
   title: string
@@ -67,6 +68,7 @@ export function ListingForm({ mode, listingId }: ListingFormProps) {
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM)
   const [serverError, setServerError] = useState<string | null>(null)
   const [fetchError, setFetchError] = useState<string | null>(null)
+  const [images, setImages] = useState<MyListingImageResponse[]>([])
 
   const fetchListing = useCallback(async () => {
     if (mode !== 'edit' || !listingId) return
@@ -83,6 +85,7 @@ export function ListingForm({ mode, listingId }: ListingFormProps) {
 
       const listing = await getMyListing(token, listingId)
 
+      setImages(listing.images)
       setFormData({
         title: listing.title,
         description: listing.description,
@@ -499,6 +502,15 @@ export function ListingForm({ mode, listingId }: ListingFormProps) {
           </div>
         </CardContent>
       </Card>
+
+      {/* Images (edit mode only) */}
+      {mode === 'edit' && listingId && (
+        <ListingImages
+          listingId={listingId}
+          images={images}
+          onImagesChange={setImages}
+        />
+      )}
 
       {/* Feedback */}
       {formState === 'error' && serverError && (

--- a/apps/web/src/app/dashboard/listings/components/listing-images.tsx
+++ b/apps/web/src/app/dashboard/listings/components/listing-images.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import Image from 'next/image'
+import { useAuth } from '@/lib/auth'
+import { addListingImage, deleteListingImage, reorderListingImages, getPresignedUrl } from '@/lib/api'
+import { validateFile, uploadToS3, UploadError } from '@/lib/upload'
+import type { MyListingImageResponse } from '@surfaced-art/types'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+function getCloudfrontDomain(): string {
+  return process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN || ''
+}
+
+interface ListingImagesProps {
+  listingId: string
+  images: MyListingImageResponse[]
+  onImagesChange: (images: MyListingImageResponse[]) => void
+}
+
+export function ListingImages({ listingId, images, onImagesChange }: ListingImagesProps) {
+  const { getIdToken } = useAuth()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setUploadError(null)
+    setUploading(true)
+
+    try {
+      validateFile(file)
+
+      const token = await getIdToken()
+      if (!token) {
+        setUploadError('Not authenticated')
+        return
+      }
+
+      const presigned = await getPresignedUrl(token, 'listing', file.type)
+      await uploadToS3(file, presigned)
+
+      const cloudfrontDomain = getCloudfrontDomain()
+      if (!cloudfrontDomain) {
+        throw new Error('Image CDN is not configured.')
+      }
+      const cloudFrontUrl = `https://${cloudfrontDomain}/${presigned.key}`
+
+      const newImage = await addListingImage(token, listingId, {
+        url: cloudFrontUrl,
+        isProcessPhoto: false,
+      })
+
+      onImagesChange([...images, newImage])
+    } catch (err) {
+      if (err instanceof UploadError) {
+        setUploadError(err.message)
+      } else {
+        setUploadError(err instanceof Error ? err.message : 'Upload failed')
+      }
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+    }
+  }
+
+  async function handleDelete(imageId: string) {
+    try {
+      const token = await getIdToken()
+      if (!token) return
+
+      await deleteListingImage(token, listingId, imageId)
+      onImagesChange(images.filter((img) => img.id !== imageId))
+      setDeleteConfirmId(null)
+    } catch {
+      // Could show toast in the future
+    }
+  }
+
+  async function handleMove(imageId: string, direction: 'up' | 'down') {
+    const index = images.findIndex((img) => img.id === imageId)
+    if (index === -1) return
+    if (direction === 'up' && index === 0) return
+    if (direction === 'down' && index === images.length - 1) return
+
+    const newImages = [...images]
+    const swapIndex = direction === 'up' ? index - 1 : index + 1
+    ;[newImages[index], newImages[swapIndex]] = [newImages[swapIndex], newImages[index]]
+
+    const orderedIds = newImages.map((img) => img.id)
+    onImagesChange(newImages)
+
+    try {
+      const token = await getIdToken()
+      if (!token) return
+
+      const result = await reorderListingImages(token, listingId, orderedIds)
+      onImagesChange(result)
+    } catch {
+      // Revert on error
+      onImagesChange(images)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Images</CardTitle>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+        >
+          {uploading ? 'Uploading...' : 'Add Image'}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={handleFileChange}
+          className="hidden"
+          data-testid="image-upload-input"
+        />
+
+        {uploadError && (
+          <p role="alert" className="text-sm text-destructive">
+            {uploadError}
+          </p>
+        )}
+
+        {images.length === 0 && (
+          <div data-testid="listing-images-empty" className="text-center py-8 text-muted-foreground">
+            <p>No images yet. Upload photos of your artwork.</p>
+          </div>
+        )}
+
+        {images.map((image, index) => (
+          <div
+            key={image.id}
+            data-testid="listing-image-item"
+            className="flex items-center gap-4 rounded-md border p-3"
+          >
+            {/* Thumbnail */}
+            <div className="relative w-16 h-16 rounded-md overflow-hidden flex-shrink-0 bg-muted">
+              <Image
+                src={image.url}
+                alt={`Image ${index + 1}`}
+                fill
+                className="object-cover"
+                unoptimized
+              />
+            </div>
+
+            {/* Info */}
+            <div className="flex-1 min-w-0 flex items-center gap-2">
+              {index === 0 && (
+                <Badge className="bg-accent-primary/10 text-accent-primary">Thumbnail</Badge>
+              )}
+              {image.isProcessPhoto && (
+                <Badge className="bg-warning/10 text-warning">Process</Badge>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-1 shrink-0">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={index === 0}
+                onClick={() => handleMove(image.id, 'up')}
+                aria-label="Move up"
+              >
+                ↑
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={index === images.length - 1}
+                onClick={() => handleMove(image.id, 'down')}
+                aria-label="Move down"
+              >
+                ↓
+              </Button>
+              {deleteConfirmId === image.id ? (
+                <div className="flex gap-1">
+                  <Button
+                    type="button"
+                    data-testid="image-delete-confirm"
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleDelete(image.id)}
+                  >
+                    Confirm
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDeleteConfirmId(null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  data-testid="image-delete-button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setDeleteConfirmId(image.id)}
+                  aria-label="Delete image"
+                >
+                  Delete
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/app/dashboard/listings/components/listings-table.tsx
+++ b/apps/web/src/app/dashboard/listings/components/listings-table.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { useAuth } from '@/lib/auth'
-import { getMyListings, deleteMyListing } from '@/lib/api'
+import { getMyListings, deleteMyListing, updateListingAvailability } from '@/lib/api'
 import { formatCurrency } from '@surfaced-art/utils'
 import type { MyListingListItem } from '@surfaced-art/types'
 import { Button } from '@/components/ui/button'
@@ -96,6 +96,27 @@ export function ListingsTable() {
       setDeleteConfirmId(null)
     } catch {
       // Could show toast here in the future
+    }
+  }
+
+  async function handleToggleAvailability(listing: MyListingListItem) {
+    const newStatus = listing.status === 'available' ? 'reserved_artist' : 'available'
+
+    // Optimistic update
+    setListings((prev) =>
+      prev.map((l) => (l.id === listing.id ? { ...l, status: newStatus as MyListingListItem['status'] } : l)),
+    )
+
+    try {
+      const token = await getIdToken()
+      if (!token) return
+
+      await updateListingAvailability(token, listing.id, { status: newStatus })
+    } catch {
+      // Revert on error
+      setListings((prev) =>
+        prev.map((l) => (l.id === listing.id ? { ...l, status: listing.status } : l)),
+      )
     }
   }
 
@@ -235,6 +256,16 @@ export function ListingsTable() {
                 </>
               ) : (
                 <>
+                  {(listing.status === 'available' || listing.status === 'reserved_artist') && (
+                    <Button
+                      data-testid="availability-toggle"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleToggleAvailability(listing)}
+                    >
+                      {listing.status === 'available' ? 'Reserve' : 'Unreserve'}
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
                     size="sm"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,10 +12,13 @@ import type {
   CategoryWithCount,
   DashboardResponse,
   FeaturedArtistItem,
+  ListingAvailabilityBody,
   ListingCreateBody,
   ListingDetailResponse,
+  ListingImageBody,
   ListingListItem,
   ListingUpdateBody,
+  MyListingImageResponse,
   MyListingListItem,
   MyListingResponse,
   PaginatedResponse,
@@ -336,4 +339,63 @@ export async function updateMyListing(
     headers: { Authorization: `Bearer ${token}` },
     body: JSON.stringify(data),
   })
+}
+
+export async function addListingImage(
+  token: string,
+  listingId: string,
+  data: ListingImageBody,
+): Promise<MyListingImageResponse> {
+  return apiFetch<MyListingImageResponse>(
+    `/me/listings/${encodeURIComponent(listingId)}/images`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    },
+  )
+}
+
+export async function deleteListingImage(
+  token: string,
+  listingId: string,
+  imageId: string,
+): Promise<void> {
+  await apiFetch<void>(
+    `/me/listings/${encodeURIComponent(listingId)}/images/${encodeURIComponent(imageId)}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  )
+}
+
+export async function reorderListingImages(
+  token: string,
+  listingId: string,
+  orderedIds: string[],
+): Promise<MyListingImageResponse[]> {
+  return apiFetch<MyListingImageResponse[]>(
+    `/me/listings/${encodeURIComponent(listingId)}/images/reorder`,
+    {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ orderedIds }),
+    },
+  )
+}
+
+export async function updateListingAvailability(
+  token: string,
+  id: string,
+  data: ListingAvailabilityBody,
+): Promise<MyListingResponse> {
+  return apiFetch<MyListingResponse>(
+    `/me/listings/${encodeURIComponent(id)}/availability`,
+    {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    },
+  )
 }


### PR DESCRIPTION
## Summary
- `ListingImages` component: upload, reorder (arrow buttons), delete with confirmation, process photo badges
- Availability toggle on listings table: Reserve/Unreserve with optimistic UI and rollback on error
- Integrated `ListingImages` into edit listing form
- API client functions: `addListingImage()`, `deleteListingImage()`, `reorderListingImages()`, `updateListingAvailability()`

## Test plan
- [x] 11 TDD tests for ListingImages component
- [x] 5 TDD tests for availability toggle
- [x] All 294 web tests pass
- [x] All quality gates pass (test, lint, typecheck, build)

Closes #274

## Summary by Sourcery

Add listing image management to the listing edit flow and introduce an availability toggle for listings with API support.

New Features:
- Enable creators to upload, reorder, and delete listing images, including process photo badges, from the listing edit page.
- Add an availability toggle on the listings table to reserve or unreserve listings with optimistic updates.

Enhancements:
- Extend the API client with endpoints for managing listing images and updating listing availability.

Tests:
- Add unit tests for the ListingImages component covering upload, reordering, deletion, and badges.
- Add unit tests for the listings availability toggle, including visibility rules and status transitions.