### PR TITLE
fix(api): address AI code review findings (batch 2026-03-04)

### DIFF
--- a/apps/api/src/routes/admin/audit.ts
+++ b/apps/api/src/routes/admin/audit.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import type { PrismaClient, Prisma } from '@surfaced-art/db'
-import { logger } from '@surfaced-art/utils'
+import { logger, validateUuid } from '@surfaced-art/utils'
 import { adminAuditLogQuery } from '@surfaced-art/types'
 import type {
   AdminAuditLogEntry,
@@ -97,8 +97,7 @@ export function createAdminAuditRoutes(prisma: PrismaClient) {
     const { userId } = c.req.param()
 
     // Validate userId is a valid UUID before using in query
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-    if (!uuidRegex.test(userId)) {
+    if (!validateUuid(userId)) {
       return notFound(c, 'User not found')
     }
 

--- a/apps/api/src/routes/admin/users.ts
+++ b/apps/api/src/routes/admin/users.ts
@@ -1,13 +1,14 @@
 import { Hono } from 'hono'
 import type { PrismaClient, Prisma } from '@surfaced-art/db'
 import { logger } from '@surfaced-art/utils'
-import { adminUsersQuery, adminRoleGrantBody } from '@surfaced-art/types'
+import { adminUsersQuery, adminRoleGrantBody, UserRole } from '@surfaced-art/types'
 import type {
   AdminUserListItem,
   AdminUserDetailResponse,
   AdminRoleGrantResponse,
   AdminActionResponse,
   PaginatedResponse,
+  UserRoleType,
 } from '@surfaced-art/types'
 import type { AuthUser } from '../../middleware/auth'
 import { notFound, forbidden, conflict, validationError, badRequest, internalError } from '../../errors'
@@ -243,13 +244,12 @@ export function createAdminUserRoutes(prisma: PrismaClient) {
     const adminUser = c.get('user')
     const { id, role } = c.req.param()
 
-    // Validate role path param against known roles
-    const validRoles = ['buyer', 'artist', 'admin', 'curator', 'moderator'] as const
-    type ValidRole = typeof validRoles[number]
-    if (!validRoles.includes(role as ValidRole)) {
+    // Validate role path param against known roles (derived from shared enum)
+    const validRoles = Object.values(UserRole) as UserRoleType[]
+    if (!validRoles.includes(role as UserRoleType)) {
       return badRequest(c, `Invalid role: ${role}`)
     }
-    const validatedRole = role as ValidRole
+    const validatedRole = role as UserRoleType
 
     // Prevent removing own admin role
     if (id === adminUser.id && validatedRole === 'admin') {


### PR DESCRIPTION
## Summary
Batch fix addressing AI code review findings from #ai-code-review Slack channel.
Triaged 9 unaddressed bot review messages across 7 PRs. Only PR #331 was merged to `dev`; PRs #362–367 are still open and deferred.

## Fixes Applied
| File | Issue | Source | Commit |
|------|-------|--------|--------|
| `apps/api/src/routes/admin/users.ts` | Hardcoded `validRoles` array — derived from shared `UserRole` enum instead | Sourcery | `75dd701` |
| `apps/api/src/routes/admin/audit.ts` | Inline UUID regex duplicating `validateUuid` from `@surfaced-art/utils` — replaced with shared validator | Sourcery | `75dd701` |

## Skipped (with reasoning)
| PR | Source | Reason |
|----|--------|--------|
| #367 (2 messages) | Sourcery, Greptile | PR not yet merged to `dev` — deferred |
| #366 (2 messages) | Sourcery, Greptile | PR not yet merged to `dev` — deferred |
| #365 (1 message) | Sourcery | PR not yet merged to `dev` — deferred |
| #364 (1 message) | Sourcery | PR not yet merged to `dev` — no actionable findings (review said "looks great") |
| #363 (1 message) | Sourcery | PR not yet merged to `dev` — deferred |
| #362 (1 message) | Sourcery | PR not yet merged to `dev` — deferred |

## Source Reviews
- PR #331: https://github.com/nickcjordan/surfaced-art/pull/331

## Summary by Sourcery

Align admin API route validations with shared types and utilities to address AI code review findings.

Bug Fixes:
- Ensure admin user role updates validate against the shared UserRole enum rather than a hardcoded role list.
- Use the shared validateUuid helper for admin audit userId validation instead of an inline UUID regex.