### PR TITLE
fix(scripts): use dataSources.query for Notion SDK v5

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,7 +30,7 @@ NOTION_API_TOKEN=secret_xxx npx tsx scripts/notion-to-s3.ts --artist "Elena Cord
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `NOTION_API_TOKEN` | Yes | — | Notion integration token |
-| `NOTION_DATABASE_ID` | No | `98c10909-...` | Tracker database ID |
+| `NOTION_DATA_SOURCE_ID` | No | `d190c7e8-...` | Tracker data source (collection) ID |
 | `S3_MEDIA_BUCKET` | No | `surfaced-art-prod-media` | Target S3 bucket |
 | `AWS_REGION` | No | `us-east-1` | AWS region |
 

--- a/scripts/notion-to-s3.ts
+++ b/scripts/notion-to-s3.ts
@@ -17,7 +17,7 @@
  *
  * Environment variables:
  *   NOTION_API_TOKEN       (required) Notion integration token
- *   NOTION_DATABASE_ID     (optional) defaults to the tracker DB ID
+ *   NOTION_DATA_SOURCE_ID  (optional) defaults to the tracker data source ID
  *   S3_MEDIA_BUCKET        (optional) defaults to surfaced-art-prod-media
  *   AWS_REGION             (optional) defaults to us-east-1
  */
@@ -39,8 +39,10 @@ import {
 // Configuration
 // ---------------------------------------------------------------------------
 
-const NOTION_DATABASE_ID =
-  process.env.NOTION_DATABASE_ID ?? '98c10909-b35d-47b0-954b-f992993a1bc3'
+// Notion SDK v5 uses dataSources.query (not databases.query).
+// The data source ID is the collection ID from the Notion database.
+const NOTION_DATA_SOURCE_ID =
+  process.env.NOTION_DATA_SOURCE_ID ?? 'd190c7e8-fbcb-49c6-ac4e-abf6389575cf'
 const S3_BUCKET = process.env.S3_MEDIA_BUCKET ?? 'surfaced-art-prod-media'
 const AWS_REGION = process.env.AWS_REGION ?? 'us-east-1'
 
@@ -98,9 +100,9 @@ async function fetchCompletedRows(
       : { and: filterConditions }
 
   do {
-    const response = await notion.databases.query({
-      database_id: NOTION_DATABASE_ID,
-      filter: filter as Parameters<typeof notion.databases.query>[0]['filter'],
+    const response = await notion.dataSources.query({
+      data_source_id: NOTION_DATA_SOURCE_ID,
+      filter: filter as Parameters<typeof notion.dataSources.query>[0]['filter'],
       start_cursor: cursor,
       page_size: 100,
     })
@@ -186,7 +188,7 @@ async function main(): Promise<void> {
 
   console.log(`Bucket:   ${S3_BUCKET}`)
   console.log(`Region:   ${AWS_REGION}`)
-  console.log(`Database: ${NOTION_DATABASE_ID}`)
+  console.log(`Data src: ${NOTION_DATA_SOURCE_ID}`)
   if (artist) console.log(`Artist:   ${artist}`)
   if (dryRun) console.log(`Mode:     DRY RUN (no uploads)`)
   console.log('')


### PR DESCRIPTION
## Summary

Fixes the `notion.databases.query is not a function` error in the seed images workflow.

The `@notionhq/client` v5 (2025-09-03 API) moved `databases.query` to `dataSources.query` to support multi-source databases. The script now uses the correct API method with the data source (collection) ID instead of the database ID.

## Changes

- `scripts/notion-to-s3.ts` — `databases.query` → `dataSources.query`, `NOTION_DATABASE_ID` → `NOTION_DATA_SOURCE_ID`
- `scripts/README.md` — updated env var docs

## Test plan

- [x] 16 unit tests pass
- [x] Type check passes
- [ ] Re-run the "Seed Images — Notion to S3" workflow with dry-run after merge

## Summary by Sourcery

Update the Notion-to-S3 script to use the Notion SDK v5 data sources API instead of the deprecated databases API.

Bug Fixes:
- Resolve failures in the Notion-to-S3 seed images workflow caused by the removed notion.databases.query method in Notion SDK v5.

Documentation:
- Document the new NOTION_DATA_SOURCE_ID environment variable and its semantics in the scripts README.