### PR TITLE
feat(api): admin impersonation — read-only view-as (#316)

### DIFF
--- a/apps/api/src/lib/artist-queries.ts
+++ b/apps/api/src/lib/artist-queries.ts
@@ -1,0 +1,150 @@
+import type { PrismaClient } from '@surfaced-art/db'
+import type {
+  DashboardResponse,
+  MyListingImageResponse,
+  MyListingListItem,
+  ProfileCompletionField,
+} from '@surfaced-art/types'
+
+function formatListingImage(img: {
+  id: string; url: string; isProcessPhoto: boolean; sortOrder: number;
+  width: number | null; height: number | null; createdAt: Date
+}): MyListingImageResponse {
+  return {
+    id: img.id,
+    url: img.url,
+    isProcessPhoto: img.isProcessPhoto,
+    sortOrder: img.sortOrder,
+    width: img.width,
+    height: img.height,
+    createdAt: img.createdAt.toISOString(),
+  }
+}
+
+export function formatListingListItem(listing: {
+  id: string; type: string; title: string; medium: string; category: string;
+  price: number; status: string; isDocumented: boolean;
+  quantityTotal: number; quantityRemaining: number;
+  createdAt: Date; updatedAt: Date;
+  images: { id: string; url: string; isProcessPhoto: boolean; sortOrder: number; width: number | null; height: number | null; createdAt: Date }[];
+}): MyListingListItem {
+  const firstImage = listing.images[0]
+  const primaryImage = firstImage ? formatListingImage(firstImage) : null
+  return {
+    id: listing.id,
+    type: listing.type as MyListingListItem['type'],
+    title: listing.title,
+    medium: listing.medium,
+    category: listing.category as MyListingListItem['category'],
+    price: listing.price,
+    status: listing.status as MyListingListItem['status'],
+    isDocumented: listing.isDocumented,
+    quantityTotal: listing.quantityTotal,
+    quantityRemaining: listing.quantityRemaining,
+    createdAt: listing.createdAt.toISOString(),
+    updatedAt: listing.updatedAt.toISOString(),
+    primaryImage,
+  }
+}
+
+/**
+ * Fetch an artist's dashboard data by userId.
+ * Returns null if the user has no artist profile.
+ */
+export async function fetchDashboard(
+  prisma: PrismaClient,
+  userId: string,
+): Promise<DashboardResponse | null> {
+  const artist = await prisma.artistProfile.findUnique({
+    where: { userId },
+    include: { categories: true, cvEntries: true },
+  })
+
+  if (!artist) return null
+
+  const [totalListings, availableListings, soldListings] = await Promise.all([
+    prisma.listing.count({ where: { artistId: artist.id } }),
+    prisma.listing.count({ where: { artistId: artist.id, status: 'available' } }),
+    prisma.listing.count({ where: { artistId: artist.id, status: 'sold' } }),
+  ])
+
+  const fields: ProfileCompletionField[] = [
+    { label: 'Bio', complete: artist.bio.trim().length > 0 },
+    { label: 'Location', complete: artist.location.trim().length > 0 },
+    { label: 'Profile image', complete: artist.profileImageUrl !== null },
+    { label: 'Cover image', complete: artist.coverImageUrl !== null },
+    { label: 'At least 1 category', complete: artist.categories.length > 0 },
+    { label: 'At least 1 CV entry', complete: artist.cvEntries.length > 0 },
+  ]
+
+  const completedCount = fields.filter((f) => f.complete).length
+  const percentage = Math.round((completedCount / fields.length) * 100)
+
+  return {
+    profile: {
+      id: artist.id,
+      displayName: artist.displayName,
+      slug: artist.slug,
+      bio: artist.bio,
+      location: artist.location,
+      websiteUrl: artist.websiteUrl,
+      instagramUrl: artist.instagramUrl,
+      profileImageUrl: artist.profileImageUrl,
+      coverImageUrl: artist.coverImageUrl,
+      status: artist.status,
+      stripeAccountId: artist.stripeAccountId,
+      categories: artist.categories.map((c) => c.category),
+    },
+    completion: { percentage, fields },
+    stats: {
+      totalListings,
+      availableListings,
+      soldListings,
+      totalViews: 0,
+    },
+  }
+}
+
+/**
+ * Fetch paginated listings for a given artist (by userId).
+ * Returns null if the user has no artist profile.
+ */
+export async function fetchUserListings(
+  prisma: PrismaClient,
+  userId: string,
+  opts: { page: number; limit: number; status?: string; category?: string },
+): Promise<{ data: MyListingListItem[]; meta: { page: number; limit: number; total: number; totalPages: number }; artistId: string } | null> {
+  const artist = await prisma.artistProfile.findUnique({
+    where: { userId },
+  })
+
+  if (!artist) return null
+
+  const where: Record<string, unknown> = { artistId: artist.id }
+  if (opts.status) where.status = opts.status
+  if (opts.category) where.category = opts.category
+
+  const [total, listings] = await Promise.all([
+    prisma.listing.count({ where }),
+    prisma.listing.findMany({
+      where,
+      include: { images: { orderBy: { sortOrder: 'asc' } } },
+      orderBy: { createdAt: 'desc' },
+      skip: (opts.page - 1) * opts.limit,
+      take: opts.limit,
+    }),
+  ])
+
+  const data: MyListingListItem[] = listings.map((listing) => formatListingListItem(listing))
+
+  return {
+    data,
+    meta: {
+      page: opts.page,
+      limit: opts.limit,
+      total,
+      totalPages: Math.ceil(total / opts.limit) || 1,
+    },
+    artistId: artist.id,
+  }
+}

--- a/apps/api/src/routes/admin/impersonation.test.ts
+++ b/apps/api/src/routes/admin/impersonation.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+import { createAdminRoutes } from './index'
+import { setVerifier, resetVerifier } from '../../middleware/auth'
+import type { PrismaClient } from '@surfaced-art/db'
+
+// Mock email module (required by applications sub-router)
+vi.mock('@surfaced-art/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-123' }),
+  ArtistAcceptance: vi.fn(() => null),
+  ArtistRejection: vi.fn(() => null),
+}))
+
+// ─── Test helpers ────────────────────────────────────────────────────
+
+function createMockVerifier(sub = 'cognito-admin', email = 'admin@surfacedart.com', name = 'Admin User') {
+  return { verify: vi.fn().mockResolvedValue({ sub, email, name }) }
+}
+
+const ADMIN_USER_ID = 'admin-uuid-123'
+const TARGET_USER_ID = 'target-uuid-456'
+const TARGET_ARTIST_ID = 'artist-uuid-789'
+const LISTING_ID = 'listing-uuid-001'
+
+const mockAdminUser = {
+  id: ADMIN_USER_ID,
+  cognitoId: 'cognito-admin',
+  email: 'admin@surfacedart.com',
+  fullName: 'Admin User',
+  roles: [{ role: 'admin', grantedAt: new Date('2025-01-01'), grantedBy: null }],
+}
+
+const mockTargetUser = {
+  id: TARGET_USER_ID,
+  cognitoId: 'cognito-target',
+  email: 'artist@example.com',
+  fullName: 'Target Artist',
+  avatarUrl: 'https://example.com/avatar.jpg',
+  roles: [
+    { role: 'buyer', grantedAt: new Date('2025-01-01'), grantedBy: null },
+    { role: 'artist', grantedAt: new Date('2025-01-15'), grantedBy: ADMIN_USER_ID },
+  ],
+  createdAt: new Date('2025-01-01'),
+  lastActiveAt: new Date('2025-02-01'),
+  artistProfile: {
+    id: TARGET_ARTIST_ID,
+    displayName: 'Target Artist',
+    slug: 'target-artist',
+    status: 'active',
+  },
+  _count: { ordersAsBuyer: 3, reviewsAsBuyer: 1, saves: 5, follows: 2 },
+}
+
+const mockArtistProfile = {
+  id: TARGET_ARTIST_ID,
+  userId: TARGET_USER_ID,
+  displayName: 'Target Artist',
+  slug: 'target-artist',
+  bio: 'An artist bio',
+  location: 'New York, NY',
+  websiteUrl: 'https://artist.com',
+  instagramUrl: 'https://instagram.com/artist',
+  profileImageUrl: 'https://example.com/profile.jpg',
+  coverImageUrl: 'https://example.com/cover.jpg',
+  status: 'active',
+  stripeAccountId: 'acct_123',
+  categories: [{ category: 'painting' }],
+  cvEntries: [{ id: 'cv-1' }],
+}
+
+const mockListing = {
+  id: LISTING_ID,
+  type: 'original',
+  title: 'Test Painting',
+  medium: 'Oil on canvas',
+  category: 'painting',
+  price: 15000,
+  status: 'available',
+  isDocumented: false,
+  quantityTotal: 1,
+  quantityRemaining: 1,
+  createdAt: new Date('2025-02-01'),
+  updatedAt: new Date('2025-02-01'),
+  images: [
+    {
+      id: 'img-1',
+      url: 'https://example.com/img.jpg',
+      isProcessPhoto: false,
+      sortOrder: 0,
+      width: 800,
+      height: 600,
+      createdAt: new Date('2025-02-01'),
+    },
+  ],
+}
+
+function createMockPrisma(overrides?: {
+  adminRoles?: string[]
+  targetUser?: unknown
+  artistProfile?: unknown
+  listings?: unknown[]
+  listingCount?: number
+}) {
+  const adminRoles = overrides?.adminRoles ?? ['admin']
+
+  const userFindUnique = vi.fn().mockImplementation(({ where }: { where: { cognitoId?: string; id?: string } }) => {
+    if (where.cognitoId === 'cognito-admin') {
+      return Promise.resolve({ ...mockAdminUser, roles: adminRoles.map((r) => ({ role: r })) })
+    }
+    if (where.id === TARGET_USER_ID) {
+      return Promise.resolve(overrides?.targetUser !== undefined ? overrides.targetUser : mockTargetUser)
+    }
+    if (where.id === ADMIN_USER_ID) {
+      return Promise.resolve({ ...mockAdminUser, roles: adminRoles.map((r) => ({ role: r, grantedAt: new Date('2025-01-01'), grantedBy: null })) })
+    }
+    return Promise.resolve(null)
+  })
+
+  return {
+    user: {
+      findUnique: userFindUnique,
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    userRole: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    artistProfile: {
+      findUnique: vi.fn().mockResolvedValue(overrides?.artistProfile !== undefined ? overrides.artistProfile : mockArtistProfile),
+    },
+    artistApplication: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      count: vi.fn().mockResolvedValue(0),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    listing: {
+      findMany: vi.fn().mockResolvedValue(overrides?.listings ?? [mockListing]),
+      count: vi.fn().mockResolvedValue(overrides?.listingCount ?? (overrides?.listings?.length ?? 1)),
+    },
+    adminAuditLog: {
+      create: vi.fn().mockResolvedValue({ id: 'audit-uuid-1' }),
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      return fn({
+        artistApplication: { update: vi.fn().mockResolvedValue({}) },
+        artistProfile: { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({}) },
+        userRole: { create: vi.fn().mockResolvedValue({}) },
+      })
+    }),
+  } as unknown as PrismaClient
+}
+
+function createTestApp(prisma: PrismaClient) {
+  const app = new Hono()
+  app.route('/admin', createAdminRoutes(prisma))
+  return app
+}
+
+function impersonateUser(app: ReturnType<typeof createTestApp>, userId: string, token?: string) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return app.request(`/admin/impersonate/${userId}`, { method: 'POST', headers })
+}
+
+function impersonateDashboard(app: ReturnType<typeof createTestApp>, userId: string, token?: string) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return app.request(`/admin/impersonate/${userId}/dashboard`, { headers })
+}
+
+function impersonateListings(app: ReturnType<typeof createTestApp>, userId: string, query = '', token?: string) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return app.request(`/admin/impersonate/${userId}/listings${query ? `?${query}` : ''}`, { headers })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe('POST /admin/impersonate/:userId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setVerifier(createMockVerifier() as never)
+  })
+  afterEach(() => resetVerifier())
+
+  it('should return 401 without auth token', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    const res = await impersonateUser(app, TARGET_USER_ID)
+    expect(res.status).toBe(401)
+  })
+
+  it('should return 403 without admin role', async () => {
+    const prisma = createMockPrisma({ adminRoles: ['buyer'] })
+    const app = createTestApp(prisma)
+    const res = await impersonateUser(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(403)
+  })
+
+  it('should return 404 when user not found', async () => {
+    const prisma = createMockPrisma({ targetUser: null })
+    const app = createTestApp(prisma)
+    const res = await impersonateUser(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(404)
+  })
+
+  it('should return user detail for non-artist user', async () => {
+    const nonArtistUser = {
+      ...mockTargetUser,
+      artistProfile: null,
+      roles: [{ role: 'buyer', grantedAt: new Date('2025-01-01'), grantedBy: null }],
+    }
+    const prisma = createMockPrisma({ targetUser: nonArtistUser, artistProfile: null })
+    const app = createTestApp(prisma)
+    const res = await impersonateUser(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.user.id).toBe(TARGET_USER_ID)
+    expect(body.user.email).toBe('artist@example.com')
+    expect(body.dashboard).toBeNull()
+  })
+
+  it('should return user detail + dashboard for artist user', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    const res = await impersonateUser(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.user.id).toBe(TARGET_USER_ID)
+    expect(body.user.artistProfile).not.toBeNull()
+    expect(body.dashboard).not.toBeNull()
+    expect(body.dashboard.profile.id).toBe(TARGET_ARTIST_ID)
+    expect(body.dashboard.completion).toBeDefined()
+    expect(body.dashboard.stats).toBeDefined()
+  })
+
+  it('should write audit log with action user.impersonate', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    await impersonateUser(app, TARGET_USER_ID, 'valid-token')
+
+    expect(prisma.adminAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          adminId: ADMIN_USER_ID,
+          action: 'user.impersonate',
+          targetType: 'user',
+          targetId: TARGET_USER_ID,
+        }),
+      }),
+    )
+  })
+})
+
+describe('GET /admin/impersonate/:userId/dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setVerifier(createMockVerifier() as never)
+  })
+  afterEach(() => resetVerifier())
+
+  it('should return 401 without auth token', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    const res = await impersonateDashboard(app, TARGET_USER_ID)
+    expect(res.status).toBe(401)
+  })
+
+  it('should return 404 when user not found', async () => {
+    const prisma = createMockPrisma({ targetUser: null })
+    const app = createTestApp(prisma)
+    const res = await impersonateDashboard(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(404)
+  })
+
+  it('should return 404 when user is not an artist', async () => {
+    const nonArtistUser = { ...mockTargetUser, artistProfile: null }
+    const prisma = createMockPrisma({ targetUser: nonArtistUser, artistProfile: null })
+    const app = createTestApp(prisma)
+    const res = await impersonateDashboard(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(404)
+  })
+
+  it('should return dashboard data for artist user', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    const res = await impersonateDashboard(app, TARGET_USER_ID, 'valid-token')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.profile.id).toBe(TARGET_ARTIST_ID)
+    expect(body.profile.displayName).toBe('Target Artist')
+    expect(body.completion.percentage).toBeDefined()
+    expect(body.completion.fields).toBeInstanceOf(Array)
+    expect(body.stats.totalListings).toBeDefined()
+  })
+
+  it('should write audit log', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    await impersonateDashboard(app, TARGET_USER_ID, 'valid-token')
+
+    expect(prisma.adminAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          adminId: ADMIN_USER_ID,
+          action: 'user.impersonate',
+          targetType: 'user',
+          targetId: TARGET_USER_ID,
+          details: expect.objectContaining({ endpoint: 'dashboard' }),
+        }),
+      }),
+    )
+  })
+})
+
+describe('GET /admin/impersonate/:userId/listings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setVerifier(createMockVerifier() as never)
+  })
+  afterEach(() => resetVerifier())
+
+  it('should return 401 without auth token', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    const res = await impersonateListings(app, TARGET_USER_ID)
+    expect(res.status).toBe(401)
+  })
+
+  it('should return 404 when user not found', async () => {
+    const prisma = createMockPrisma({ targetUser: null })
+    const app = createTestApp(prisma)
+    const res = await impersonateListings(app, TARGET_USER_ID, '', 'valid-token')
+    expect(res.status).toBe(404)
+  })
+
+  it('should return 404 when user is not an artist', async () => {
+    const nonArtistUser = { ...mockTargetUser, artistProfile: null }
+    const prisma = createMockPrisma({ targetUser: nonArtistUser, artistProfile: null })
+    const app = createTestApp(prisma)
+    const res = await impersonateListings(app, TARGET_USER_ID, '', 'valid-token')
+    expect(res.status).toBe(404)
+  })
+
+  it('should return paginated listings for artist user', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    const res = await impersonateListings(app, TARGET_USER_ID, '', 'valid-token')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].id).toBe(LISTING_ID)
+    expect(body.data[0].title).toBe('Test Painting')
+    expect(body.data[0].primaryImage).toBeDefined()
+    expect(body.meta).toEqual({ page: 1, limit: 20, total: 1, totalPages: 1 })
+  })
+
+  it('should support status and category query filters', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    await impersonateListings(app, TARGET_USER_ID, 'status=available&category=painting', 'valid-token')
+
+    expect(prisma.listing.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          artistId: TARGET_ARTIST_ID,
+          status: 'available',
+          category: 'painting',
+        }),
+      }),
+    )
+  })
+
+  it('should support pagination query params', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    await impersonateListings(app, TARGET_USER_ID, 'page=2&limit=5', 'valid-token')
+
+    expect(prisma.listing.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 5,
+        take: 5,
+      }),
+    )
+  })
+
+  it('should write audit log', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+    await impersonateListings(app, TARGET_USER_ID, '', 'valid-token')
+
+    expect(prisma.adminAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          adminId: ADMIN_USER_ID,
+          action: 'user.impersonate',
+          targetType: 'user',
+          targetId: TARGET_USER_ID,
+          details: expect.objectContaining({ endpoint: 'listings' }),
+        }),
+      }),
+    )
+  })
+})

--- a/apps/api/src/routes/admin/impersonation.ts
+++ b/apps/api/src/routes/admin/impersonation.ts
@@ -1,0 +1,172 @@
+import { Hono } from 'hono'
+import type { PrismaClient } from '@surfaced-art/db'
+import { logger } from '@surfaced-art/utils'
+import type { AdminUserDetailResponse } from '@surfaced-art/types'
+import { myListingsQuery } from '@surfaced-art/types'
+import type { AuthUser } from '../../middleware/auth'
+import { notFound, validationError } from '../../errors'
+import { logAdminAction } from '../../lib/audit'
+import { fetchDashboard, fetchUserListings } from '../../lib/artist-queries'
+
+export function createAdminImpersonationRoutes(prisma: PrismaClient) {
+  const app = new Hono<{ Variables: { user: AuthUser } }>()
+
+  /**
+   * POST /admin/impersonate/:userId
+   * Get user context — user detail + dashboard data (if artist).
+   */
+  app.post('/:userId', async (c) => {
+    const start = Date.now()
+    const adminUser = c.get('user')
+    const { userId } = c.req.param()
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        roles: true,
+        artistProfile: { select: { id: true, displayName: true, slug: true, status: true } },
+        _count: {
+          select: {
+            ordersAsBuyer: true,
+            reviewsAsBuyer: true,
+            saves: true,
+            follows: true,
+          },
+        },
+      },
+    })
+
+    if (!user) {
+      return notFound(c, 'User not found')
+    }
+
+    const userDetail: AdminUserDetailResponse = {
+      id: user.id,
+      email: user.email,
+      fullName: user.fullName,
+      avatarUrl: user.avatarUrl,
+      roles: user.roles.map((r) => ({
+        role: r.role,
+        grantedAt: r.grantedAt.toISOString(),
+        grantedBy: r.grantedBy,
+      })),
+      createdAt: user.createdAt.toISOString(),
+      lastActiveAt: user.lastActiveAt?.toISOString() ?? null,
+      artistProfile: user.artistProfile
+        ? {
+            id: user.artistProfile.id,
+            displayName: user.artistProfile.displayName,
+            slug: user.artistProfile.slug,
+            status: user.artistProfile.status,
+          }
+        : null,
+      stats: {
+        orderCount: user._count.ordersAsBuyer,
+        reviewCount: user._count.reviewsAsBuyer,
+        saveCount: user._count.saves,
+        followCount: user._count.follows,
+      },
+    }
+
+    const dashboard = user.artistProfile ? await fetchDashboard(prisma, userId) : null
+
+    void logAdminAction(prisma, {
+      adminId: adminUser.id,
+      action: 'user.impersonate',
+      targetType: 'user',
+      targetId: userId,
+    })
+
+    logger.info('Admin impersonated user', {
+      adminId: adminUser.id,
+      targetUserId: userId,
+      hasArtistProfile: user.artistProfile !== null,
+      durationMs: Date.now() - start,
+    })
+
+    return c.json({ user: userDetail, dashboard })
+  })
+
+  /**
+   * GET /admin/impersonate/:userId/dashboard
+   * View artist dashboard as that user.
+   */
+  app.get('/:userId/dashboard', async (c) => {
+    const start = Date.now()
+    const adminUser = c.get('user')
+    const { userId } = c.req.param()
+
+    const user = await prisma.user.findUnique({ where: { id: userId } })
+    if (!user) {
+      return notFound(c, 'User not found')
+    }
+
+    const dashboard = await fetchDashboard(prisma, userId)
+    if (!dashboard) {
+      return notFound(c, 'Artist profile not found')
+    }
+
+    void logAdminAction(prisma, {
+      adminId: adminUser.id,
+      action: 'user.impersonate',
+      targetType: 'user',
+      targetId: userId,
+      details: { endpoint: 'dashboard' },
+    })
+
+    logger.info('Admin viewed user dashboard', {
+      adminId: adminUser.id,
+      targetUserId: userId,
+      artistId: dashboard.profile.id,
+      durationMs: Date.now() - start,
+    })
+
+    return c.json(dashboard)
+  })
+
+  /**
+   * GET /admin/impersonate/:userId/listings
+   * View user's listings with same query params as GET /me/listings.
+   */
+  app.get('/:userId/listings', async (c) => {
+    const start = Date.now()
+    const adminUser = c.get('user')
+    const { userId } = c.req.param()
+
+    const user = await prisma.user.findUnique({ where: { id: userId } })
+    if (!user) {
+      return notFound(c, 'User not found')
+    }
+
+    const queryParsed = myListingsQuery.safeParse(Object.fromEntries(new URL(c.req.url).searchParams))
+    if (!queryParsed.success) {
+      return validationError(c, queryParsed.error)
+    }
+
+    const { page, limit, status, category } = queryParsed.data
+
+    const result = await fetchUserListings(prisma, userId, { page, limit, status, category })
+    if (!result) {
+      return notFound(c, 'Artist profile not found')
+    }
+
+    void logAdminAction(prisma, {
+      adminId: adminUser.id,
+      action: 'user.impersonate',
+      targetType: 'user',
+      targetId: userId,
+      details: { endpoint: 'listings' },
+    })
+
+    logger.info('Admin viewed user listings', {
+      adminId: adminUser.id,
+      targetUserId: userId,
+      artistId: result.artistId,
+      durationMs: Date.now() - start,
+    })
+
+    return c.json({ data: result.data, meta: result.meta })
+  })
+
+  return app
+}

--- a/apps/api/src/routes/admin/index.ts
+++ b/apps/api/src/routes/admin/index.ts
@@ -8,6 +8,7 @@ import { createAdminListingRoutes } from './listings'
 import { createAdminAuditRoutes } from './audit'
 import { createAdminPlatformRoutes } from './platform'
 import { createAdminBulkRoutes } from './bulk'
+import { createAdminImpersonationRoutes } from './impersonation'
 
 export function createAdminRoutes(prisma: PrismaClient) {
   const admin = new Hono<{ Variables: { user: AuthUser } }>()
@@ -22,6 +23,7 @@ export function createAdminRoutes(prisma: PrismaClient) {
   admin.route('/audit-log', createAdminAuditRoutes(prisma))
   admin.route('/', createAdminPlatformRoutes(prisma))
   admin.route('/', createAdminBulkRoutes(prisma))
+  admin.route('/impersonate', createAdminImpersonationRoutes(prisma))
 
   return admin
 }

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
 import type { PrismaClient } from '@surfaced-art/db'
 import type { CategoryType as PrismaCategoryType } from '@surfaced-art/db'
-import type { CategoriesUpdateResponse, CvEntryResponse, CvEntryListResponse, DashboardResponse, MyListingImageResponse, MyListingListItem, MyListingResponse, ProcessMediaResponse, ProcessMediaListResponse, ProfileCompletionField, ProfileUpdateResponse, StripeOnboardingResponse, StripeStatusResponse } from '@surfaced-art/types'
+import type { CategoriesUpdateResponse, CvEntryResponse, CvEntryListResponse, MyListingImageResponse, MyListingResponse, ProcessMediaResponse, ProcessMediaListResponse, ProfileUpdateResponse, StripeOnboardingResponse, StripeStatusResponse } from '@surfaced-art/types'
+import { fetchDashboard, fetchUserListings } from '../lib/artist-queries'
 import { categoriesUpdateBody, cvEntryBody, cvEntryReorderBody, listingAvailabilityBody, listingCreateBody, listingImageBody, listingImageReorderBody, listingUpdateBody, myListingsQuery, processMediaPhotoBody, processMediaVideoBody, processMediaReorderBody, profileUpdateBody, sanitizeText } from '@surfaced-art/types'
 import { logger } from '@surfaced-art/utils'
 import { authMiddleware, requireRole, type AuthUser } from '../middleware/auth'
@@ -96,31 +97,7 @@ function formatListingResponse(listing: {
   }
 }
 
-function formatListingListItem(listing: {
-  id: string; type: string; title: string; medium: string; category: string;
-  price: number; status: string; isDocumented: boolean;
-  quantityTotal: number; quantityRemaining: number;
-  createdAt: Date; updatedAt: Date;
-  images: { id: string; url: string; isProcessPhoto: boolean; sortOrder: number; width: number | null; height: number | null; createdAt: Date }[];
-}): MyListingListItem {
-  const firstImage = listing.images[0]
-  const primaryImage = firstImage ? formatListingImage(firstImage) : null
-  return {
-    id: listing.id,
-    type: listing.type as MyListingListItem['type'],
-    title: listing.title,
-    medium: listing.medium,
-    category: listing.category as MyListingListItem['category'],
-    price: listing.price,
-    status: listing.status as MyListingListItem['status'],
-    isDocumented: listing.isDocumented,
-    quantityTotal: listing.quantityTotal,
-    quantityRemaining: listing.quantityRemaining,
-    createdAt: listing.createdAt.toISOString(),
-    updatedAt: listing.updatedAt.toISOString(),
-    primaryImage,
-  }
-}
+
 
 export function createMeRoutes(prisma: PrismaClient) {
   const me = new Hono<{ Variables: { user: AuthUser } }>()
@@ -137,66 +114,15 @@ export function createMeRoutes(prisma: PrismaClient) {
     const start = Date.now()
     const user = c.get('user')
 
-    const artist = await prisma.artistProfile.findUnique({
-      where: { userId: user.id },
-      include: {
-        categories: true,
-        cvEntries: true,
-      },
-    })
+    const response = await fetchDashboard(prisma, user.id)
 
-    if (!artist) {
+    if (!response) {
       return notFound(c, 'Artist profile not found')
     }
 
-    const [totalListings, availableListings, soldListings] = await Promise.all([
-      prisma.listing.count({ where: { artistId: artist.id } }),
-      prisma.listing.count({ where: { artistId: artist.id, status: 'available' } }),
-      prisma.listing.count({ where: { artistId: artist.id, status: 'sold' } }),
-    ])
-
-    const fields: ProfileCompletionField[] = [
-      { label: 'Bio', complete: artist.bio.trim().length > 0 },
-      { label: 'Location', complete: artist.location.trim().length > 0 },
-      { label: 'Profile image', complete: artist.profileImageUrl !== null },
-      { label: 'Cover image', complete: artist.coverImageUrl !== null },
-      { label: 'At least 1 category', complete: artist.categories.length > 0 },
-      { label: 'At least 1 CV entry', complete: artist.cvEntries.length > 0 },
-    ]
-
-    const completedCount = fields.filter((f) => f.complete).length
-    const percentage = Math.round((completedCount / fields.length) * 100)
-
-    const response: DashboardResponse = {
-      profile: {
-        id: artist.id,
-        displayName: artist.displayName,
-        slug: artist.slug,
-        bio: artist.bio,
-        location: artist.location,
-        websiteUrl: artist.websiteUrl,
-        instagramUrl: artist.instagramUrl,
-        profileImageUrl: artist.profileImageUrl,
-        coverImageUrl: artist.coverImageUrl,
-        status: artist.status,
-        stripeAccountId: artist.stripeAccountId,
-        categories: artist.categories.map((c) => c.category),
-      },
-      completion: {
-        percentage,
-        fields,
-      },
-      stats: {
-        totalListings,
-        availableListings,
-        soldListings,
-        totalViews: 0, // Placeholder until analytics
-      },
-    }
-
     logger.info('Dashboard data fetched', {
-      artistId: artist.id,
-      completionPct: percentage,
+      artistId: response.profile.id,
+      completionPct: response.completion.percentage,
       durationMs: Date.now() - start,
     })
 
@@ -847,40 +773,13 @@ export function createMeRoutes(prisma: PrismaClient) {
 
     const { page, limit, status, category } = queryParsed.data
 
-    const artist = await prisma.artistProfile.findUnique({
-      where: { userId: user.id },
-    })
+    const result = await fetchUserListings(prisma, user.id, { page, limit, status, category })
 
-    if (!artist) {
+    if (!result) {
       return notFound(c, 'Artist profile not found')
     }
 
-    const where: Record<string, unknown> = { artistId: artist.id }
-    if (status) where.status = status
-    if (category) where.category = category
-
-    const [total, listings] = await Promise.all([
-      prisma.listing.count({ where }),
-      prisma.listing.findMany({
-        where,
-        include: { images: { orderBy: { sortOrder: 'asc' } } },
-        orderBy: { createdAt: 'desc' },
-        skip: (page - 1) * limit,
-        take: limit,
-      }),
-    ])
-
-    const data: MyListingListItem[] = listings.map((listing) => formatListingListItem(listing))
-
-    return c.json({
-      data,
-      meta: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit) || 1,
-      },
-    })
+    return c.json({ data: result.data, meta: result.meta })
   })
 
   /**


### PR DESCRIPTION
## Summary

Adds admin impersonation endpoints for diagnosing support issues by viewing what a specific user sees, without signing in as them.

### Endpoints

- **`POST /admin/impersonate/:userId`** — Returns user detail (`AdminUserDetailResponse`) + dashboard data (`DashboardResponse`) if the user is an artist. Non-artist users return `dashboard: null`.
- **`GET /admin/impersonate/:userId/dashboard`** — Returns the same `DashboardResponse` shape as `GET /me/dashboard`, scoped to the target user. Returns 404 if user is not an artist.
- **`GET /admin/impersonate/:userId/listings`** — Returns paginated listings with the same shape/filters as `GET /me/listings` (status, category, page, limit). Returns 404 if user is not an artist.

### Refactoring

Extracted shared query logic from `GET /me/dashboard` and `GET /me/listings` into reusable functions in `apps/api/src/lib/artist-queries.ts`:
- `fetchDashboard(prisma, userId)` — returns `DashboardResponse | null`
- `fetchUserListings(prisma, userId, opts)` — returns paginated `MyListingListItem[]` or null
- `formatListingListItem()` — shared formatter

Both `/me` and `/admin/impersonate` routes now use these shared functions, eliminating duplication.

### Audit Logging

All impersonation requests are audit-logged with action `user.impersonate` and include endpoint details where applicable.

### Tests

18 tests covering all three endpoints:
- Auth (401/403) and not-found (404) cases
- Artist vs non-artist user responses
- Query parameter filtering and pagination
- Audit log verification

### Pre-existing typecheck note

The `npm run typecheck` failure is pre-existing on `dev` — caused by the image dimensions migration adding `width`/`height` fields that haven't been reflected in the local Prisma client types. Not related to this PR.

## Test Plan

- [x] All 577 tests pass (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [ ] Typecheck — pre-existing failures only (verified on clean `dev`)

Closes #316

## Summary by Sourcery

Add admin impersonation APIs for viewing a user’s artist dashboard and listings in a read-only way, backed by shared artist query helpers reused by existing /me routes.

New Features:
- Introduce admin impersonation endpoints to fetch a user’s details plus optional artist dashboard, their dashboard alone, or their listings with existing filters and pagination.

Enhancements:
- Extract shared artist dashboard and listings query/formatting logic into reusable helpers consumed by both /me and admin impersonation routes to remove duplication.

Tests:
- Add comprehensive tests for admin impersonation endpoints covering auth, artist vs non-artist behavior, filtering, pagination, and audit logging.