### PR TITLE
fix(web): correct reorderListingImages return type

### DIFF
--- a/apps/web/src/app/dashboard/listings/__tests__/listing-images.test.tsx
+++ b/apps/web/src/app/dashboard/listings/__tests__/listing-images.test.tsx
@@ -64,7 +64,7 @@ describe('ListingImages', () => {
     vi.clearAllMocks()
     mockGetIdToken.mockResolvedValue('test-token')
     mockDeleteListingImage.mockResolvedValue(undefined)
-    mockReorderListingImages.mockResolvedValue(mockImages)
+    mockReorderListingImages.mockResolvedValue({ images: mockImages })
 
     // Mock environment variable
     vi.stubEnv('NEXT_PUBLIC_CLOUDFRONT_DOMAIN', 'cdn.example.com')
@@ -161,7 +161,7 @@ describe('ListingImages', () => {
     const onImagesChange = vi.fn()
     const user = userEvent.setup()
 
-    mockReorderListingImages.mockResolvedValue([mockImages[1], mockImages[0]])
+    mockReorderListingImages.mockResolvedValue({ images: [mockImages[1], mockImages[0]] })
 
     render(
       <ListingImages
@@ -188,7 +188,7 @@ describe('ListingImages', () => {
     const onImagesChange = vi.fn()
     const user = userEvent.setup()
 
-    mockReorderListingImages.mockResolvedValue([mockImages[1], mockImages[0]])
+    mockReorderListingImages.mockResolvedValue({ images: [mockImages[1], mockImages[0]] })
 
     render(
       <ListingImages

--- a/apps/web/src/app/dashboard/listings/components/listing-images.tsx
+++ b/apps/web/src/app/dashboard/listings/components/listing-images.tsx
@@ -103,7 +103,7 @@ export function ListingImages({ listingId, images, onImagesChange }: ListingImag
       if (!token) return
 
       const result = await reorderListingImages(token, listingId, orderedIds)
-      onImagesChange(result)
+      onImagesChange(result.images)
     } catch {
       // Revert on error
       onImagesChange(images)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -374,8 +374,8 @@ export async function reorderListingImages(
   token: string,
   listingId: string,
   orderedIds: string[],
-): Promise<MyListingImageResponse[]> {
-  return apiFetch<MyListingImageResponse[]>(
+): Promise<{ images: MyListingImageResponse[] }> {
+  return apiFetch<{ images: MyListingImageResponse[] }>(
     `/me/listings/${encodeURIComponent(listingId)}/images/reorder`,
     {
       method: 'PUT',


### PR DESCRIPTION
## Summary
- Fix return type mismatch in `reorderListingImages` — API returns `{ images: MyListingImageResponse[] }` but frontend typed it as a bare array, causing image reorder to break at runtime
- Update `ListingImages` component to destructure `result.images`
- Update test mocks to match the actual API response shape

## Test plan
- [x] 701 tests passing (407 API + 294 web)
- [x] All quality gates green: test, lint, typecheck, build

Closes Greptile review feedback on #281

## Summary by Sourcery

Align listing image reorder API types and usage with the actual backend response shape.

Bug Fixes:
- Fix listing image reorder API wrapper to return an object with an images array matching the backend response, preventing runtime breakage when reordering images.
- Update ListingImages component to use the images property from the reorder API response when updating state.
- Adjust listing image tests to mock the reorderListingImages response using the correct { images: ... } shape.