### PR TITLE
chore(infra): add S3 lifecycle rules for media bucket

### DIFF
--- a/infrastructure/terraform/modules/s3-cloudfront/main.tf
+++ b/infrastructure/terraform/modules/s3-cloudfront/main.tf
@@ -27,21 +27,17 @@ resource "aws_s3_bucket_versioning" "media" {
 
 # Lifecycle rules for storage cost management
 resource "aws_s3_bucket_lifecycle_configuration" "media" {
-  bucket = aws_s3_bucket.media.id
+  bucket     = aws_s3_bucket.media.id
+  depends_on = [aws_s3_bucket_versioning.media]
 
   rule {
-    id     = "transition-noncurrent-to-glacier"
+    id     = "noncurrent-version-management"
     status = "Enabled"
 
     noncurrent_version_transition {
       noncurrent_days = 90
       storage_class   = "GLACIER"
     }
-  }
-
-  rule {
-    id     = "delete-noncurrent-versions"
-    status = "Enabled"
 
     noncurrent_version_expiration {
       noncurrent_days = 365


### PR DESCRIPTION
## Summary
- Add lifecycle configuration to S3 media buckets (prod + dev) to manage storage costs
- Transition non-current object versions to S3 Glacier after 90 days
- Delete non-current versions after 365 days
- Abort incomplete multipart uploads after 7 days

Versioning was already enabled. These rules prevent unbounded storage growth as artists update images over time. Existing current images are unaffected — rules only apply to non-current versions and incomplete uploads.

**Cost impact:** Glacier storage is ~$0.004/GB/month vs $0.023/GB/month for S3 Standard (83% cheaper). With current image volume (~600MB), impact is negligible — the value is preventing growth as the platform scales.

Closes #341

## Test plan
- [ ] `terraform plan` shows 1 new resource (`aws_s3_bucket_lifecycle_configuration.media`)
- [ ] All quality gates pass (test, lint, typecheck, build)
- [ ] After apply: `aws s3api get-bucket-lifecycle-configuration --bucket surfaced-art-prod-media` returns the 3 rules

## Summary by Sourcery

Configure lifecycle management for versioned S3 media buckets to control long-term storage growth and costs.

New Features:
- Add lifecycle rules to transition non-current media objects to S3 Glacier after 90 days.
- Add expiration policy to delete non-current media object versions after 365 days.
- Add rule to automatically abort incomplete multipart uploads after 7 days in media buckets.

Deployment:
- Introduce Terraform-managed S3 bucket lifecycle configuration for media buckets in shared s3-cloudfront module.