### PR TITLE
feat(web): add privacy policy and terms of service pages

### DIFF
--- a/apps/web/src/app/(main)/privacy/page.test.tsx
+++ b/apps/web/src/app/(main)/privacy/page.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://surfacedart.com')
+vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.surfacedart.com')
+import { render, screen } from '@testing-library/react'
+
+import PrivacyPage, { metadata } from './page'
+
+describe('Privacy Policy Page', () => {
+  it('should render the page heading', () => {
+    render(<PrivacyPage />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent(/privacy policy/i)
+  })
+
+  it('should cover data collection', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-data-collected')).toBeInTheDocument()
+  })
+
+  it('should cover third-party services', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-third-party')).toBeInTheDocument()
+  })
+
+  it('should cover cookies and analytics', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-cookies')).toBeInTheDocument()
+  })
+
+  it('should cover data retention', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-retention')).toBeInTheDocument()
+  })
+
+  it('should cover deletion rights', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-rights')).toBeInTheDocument()
+  })
+
+  it('should include contact information', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-contact')).toBeInTheDocument()
+  })
+
+  it('should have correct metadata title', () => {
+    expect(metadata.title).toContain('Privacy')
+  })
+
+  it('should have canonical URL in metadata', () => {
+    expect(metadata.alternates?.canonical).toBe('https://surfacedart.com/privacy')
+  })
+
+  it('should have metadata description', () => {
+    expect(metadata.description).toBeDefined()
+    expect(typeof metadata.description).toBe('string')
+  })
+
+  it('should have data-testid on hero section', () => {
+    render(<PrivacyPage />)
+    expect(screen.getByTestId('privacy-hero')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from 'next'
+import { JsonLd } from '@/components/JsonLd'
+import { Breadcrumbs } from '@/components/Breadcrumbs'
+import { SITE_URL } from '@/lib/site-config'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Surfaced Art',
+  description:
+    'Learn how Surfaced Art collects, uses, and protects your personal data. Covers third-party services, cookies, retention, and your deletion rights.',
+  alternates: {
+    canonical: `${SITE_URL}/privacy`,
+  },
+  openGraph: {
+    title: 'Privacy Policy — Surfaced Art',
+    description:
+      'Learn how Surfaced Art collects, uses, and protects your personal data.',
+    type: 'website',
+    url: `${SITE_URL}/privacy`,
+  },
+}
+
+export default function PrivacyPage() {
+  return (
+    <div className="space-y-12 md:space-y-16">
+      <JsonLd data={{
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: 'Privacy Policy',
+        url: `${SITE_URL}/privacy`,
+        description: metadata.description,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Surfaced Art',
+          url: SITE_URL,
+        },
+      }} />
+
+      <Breadcrumbs items={[
+        { label: 'Home', href: '/' },
+        { label: 'Privacy Policy' },
+      ]} />
+
+      {/* Hero */}
+      <section data-testid="privacy-hero" className="max-w-2xl">
+        <h1 className="font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
+          Privacy Policy
+        </h1>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Last updated: March 2026
+        </p>
+        <p className="mt-6 text-lg leading-relaxed text-muted-text">
+          Surfaced Art (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is committed to
+          protecting your privacy. This policy explains what information we collect, how we use it,
+          and your rights regarding that information.
+        </p>
+      </section>
+
+      {/* Data Collected */}
+      <section data-testid="privacy-data-collected" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Information We Collect</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We collect information you provide directly to us, such as when you create an account,
+          apply to become an artist, or make a purchase:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li><strong>Account information:</strong> name, email address, and password</li>
+          <li><strong>Artist profile data:</strong> biography, location, portfolio images, and social links</li>
+          <li><strong>Transaction data:</strong> purchase history, shipping addresses, and payment method details (processed by Stripe — we do not store raw card numbers)</li>
+          <li><strong>Communications:</strong> messages you send to us or through the platform</li>
+        </ul>
+        <p className="text-base leading-relaxed text-muted-text">
+          We also collect limited data automatically when you use the platform, including IP address,
+          browser type, pages visited, and session duration, for security and analytics purposes.
+        </p>
+      </section>
+
+      {/* Third-Party Services */}
+      <section data-testid="privacy-third-party" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Third-Party Services</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We use the following third-party services, each with their own privacy policies:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li>
+            <strong>Stripe:</strong> Payment processing. Stripe collects and processes payment
+            information directly. See{' '}
+            <a href="https://stripe.com/privacy" target="_blank" rel="noopener noreferrer"
+               className="underline underline-offset-4 hover:text-foreground transition-colors">
+              Stripe&rsquo;s Privacy Policy
+            </a>.
+          </li>
+          <li>
+            <strong>PostHog:</strong> Product analytics. We use PostHog to understand how the platform
+            is used. PostHog collects anonymized usage events. See{' '}
+            <a href="https://posthog.com/privacy" target="_blank" rel="noopener noreferrer"
+               className="underline underline-offset-4 hover:text-foreground transition-colors">
+              PostHog&rsquo;s Privacy Policy
+            </a>.
+          </li>
+          <li>
+            <strong>Amazon Web Services (AWS):</strong> Infrastructure hosting. Your data is stored
+            on AWS servers in the United States. See{' '}
+            <a href="https://aws.amazon.com/privacy/" target="_blank" rel="noopener noreferrer"
+               className="underline underline-offset-4 hover:text-foreground transition-colors">
+              AWS&rsquo;s Privacy Policy
+            </a>.
+          </li>
+          <li>
+            <strong>Vercel:</strong> Frontend hosting and CDN delivery. See{' '}
+            <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer"
+               className="underline underline-offset-4 hover:text-foreground transition-colors">
+              Vercel&rsquo;s Privacy Policy
+            </a>.
+          </li>
+        </ul>
+        <p className="text-base leading-relaxed text-muted-text">
+          We do not sell your personal information to any third party.
+        </p>
+      </section>
+
+      {/* Cookies and Analytics */}
+      <section data-testid="privacy-cookies" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Cookies and Analytics</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We use cookies and similar technologies to maintain your session, remember your preferences,
+          and improve the platform experience. Specifically:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li><strong>Session cookies:</strong> Required for authentication and keeping you signed in</li>
+          <li><strong>Analytics cookies:</strong> Used by PostHog to measure platform usage in aggregate</li>
+        </ul>
+        <p className="text-base leading-relaxed text-muted-text">
+          You can disable cookies in your browser settings, though some features of the platform
+          may not function correctly without them.
+        </p>
+      </section>
+
+      {/* Data Retention */}
+      <section data-testid="privacy-retention" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Data Retention</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We retain your personal data for as long as your account is active or as needed to provide
+          you with our services. Specifically:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li>Account data is retained for the duration of your account and for up to 90 days after deletion</li>
+          <li>Transaction records are retained for 7 years for tax and legal compliance</li>
+          <li>Analytics data is retained for 12 months, after which it is aggregated or deleted</li>
+          <li>Communications with support are retained for 2 years</li>
+        </ul>
+      </section>
+
+      {/* Your Rights */}
+      <section data-testid="privacy-rights" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Your Rights</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          Depending on your location, you may have the following rights regarding your personal data:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li><strong>Access:</strong> Request a copy of the personal data we hold about you</li>
+          <li><strong>Correction:</strong> Request that we correct inaccurate or incomplete data</li>
+          <li><strong>Deletion:</strong> Request that we delete your personal data (subject to legal retention requirements)</li>
+          <li><strong>Portability:</strong> Request your data in a machine-readable format</li>
+          <li><strong>Objection:</strong> Object to certain types of processing, including direct marketing</li>
+        </ul>
+        <p className="text-base leading-relaxed text-muted-text">
+          To exercise any of these rights, contact us at the address below. We will respond within
+          30 days.
+        </p>
+      </section>
+
+      {/* Contact */}
+      <section data-testid="privacy-contact" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Contact Us</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          If you have questions about this privacy policy or how we handle your data, please contact us:
+        </p>
+        <address className="not-italic text-base text-muted-text space-y-1">
+          <p>Surfaced Art</p>
+          <p>
+            Email:{' '}
+            <a href="mailto:privacy@surfacedart.com"
+               className="underline underline-offset-4 hover:text-foreground transition-colors">
+              privacy@surfacedart.com
+            </a>
+          </p>
+        </address>
+        <p className="text-base leading-relaxed text-muted-text">
+          We may update this policy from time to time. When we do, we will update the &ldquo;last
+          updated&rdquo; date at the top of this page and, where the changes are material, notify
+          you by email or a notice on the platform.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/(main)/terms/page.test.tsx
+++ b/apps/web/src/app/(main)/terms/page.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://surfacedart.com')
+vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.surfacedart.com')
+import { render, screen } from '@testing-library/react'
+
+import TermsPage, { metadata } from './page'
+
+describe('Terms of Service Page', () => {
+  it('should render the page heading', () => {
+    render(<TermsPage />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent(/terms of service/i)
+  })
+
+  it('should cover eligibility', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-eligibility')).toBeInTheDocument()
+  })
+
+  it('should cover account responsibilities', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-account')).toBeInTheDocument()
+  })
+
+  it('should cover commission structure', () => {
+    render(<TermsPage />)
+    const commissionSection = screen.getByTestId('terms-commission')
+    expect(commissionSection).toBeInTheDocument()
+    expect(commissionSection.textContent).toMatch(/30%/)
+  })
+
+  it('should cover prohibited conduct', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-prohibited')).toBeInTheDocument()
+  })
+
+  it('should cover IP ownership', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-ip')).toBeInTheDocument()
+  })
+
+  it('should cover dispute resolution', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-disputes')).toBeInTheDocument()
+  })
+
+  it('should cover limitation of liability', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-liability')).toBeInTheDocument()
+  })
+
+  it('should cover modification clause', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-modifications')).toBeInTheDocument()
+  })
+
+  it('should have correct metadata title', () => {
+    expect(metadata.title).toContain('Terms')
+  })
+
+  it('should have canonical URL in metadata', () => {
+    expect(metadata.alternates?.canonical).toBe('https://surfacedart.com/terms')
+  })
+
+  it('should have metadata description', () => {
+    expect(metadata.description).toBeDefined()
+    expect(typeof metadata.description).toBe('string')
+  })
+
+  it('should have data-testid on hero section', () => {
+    render(<TermsPage />)
+    expect(screen.getByTestId('terms-hero')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/(main)/terms/page.tsx
+++ b/apps/web/src/app/(main)/terms/page.tsx
@@ -1,0 +1,208 @@
+import type { Metadata } from 'next'
+import { JsonLd } from '@/components/JsonLd'
+import { Breadcrumbs } from '@/components/Breadcrumbs'
+import { SITE_URL } from '@/lib/site-config'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — Surfaced Art',
+  description:
+    'Read the Surfaced Art terms of service covering eligibility, account responsibilities, commission structure, prohibited conduct, and dispute resolution.',
+  alternates: {
+    canonical: `${SITE_URL}/terms`,
+  },
+  openGraph: {
+    title: 'Terms of Service — Surfaced Art',
+    description:
+      'Read the Surfaced Art terms of service covering eligibility, account responsibilities, commission structure, and more.',
+    type: 'website',
+    url: `${SITE_URL}/terms`,
+  },
+}
+
+export default function TermsPage() {
+  return (
+    <div className="space-y-12 md:space-y-16">
+      <JsonLd data={{
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: 'Terms of Service',
+        url: `${SITE_URL}/terms`,
+        description: metadata.description,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'Surfaced Art',
+          url: SITE_URL,
+        },
+      }} />
+
+      <Breadcrumbs items={[
+        { label: 'Home', href: '/' },
+        { label: 'Terms of Service' },
+      ]} />
+
+      {/* Hero */}
+      <section data-testid="terms-hero" className="max-w-2xl">
+        <h1 className="font-serif text-4xl tracking-tight text-foreground sm:text-5xl">
+          Terms of Service
+        </h1>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Last updated: March 2026
+        </p>
+        <p className="mt-6 text-lg leading-relaxed text-muted-text">
+          These Terms of Service (&ldquo;Terms&rdquo;) govern your use of the Surfaced Art platform
+          (&ldquo;Platform&rdquo;) operated by Surfaced Art (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or
+          &ldquo;our&rdquo;). By accessing or using the Platform, you agree to be bound by these Terms.
+        </p>
+      </section>
+
+      {/* Eligibility */}
+      <section data-testid="terms-eligibility" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Eligibility</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          You must be at least 18 years of age to use the Platform. By using the Platform, you represent
+          and warrant that you meet this requirement. If you are using the Platform on behalf of a
+          business or organization, you represent that you have the authority to bind that entity to
+          these Terms.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Artist accounts are by application only. Acceptance to sell on Surfaced Art is at our sole
+          discretion. We may revoke artist status at any time for violations of these Terms or our
+          community standards.
+        </p>
+      </section>
+
+      {/* Account Responsibilities */}
+      <section data-testid="terms-account" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Account Responsibilities</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          You are responsible for maintaining the confidentiality of your account credentials and for
+          all activity that occurs under your account. You agree to:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li>Provide accurate and complete information when creating your account</li>
+          <li>Keep your contact information and payment details up to date</li>
+          <li>Notify us immediately of any unauthorized access to your account</li>
+          <li>Not share your account credentials with any third party</li>
+          <li>Not create multiple accounts to circumvent restrictions or suspensions</li>
+        </ul>
+      </section>
+
+      {/* Commission Structure */}
+      <section data-testid="terms-commission" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Commission Structure</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          Surfaced Art charges a 30% commission on all sales completed through the Platform. This
+          commission is deducted automatically from the sale price before the remaining 70% is
+          disbursed to the artist.
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li>The commission rate applies to the listed price of the artwork, excluding shipping</li>
+          <li>Disbursements are processed via Stripe Connect on a rolling basis (typically within 2–7 business days after a sale clears)</li>
+          <li>We reserve the right to modify the commission rate with 30 days&rsquo; written notice to artists</li>
+          <li>Refunds processed by the Platform may result in commission clawbacks at our discretion</li>
+        </ul>
+      </section>
+
+      {/* Prohibited Conduct */}
+      <section data-testid="terms-prohibited" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Prohibited Conduct</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          You agree not to use the Platform to:
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-base text-muted-text pl-2">
+          <li>List or sell items that are not handmade by you personally (no dropshipping, no AI-generated works, no mass-produced items)</li>
+          <li>Misrepresent the nature, origin, or authenticity of any artwork</li>
+          <li>Infringe on the intellectual property rights of others</li>
+          <li>Engage in fraudulent, deceptive, or misleading practices</li>
+          <li>Harass, threaten, or harm other users of the Platform</li>
+          <li>Circumvent our payment systems or conduct transactions off-platform to avoid commission</li>
+          <li>Upload content that is illegal, obscene, or violates our community standards</li>
+          <li>Use the Platform in any way that could damage, disable, or impair the service</li>
+        </ul>
+        <p className="text-base leading-relaxed text-muted-text">
+          Violation of these prohibitions may result in immediate account suspension or termination
+          without refund of any fees.
+        </p>
+      </section>
+
+      {/* IP Ownership */}
+      <section data-testid="terms-ip" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Intellectual Property</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          Artists retain full ownership of the intellectual property rights in their artwork. By
+          listing on Surfaced Art, you grant us a limited, non-exclusive, royalty-free license to
+          display, reproduce, and distribute images of your artwork solely for the purpose of
+          operating and promoting the Platform.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          The Surfaced Art name, logo, and Platform design are our intellectual property. You may
+          not use them without our prior written permission. The sale of a physical artwork does not
+          transfer copyright or reproduction rights to the buyer unless explicitly stated in the
+          listing.
+        </p>
+      </section>
+
+      {/* Dispute Resolution */}
+      <section data-testid="terms-disputes" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Dispute Resolution</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          If a dispute arises between you and another user of the Platform, we encourage you to
+          resolve it directly. If you are unable to do so, you may contact us and we will attempt
+          to mediate in good faith, though we are under no obligation to do so.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Any dispute between you and Surfaced Art arising from or related to these Terms shall be
+          governed by the laws of the State of California, without regard to its conflict of law
+          provisions. You agree to submit to the exclusive jurisdiction of courts located in
+          San Francisco County, California for resolution of any such dispute.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Prior to filing any formal legal action, you agree to attempt to resolve disputes by
+          contacting us in writing and giving us 30 days to respond.
+        </p>
+      </section>
+
+      {/* Limitation of Liability */}
+      <section data-testid="terms-liability" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Limitation of Liability</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          To the maximum extent permitted by law, Surfaced Art and its officers, directors, employees,
+          and agents shall not be liable for any indirect, incidental, special, consequential, or
+          punitive damages arising from your use of or inability to use the Platform.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Our total liability to you for any claim arising out of or related to these Terms shall
+          not exceed the greater of (a) the total fees paid by you to us in the 12 months preceding
+          the claim, or (b) $100 USD.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          The Platform is provided &ldquo;as is&rdquo; and &ldquo;as available&rdquo; without warranties of any kind,
+          express or implied, including but not limited to implied warranties of merchantability,
+          fitness for a particular purpose, or non-infringement.
+        </p>
+      </section>
+
+      {/* Modifications */}
+      <section data-testid="terms-modifications" className="max-w-2xl space-y-4">
+        <h2 className="font-serif text-2xl text-foreground">Modifications to These Terms</h2>
+        <p className="text-base leading-relaxed text-muted-text">
+          We reserve the right to modify these Terms at any time. When we make changes, we will
+          update the &ldquo;last updated&rdquo; date at the top of this page. For material changes, we will
+          notify active users by email at least 14 days before the changes take effect.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Your continued use of the Platform after the effective date of any changes constitutes
+          your acceptance of the updated Terms. If you do not agree to the modified Terms, you must
+          stop using the Platform and may request account deletion.
+        </p>
+        <p className="text-base leading-relaxed text-muted-text">
+          Questions about these Terms? Contact us at{' '}
+          <a href="mailto:legal@surfacedart.com"
+             className="underline underline-offset-4 hover:text-foreground transition-colors">
+            legal@surfacedart.com
+          </a>.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -22,6 +22,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${SITE_URL}/privacy`,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/terms`,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+    {
       url: `${SITE_URL}/artists`,
       changeFrequency: 'daily',
       priority: 0.9,

--- a/apps/web/src/components/Footer.test.tsx
+++ b/apps/web/src/components/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://surfacedart.com')
+vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.surfacedart.com')
+import { render, screen } from '@testing-library/react'
+
+import { Footer } from './Footer'
+
+describe('Footer', () => {
+  it('should render a link to the privacy policy page', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /privacy policy/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/privacy')
+  })
+
+  it('should render a link to the terms of service page', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /terms of service/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/terms')
+  })
+})

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -101,11 +101,25 @@ export function Footer() {
           </div>
         </div>
 
-        {/* Copyright */}
-        <div className="mt-16 border-t border-border pt-8">
+        {/* Copyright and legal links */}
+        <div className="mt-16 border-t border-border pt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
           <p className="text-xs text-muted-foreground/60 text-center">
             &copy; {currentYear} Surfaced Art. All rights reserved.
           </p>
+          <nav className="flex gap-4">
+            <Link
+              href="/privacy"
+              className="text-xs text-muted-foreground/60 transition-colors hover:text-foreground"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="/terms"
+              className="text-xs text-muted-foreground/60 transition-colors hover:text-foreground"
+            >
+              Terms of Service
+            </Link>
+          </nav>
         </div>
       </Container>
     </footer>


### PR DESCRIPTION
## Summary

- Adds `/privacy` page with full privacy policy content
- Adds `/terms` page with full terms of service content
- Adds both routes to sitemap
- Adds Privacy Policy and Terms of Service links to the footer

## What was implemented

**`/privacy` page** covers all required topics:
- Data collected (account info, artist profile data, transaction data, communications)
- Third-party services: PostHog, Stripe, AWS, Vercel — each with links to their own privacy policies
- Cookies and analytics (session cookies + PostHog analytics)
- Data retention (account: 90 days post-deletion, transactions: 7 years, analytics: 12 months, comms: 2 years)
- Deletion rights and full GDPR-adjacent rights (access, correction, deletion, portability, objection)
- Contact info (privacy@surfacedart.com)

**`/terms` page** covers all required topics:
- Eligibility (18+, artist accounts by application)
- Account responsibilities
- Commission structure (30%, disbursement via Stripe Connect, 30-day notice for rate changes)
- Prohibited conduct (no dropshipping, no AI art, no circumventing payments, etc.)
- IP ownership (artists retain copyright; platform gets limited display license)
- Dispute resolution (California law, San Francisco County courts, 30-day pre-suit notice)
- Limitation of liability (consequential damages excluded, cap at fees paid or $100)
- Modification clause (14-day email notice for material changes)

Both pages follow the same patterns as `/about`:
- Static `metadata` export with `title`, `description`, `alternates.canonical`, and `openGraph`
- `<JsonLd>` with `WebPage` schema
- `<Breadcrumbs>` with home → page hierarchy
- `data-testid` on every major section
- Max-width prose layout matching existing content pages

**Footer**: Privacy Policy and Terms of Service links added to the copyright bar (right side, responsive).

**Sitemap**: Both routes added with `changeFrequency: 'yearly'` and `priority: 0.3`.

## Tests

26 new tests across 3 files:
- `apps/web/src/app/(main)/privacy/page.test.tsx` — 11 tests (all sections present, metadata, canonical URL)
- `apps/web/src/app/(main)/terms/page.test.tsx` — 13 tests (all sections present, 30% commission text, metadata, canonical URL)
- `apps/web/src/components/Footer.test.tsx` — 2 tests (Privacy Policy link, Terms of Service link with correct hrefs)

All 441 tests pass. Lint and typecheck clean. Build succeeds with `/privacy` and `/terms` as static pages.

## Notes

Content was drafted for startup legal review as described in the issue. This is a solid starting point for attorney review — it covers all the required topics and reflects the platform's actual architecture (PostHog, Stripe, AWS, Vercel).

Closes #347