### PR TITLE
refactor(api): split admin routes into sub-module directory (#303)

### DIFF
--- a/apps/api/src/routes/admin/applications.ts
+++ b/apps/api/src/routes/admin/applications.ts
@@ -4,21 +4,18 @@ import { logger, generateSlug } from '@surfaced-art/utils'
 import { adminReviewBody } from '@surfaced-art/types'
 import type { AdminApproveResponse, AdminRejectResponse } from '@surfaced-art/types'
 import { sendEmail, ArtistAcceptance, ArtistRejection } from '@surfaced-art/email'
-import { authMiddleware, requireRole, type AuthUser } from '../middleware/auth'
-import { notFound, conflict, validationError, internalError } from '../errors'
+import type { AuthUser } from '../../middleware/auth'
+import { notFound, conflict, validationError, internalError } from '../../errors'
 import { createElement } from 'react'
 
-export function createAdminRoutes(prisma: PrismaClient) {
-  const admin = new Hono<{ Variables: { user: AuthUser } }>()
-
-  admin.use('*', authMiddleware(prisma))
-  admin.use('*', requireRole('admin'))
+export function createAdminApplicationRoutes(prisma: PrismaClient) {
+  const app = new Hono<{ Variables: { user: AuthUser } }>()
 
   /**
    * POST /admin/artists/:userId/approve
    * Approve an artist application: update application status, create profile, grant role.
    */
-  admin.post('/artists/:userId/approve', async (c) => {
+  app.post('/artists/:userId/approve', async (c) => {
     const start = Date.now()
     const adminUser = c.get('user')
     const { userId } = c.req.param()
@@ -139,7 +136,7 @@ export function createAdminRoutes(prisma: PrismaClient) {
    * POST /admin/artists/:userId/reject
    * Reject an artist application: update application status and send notification.
    */
-  admin.post('/artists/:userId/reject', async (c) => {
+  app.post('/artists/:userId/reject', async (c) => {
     const start = Date.now()
     const adminUser = c.get('user')
     const { userId } = c.req.param()
@@ -214,7 +211,7 @@ export function createAdminRoutes(prisma: PrismaClient) {
     }
   })
 
-  return admin
+  return app
 }
 
 /**

--- a/apps/api/src/routes/admin/index.ts
+++ b/apps/api/src/routes/admin/index.ts
@@ -1,0 +1,15 @@
+import { Hono } from 'hono'
+import type { PrismaClient } from '@surfaced-art/db'
+import { authMiddleware, requireRole, type AuthUser } from '../../middleware/auth'
+import { createAdminApplicationRoutes } from './applications'
+
+export function createAdminRoutes(prisma: PrismaClient) {
+  const admin = new Hono<{ Variables: { user: AuthUser } }>()
+
+  admin.use('*', authMiddleware(prisma))
+  admin.use('*', requireRole('admin'))
+
+  admin.route('/', createAdminApplicationRoutes(prisma))
+
+  return admin
+}

--- a/apps/api/src/test-helpers/create-test-app.ts
+++ b/apps/api/src/test-helpers/create-test-app.ts
@@ -9,7 +9,7 @@ import { createCategoryRoutes } from '../routes/categories.js'
 import { createWaitlistRoutes } from '../routes/waitlist.js'
 import { createApplicationRoutes } from '../routes/applications.js'
 import { createMeRoutes } from '../routes/me.js'
-import { createAdminRoutes } from '../routes/admin.js'
+import { createAdminRoutes } from '../routes/admin/index.js'
 
 /**
  * Create a Hono app instance with a test PrismaClient injected.


### PR DESCRIPTION
## Summary

- Splits monolithic `apps/api/src/routes/admin.ts` into a sub-module directory (`admin/index.ts` + `admin/applications.ts`) to support scaling to ~35 endpoints in Phase 3
- Moves approve/reject handlers and `ensureUniqueSlug` helper into `applications.ts`
- Auth middleware (`authMiddleware` + `requireRole('admin')`) applied at the router level in `index.ts`
- Updates `create-test-app.ts` import path to `../routes/admin/index.js`

No URL changes. `POST /admin/artists/:userId/approve` and `POST /admin/artists/:userId/reject` continue to work identically.

Closes #303

## Test plan

- [x] All 17 admin unit tests pass (URL paths unchanged, import resolves correctly)
- [x] Admin integration test import unaffected (uses `createTestApp`, not direct admin import)
- [x] Lint passes with no new warnings
- [x] Typecheck passes for `@surfaced-art/api` (only pre-existing `uploads.ts` error from missing `@aws-sdk/s3-presigned-post`)
- [x] Verified pre-existing test/typecheck/build failures on unmodified dev branch are identical

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split the monolithic admin API routes into a dedicated sub-module and preserve existing admin endpoints and behavior.

Enhancements:
- Extract admin artist application approve/reject routes into a dedicated applications sub-router for better modularity and future expansion.
- Introduce a top-level admin router that applies authentication and admin role checks once and mounts the applications sub-routes.
- Adjust internal imports to reflect the new admin routes directory structure without changing external URLs.