### PR TITLE
feat(web): add /about and /artists pages

### DIFF
--- a/apps/web/src/app/about/page.test.tsx
+++ b/apps/web/src/app/about/page.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://surfacedart.com')
+vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.surfacedart.com')
+import { render, screen } from '@testing-library/react'
+
+import AboutPage, { metadata } from './page'
+
+describe('About Page', () => {
+  it('should render the page heading', () => {
+    render(<AboutPage />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent('About Surfaced Art')
+  })
+
+  it('should explain the gallery vs marketplace distinction', () => {
+    render(<AboutPage />)
+    expect(screen.getByText(/digital gallery/i)).toBeInTheDocument()
+  })
+
+  it('should mention the vetting process', () => {
+    render(<AboutPage />)
+    expect(screen.getByText(/Every artist is vetted/i)).toBeInTheDocument()
+  })
+
+  it('should state what the platform is not', () => {
+    render(<AboutPage />)
+    expect(screen.getByText(/No AI/i)).toBeInTheDocument()
+    expect(screen.getByText(/No dropshipping/i)).toBeInTheDocument()
+  })
+
+  it('should have correct metadata title', () => {
+    expect(metadata.title).toContain('About')
+  })
+
+  it('should have correct metadata description', () => {
+    expect(metadata.description).toBeDefined()
+    expect(typeof metadata.description).toBe('string')
+  })
+})

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next'
+import { JsonLd } from '@/components/JsonLd'
+import { Breadcrumbs } from '@/components/Breadcrumbs'
+import { SITE_URL } from '@/lib/site-config'
+
+export const metadata: Metadata = {
+  title: 'About — Surfaced Art',
+  description:
+    'Surfaced Art is a curated digital gallery for real makers. Every artist is vetted. Every piece is handmade. No AI, no dropshipping, no mass production.',
+  alternates: {
+    canonical: `${SITE_URL}/about`,
+  },
+  openGraph: {
+    title: 'About — Surfaced Art',
+    description:
+      'Surfaced Art is a curated digital gallery for real makers. Every artist is vetted. Every piece is handmade. No AI, no dropshipping, no mass production.',
+    type: 'website',
+    url: `${SITE_URL}/about`,
+  },
+}
+
+export default function AboutPage() {
+  return (
+    <div className="space-y-12 md:space-y-16">
+      <JsonLd data={{
+        '@context': 'https://schema.org',
+        '@type': 'AboutPage',
+        name: 'About Surfaced Art',
+        url: `${SITE_URL}/about`,
+        description: metadata.description,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Surfaced Art',
+          url: SITE_URL,
+        },
+      }} />
+
+      <Breadcrumbs items={[
+        { label: 'Home', href: '/' },
+        { label: 'About' },
+      ]} />
+
+      {/* Hero */}
+      <section className="max-w-2xl">
+        <h1 className="font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
+          About Surfaced Art
+        </h1>
+        <p className="mt-6 text-lg leading-relaxed text-muted-text">
+          A curated digital gallery for real makers. The credibility of a
+          gallery, accessible online.
+        </p>
+      </section>
+
+      {/* What makes us different */}
+      <section className="max-w-2xl space-y-6">
+        <h2 className="font-serif text-2xl text-foreground">
+          A gallery, not a marketplace
+        </h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          That distinction is foundational. Artists understand galleries. They
+          trust galleries. They know the relationship, the commission structure,
+          and the credibility that comes with being represented. Surfaced Art
+          exists to give genuine, independent artists a credible online home
+          where buyers can trust that every piece is handmade by the artist who
+          is selling it.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Every artist is vetted. Every piece is handmade. No AI. No dropshipping.
+          No mass production.
+        </p>
+      </section>
+
+      {/* For artists */}
+      <section className="max-w-2xl space-y-6">
+        <h2 className="font-serif text-2xl text-foreground">
+          For artists
+        </h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We are a pipeline for emerging and independent artists who don&apos;t
+          yet have gallery representation. Applying to Surfaced Art should feel
+          like applying to a gallery — an honor, not a formality. Acceptance
+          means something. Artists who earned their place have skin in the game
+          and contribute to a culture built on authenticity.
+        </p>
+      </section>
+
+      {/* For buyers */}
+      <section className="max-w-2xl space-y-6">
+        <h2 className="font-serif text-2xl text-foreground">
+          For buyers
+        </h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We are a trust signal for buyers who are tired of being burned by
+          mass-produced goods disguised as handmade. When you buy on Surfaced
+          Art, you are buying directly from the person who made it. Every
+          artist has been reviewed and accepted based on their craft, their
+          process, and their commitment to making real work.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/artists/page.test.tsx
+++ b/apps/web/src/app/artists/page.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://surfacedart.com')
+vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.surfacedart.com')
+import { render, screen } from '@testing-library/react'
+
+vi.mock('@/lib/api', () => ({
+  getFeaturedArtists: vi.fn().mockResolvedValue([]),
+}))
+
+import { getFeaturedArtists } from '@/lib/api'
+import ArtistsPage, { metadata } from './page'
+
+const mockGetFeaturedArtists = getFeaturedArtists as ReturnType<typeof vi.fn>
+
+describe('Artists Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render the page heading', async () => {
+    const Component = await ArtistsPage()
+    render(Component)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent('Our Artists')
+  })
+
+  it('should render artist cards when API returns data', async () => {
+    mockGetFeaturedArtists.mockResolvedValue([
+      {
+        slug: 'jane-doe',
+        displayName: 'Jane Doe',
+        location: 'Portland, OR',
+        profileImageUrl: null,
+        coverImageUrl: null,
+        categories: ['ceramics'],
+      },
+      {
+        slug: 'john-smith',
+        displayName: 'John Smith',
+        location: 'Brooklyn, NY',
+        profileImageUrl: null,
+        coverImageUrl: null,
+        categories: ['painting'],
+      },
+    ])
+    const Component = await ArtistsPage()
+    render(Component)
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('John Smith')).toBeInTheDocument()
+  })
+
+  it('should handle empty artist list gracefully', async () => {
+    mockGetFeaturedArtists.mockResolvedValue([])
+    const Component = await ArtistsPage()
+    render(Component)
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+    expect(screen.getByText(/check back soon/i)).toBeInTheDocument()
+  })
+
+  it('should have correct metadata title', () => {
+    expect(metadata.title).toContain('Artists')
+  })
+
+  it('should have correct metadata description', () => {
+    expect(metadata.description).toBeDefined()
+    expect(typeof metadata.description).toBe('string')
+  })
+})

--- a/apps/web/src/app/artists/page.tsx
+++ b/apps/web/src/app/artists/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next'
+import { getFeaturedArtists, ApiError } from '@/lib/api'
+import { ArtistCard } from '@/components/ArtistCard'
+import { JsonLd } from '@/components/JsonLd'
+import { Breadcrumbs } from '@/components/Breadcrumbs'
+import { SITE_URL } from '@/lib/site-config'
+
+export const revalidate = 60
+
+export const metadata: Metadata = {
+  title: 'Artists — Surfaced Art',
+  description:
+    'Browse all vetted artists on Surfaced Art. Discover ceramics, painting, print, jewelry, illustration, photography, woodworking, fibers, and mixed media.',
+  alternates: {
+    canonical: `${SITE_URL}/artists`,
+  },
+  openGraph: {
+    title: 'Artists — Surfaced Art',
+    description:
+      'Browse all vetted artists on Surfaced Art. Discover ceramics, painting, print, jewelry, illustration, photography, woodworking, fibers, and mixed media.',
+    type: 'website',
+    url: `${SITE_URL}/artists`,
+  },
+}
+
+async function fetchArtists() {
+  try {
+    return await getFeaturedArtists({ limit: 50 })
+  } catch (error) {
+    if (error instanceof ApiError) {
+      console.error(`API error fetching artists: ${error.status} ${error.message}`)
+    } else {
+      console.error('Unexpected error fetching artists:', error)
+    }
+    return []
+  }
+}
+
+export default async function ArtistsPage() {
+  const artists = await fetchArtists()
+
+  return (
+    <div className="space-y-12 md:space-y-16">
+      <JsonLd data={{
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: 'Artists — Surfaced Art',
+        url: `${SITE_URL}/artists`,
+        description: metadata.description,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Surfaced Art',
+          url: SITE_URL,
+        },
+      }} />
+
+      <Breadcrumbs items={[
+        { label: 'Home', href: '/' },
+        { label: 'Artists' },
+      ]} />
+
+      {/* Header */}
+      <section>
+        <h1 className="font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
+          Our Artists
+        </h1>
+        <p className="mt-4 max-w-lg text-lg leading-relaxed text-muted-text">
+          Every artist on Surfaced Art has been vetted for authenticity and
+          craft. Browse their profiles to discover original, handmade work.
+        </p>
+      </section>
+
+      {/* Artist grid */}
+      {artists.length > 0 ? (
+        <section data-testid="artists-grid">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {artists.map((artist) => (
+              <ArtistCard
+                key={artist.slug}
+                artist={artist}
+                data-testid="artist-card"
+              />
+            ))}
+          </div>
+        </section>
+      ) : (
+        <section className="py-12 text-center">
+          <p className="text-muted-text">
+            No artists to show right now. Please check back soon.
+          </p>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -11,6 +11,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'daily',
       priority: 1.0,
     },
+    {
+      url: `${SITE_URL}/about`,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/artists`,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
     ...CATEGORIES.map((cat) => ({
       url: `${SITE_URL}/category/${cat.slug}`,
       changeFrequency: 'daily' as const,

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -43,21 +43,27 @@ export function Footer() {
             </ul>
           </div>
 
-          {/* Platform links placeholder */}
+          {/* Platform links */}
           <div className="md:col-span-1 lg:col-span-1">
             <h3 className="text-xs font-medium uppercase tracking-widest text-foreground mb-4">
               Platform
             </h3>
             <ul className="space-y-2.5">
               <li>
-                <span className="text-sm text-muted-foreground/60">
+                <Link
+                  href="/about"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
                   About
-                </span>
+                </Link>
               </li>
               <li>
-                <span className="text-sm text-muted-foreground/60">
+                <Link
+                  href="/artists"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
                   Artists
-                </span>
+                </Link>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary

Creates two new public-facing pages and activates their Footer links:

- **`/about`** — Static page communicating the platform mission: gallery vs marketplace distinction, vetting philosophy, sections for artists and buyers. Content drawn from the product vision doc.
- **`/artists`** — Dynamic browse page showing all approved artists in a responsive grid using the existing `ArtistCard` component. Fetches via `getFeaturedArtists({ limit: 50 })` with ISR (60s).

### Also includes
- Footer: converted placeholder `<span>` elements to active `<Link>` components for About and Artists
- Sitemap: added `/about` (monthly, 0.7) and `/artists` (daily, 0.9)
- Both pages: `metadata` with canonical URL + OG fields, `<JsonLd>` structured data, `<Breadcrumbs>`
- 11 new tests (TDD)

### Issues
Closes #265, Closes #266

## Test plan

- [x] 356 web tests pass (43 files, including 11 new)
- [x] ESLint passes (0 errors)
- [x] TypeScript typechecks pass
- [x] No API changes needed

## Summary by Sourcery

Add new public About and Artists pages to the web app and wire them into navigation and SEO surfaces.

New Features:
- Introduce a static /about page describing the Surfaced Art platform for artists and buyers, with structured data and breadcrumbs.
- Add a dynamic /artists browse page listing vetted artists in a responsive grid with ISR, structured data, and breadcrumbs.

Enhancements:
- Activate About and Artists links in the footer to navigate to the new pages.
- Extend the sitemap to include the /about and /artists routes with appropriate crawl priorities.

Tests:
- Add tests covering rendering, API-driven behavior, empty states, and metadata for the new Artists and About pages.