### PR TITLE
fix: address AI code review findings (batch 2026-03-06)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
               </Suspense>
               <ScrollToTop />
               <Header />
-              <main className="flex-1 overflow-x-hidden">
+              <main className="flex-1">
                 <Container className="py-8 md:py-12">
                   {children}
                 </Container>

--- a/apps/web/src/components/SplitHero.tsx
+++ b/apps/web/src/components/SplitHero.tsx
@@ -29,7 +29,7 @@ export function SplitHero() {
   const image = pickHeroImage()
 
   return (
-    <section data-testid="hero" className="full-bleed">
+    <section data-testid="hero" className="full-bleed overflow-x-hidden">
       <div className="grid min-h-[60vh] grid-cols-1 lg:grid-cols-2">
         {/* Artwork image */}
         <div className="relative h-[50vh] lg:h-auto">


### PR DESCRIPTION
## Summary
Batch fix addressing AI code review findings from #ai-code-review Slack channel.
Triaged 6 unaddressed bot review messages across 3 PRs.

## Fixes Applied
| File | Issue | Source | Commit |
|------|-------|--------|--------|
| `apps/web/src/components/SplitHero.tsx` | Add `aria-hidden="true"` to decorative bullet dot spans for screen reader accessibility | Greptile (PR #373) | `299dab3` |
| `apps/web/src/app/layout.tsx`, `apps/web/src/components/SplitHero.tsx` | Scope `overflow-x-hidden` to hero section instead of global `<main>` to avoid masking layout issues elsewhere | Sourcery (PR #373, #374) | `cf5093f` |

## Skipped (with reasoning)
| File | Issue | Reason |
|------|-------|--------|
| `apps/web/src/app/layout.tsx` | Missing `ScrollToTop` component | Already fixed — component was created in the same PR |
| `apps/web/src/components/SplitHero.tsx` | `unoptimized` bypasses responsive sizing | Per project convention: CLAUDE.md mandates `unoptimized` prop on Next.js Image (no Vercel Image Optimization) |
| `apps/web/src/components/SplitHero.tsx` | `Math.random()` in Server Component won't rotate client-side | Acceptable trade-off — per-request rotation is the intended behavior for dynamic rendering |
| `apps/api/src/routes/admin/users.ts` | `Object.values(UserRole)` as source of truth for allowable roles | Code is correct — uses shared Prisma enum, no system-only roles exist |
| `apps/api/src/routes/admin/users.ts` | Extract shared role-validation helper | Premature abstraction — validation only used in one route |

## Source Reviews
- PR #373: https://github.com/nickcjordan/surfaced-art/pull/373
- PR #374: https://github.com/nickcjordan/surfaced-art/pull/374
- PR #368: https://github.com/nickcjordan/surfaced-art/pull/368

## Summary by Sourcery

Address accessibility and layout issues in the marketing hero section.

Bug Fixes:
- Improve screen reader accessibility of hero feature list bullets by marking decorative dots as aria-hidden.
- Limit horizontal overflow clipping to the hero section instead of the global main content area to avoid masking layout issues elsewhere.