### PR TITLE
feat(web): use hyphenated SEO-friendly category URLs

### DIFF
--- a/apps/web/e2e/visual-qa/page-rendering.spec.ts
+++ b/apps/web/e2e/visual-qa/page-rendering.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test'
 const SEED_ARTIST = { slug: 'abbey-peters', displayName: 'Abbey Peters' }
 
 // Two categories: one known-populated, one that may be empty — covers both data shapes
-const CATEGORIES = ['ceramics', 'drawing_painting']
+const CATEGORIES = ['ceramics', 'drawing-painting']
 
 test.describe('Page Rendering — Homepage', () => {
   test('homepage renders with all sections', async ({ page }) => {

--- a/apps/web/e2e/visual-qa/runtime-health.spec.ts
+++ b/apps/web/e2e/visual-qa/runtime-health.spec.ts
@@ -12,7 +12,7 @@ const PAGES = [
   { name: 'homepage', path: '/' },
   { name: 'artist-abbey-peters', path: '/artist/abbey-peters' },
   { name: 'category-ceramics', path: '/category/ceramics' },
-  { name: 'category-drawing-painting', path: '/category/drawing_painting' },
+  { name: 'category-drawing-painting', path: '/category/drawing-painting' },
 ]
 
 test.describe('Runtime Health — Console Errors', () => {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,6 +14,23 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      // Old 9-category URLs → new 4-category URLs (permanent redirects)
+      { source: "/category/painting", destination: "/category/drawing-painting", permanent: true },
+      { source: "/category/illustration", destination: "/category/drawing-painting", permanent: true },
+      { source: "/category/print", destination: "/category/printmaking-photography", permanent: true },
+      { source: "/category/photography", destination: "/category/printmaking-photography", permanent: true },
+      { source: "/category/jewelry", destination: "/category/mixed-media-3d", permanent: true },
+      { source: "/category/woodworking", destination: "/category/mixed-media-3d", permanent: true },
+      { source: "/category/fibers", destination: "/category/mixed-media-3d", permanent: true },
+      { source: "/category/mixed_media", destination: "/category/mixed-media-3d", permanent: true },
+      // Old underscore URLs → new hyphenated URLs
+      { source: "/category/drawing_painting", destination: "/category/drawing-painting", permanent: true },
+      { source: "/category/printmaking_photography", destination: "/category/printmaking-photography", permanent: true },
+      { source: "/category/mixed_media_3d", destination: "/category/mixed-media-3d", permanent: true },
+    ];
+  },
   async headers() {
     return [
       {

--- a/apps/web/src/app/(main)/category/[category]/page.tsx
+++ b/apps/web/src/app/(main)/category/[category]/page.tsx
@@ -6,12 +6,9 @@ import { CategoryBrowseView, type CategoryListingItem } from '@/components/Categ
 import { JsonLd } from '@/components/JsonLd'
 import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { SITE_URL } from '@/lib/site-config'
-import { Category } from '@surfaced-art/types'
-import type { CategoryType } from '@surfaced-art/types'
+import { urlSlugToCategory, categoryToUrlSlug } from '@/lib/category-slugs'
 
 export const revalidate = 60
-
-const validCategories = new Set(Object.values(Category))
 
 // Return empty array so no category pages are pre-rendered at build time.
 // Pages render on first visitor request and are cached via ISR (revalidate = 60).
@@ -25,22 +22,24 @@ type Props = {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { category } = await params
-  if (!validCategories.has(category as CategoryType)) {
+  const { category: urlSlug } = await params
+  const categorySlug = urlSlugToCategory(urlSlug)
+  if (!categorySlug) {
     return { title: 'Category — Surfaced Art' }
   }
-  const label = categoryLabels[category as CategoryType]
+  const label = categoryLabels[categorySlug]
+  const canonicalSlug = categoryToUrlSlug(categorySlug)
   return {
     title: `${label} — Surfaced Art`,
     description: `Browse handmade ${label.toLowerCase()} from vetted artists on Surfaced Art.`,
     alternates: {
-      canonical: `/category/${category}`,
+      canonical: `/category/${canonicalSlug}`,
     },
     openGraph: {
       title: `${label} — Surfaced Art`,
       description: `Browse handmade ${label.toLowerCase()} from vetted artists on Surfaced Art.`,
       type: 'website',
-      url: `${SITE_URL}/category/${category}`,
+      url: `${SITE_URL}/category/${canonicalSlug}`,
       images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
     },
     twitter: {
@@ -50,13 +49,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function CategoryBrowsePage({ params }: Props) {
-  const { category } = await params
+  const { category: urlSlug } = await params
+  const categorySlug = urlSlugToCategory(urlSlug)
 
-  if (!validCategories.has(category as CategoryType)) {
+  if (!categorySlug) {
     notFound()
   }
 
-  const categorySlug = category as CategoryType
   const label = categoryLabels[categorySlug]
 
   let listings: CategoryListingItem[] = []
@@ -98,6 +97,8 @@ export default async function CategoryBrowsePage({ params }: Props) {
     }
   }
 
+  const canonicalSlug = categoryToUrlSlug(categorySlug)
+
   return (
     <div className="space-y-8">
       <JsonLd data={{
@@ -105,7 +106,7 @@ export default async function CategoryBrowsePage({ params }: Props) {
         '@type': 'CollectionPage',
         name: `${label} — Surfaced Art`,
         description: `Browse handmade ${label.toLowerCase()} from vetted artists on Surfaced Art.`,
-        url: `${SITE_URL}/category/${categorySlug}`,
+        url: `${SITE_URL}/category/${canonicalSlug}`,
       }} />
       <Breadcrumbs items={[
         { label: 'Home', href: '/' },

--- a/apps/web/src/app/api/revalidate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/revalidate/__tests__/route.test.ts
@@ -101,7 +101,7 @@ describe('POST /api/revalidate', () => {
       expect(body.revalidated).toContain('/')
       // Should include all category pages
       for (const cat of CATEGORIES) {
-        expect(body.revalidated).toContain(`/category/${cat.slug}`)
+        expect(body.revalidated).toContain(cat.href)
       }
       const categoryPaths = body.revalidated.filter((p: string) => p.startsWith('/category/'))
       expect(categoryPaths).toHaveLength(CATEGORIES.length)
@@ -125,7 +125,7 @@ describe('POST /api/revalidate', () => {
       expect(body.revalidated).toContain('/')
       expect(body.revalidated).toContain('/category/ceramics')
       // Should NOT include other category pages
-      expect(body.revalidated).not.toContain('/category/drawing_painting')
+      expect(body.revalidated).not.toContain('/category/drawing-painting')
     })
 
     it('should revalidate all category pages when category is not specified', async () => {
@@ -136,7 +136,7 @@ describe('POST /api/revalidate', () => {
       const body = await response.json()
       const categoryPaths = body.revalidated.filter((p: string) => p.startsWith('/category/'))
       expect(categoryPaths).toEqual(
-        expect.arrayContaining(CATEGORIES.map((cat) => `/category/${cat.slug}`))
+        expect.arrayContaining(CATEGORIES.map((cat) => cat.href))
       )
       expect(categoryPaths).toHaveLength(CATEGORIES.length)
     })

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { CATEGORIES } from '@/lib/categories'
+import { categoryToUrlSlug } from '@/lib/category-slugs'
+import type { CategoryType } from '@surfaced-art/types'
 
 export async function POST(request: Request) {
   const secret = process.env.REVALIDATION_SECRET
@@ -35,20 +37,23 @@ export async function POST(request: Request) {
     revalidatePath('/')
     revalidated.push(`/artist/${body.slug}`, '/')
     for (const cat of CATEGORIES) {
-      revalidatePath(`/category/${cat.slug}`)
-      revalidated.push(`/category/${cat.slug}`)
+      const urlSlug = categoryToUrlSlug(cat.slug)
+      revalidatePath(`/category/${urlSlug}`)
+      revalidated.push(`/category/${urlSlug}`)
     }
   } else if (body.type === 'listing' && body.id) {
     revalidatePath(`/listing/${body.id}`)
     revalidatePath('/')
     revalidated.push(`/listing/${body.id}`, '/')
     if (body.category) {
-      revalidatePath(`/category/${body.category}`)
-      revalidated.push(`/category/${body.category}`)
+      const urlSlug = categoryToUrlSlug(body.category as CategoryType)
+      revalidatePath(`/category/${urlSlug}`)
+      revalidated.push(`/category/${urlSlug}`)
     } else {
       for (const cat of CATEGORIES) {
-        revalidatePath(`/category/${cat.slug}`)
-        revalidated.push(`/category/${cat.slug}`)
+        const urlSlug = categoryToUrlSlug(cat.slug)
+        revalidatePath(`/category/${urlSlug}`)
+        revalidated.push(`/category/${urlSlug}`)
       }
     }
   } else if (body.type === 'all') {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -37,7 +37,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     ...CATEGORIES.map((cat) => ({
-      url: `${SITE_URL}/category/${cat.slug}`,
+      url: `${SITE_URL}${cat.href}`,
       changeFrequency: 'daily' as const,
       priority: 0.8,
     })),

--- a/apps/web/src/components/CategoryFilterBar.tsx
+++ b/apps/web/src/components/CategoryFilterBar.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import type { CategoryType } from '@surfaced-art/types'
 import { CATEGORIES } from '@/lib/categories'
+import { categoryToUrlSlug } from '@/lib/category-slugs'
 import { cn } from '@/lib/utils'
 
 type CategoryFilterBarProps = {
@@ -22,7 +23,7 @@ export function CategoryFilterBar({
   'data-testid': testId = 'category-nav',
   className,
 }: CategoryFilterBarProps) {
-  const buildHref = hrefBuilder ?? ((slug: CategoryType) => `${basePath}/${slug}`)
+  const buildHref = hrefBuilder ?? ((slug: CategoryType) => `${basePath}/${categoryToUrlSlug(slug)}`)
 
   const pillBase = 'rounded-md px-3 py-1.5 text-sm transition-colors'
   const activeClasses = 'bg-accent-primary text-white'

--- a/apps/web/src/components/__tests__/CategoryFilterBar.test.tsx
+++ b/apps/web/src/components/__tests__/CategoryFilterBar.test.tsx
@@ -27,7 +27,7 @@ describe('CategoryFilterBar', () => {
     render(<CategoryFilterBar activeCategory="ceramics" />)
 
     const link = screen.getByRole('link', { name: 'Drawing & Painting' })
-    expect(link).toHaveAttribute('href', '/category/drawing_painting')
+    expect(link).toHaveAttribute('href', '/category/drawing-painting')
   })
 
   it('should use custom hrefBuilder when provided', () => {

--- a/apps/web/src/components/__tests__/MobileNav.test.tsx
+++ b/apps/web/src/components/__tests__/MobileNav.test.tsx
@@ -34,7 +34,7 @@ describe('MobileNav', () => {
   })
 
   it('should highlight the active category', async () => {
-    mockPathname = '/category/drawing_painting'
+    mockPathname = '/category/drawing-painting'
     render(<MobileNav />)
     await userEvent.click(screen.getByRole('button', { name: 'Menu' }))
 
@@ -44,7 +44,7 @@ describe('MobileNav', () => {
   })
 
   it('should not highlight inactive categories', async () => {
-    mockPathname = '/category/drawing_painting'
+    mockPathname = '/category/drawing-painting'
     render(<MobileNav />)
     await userEvent.click(screen.getByRole('button', { name: 'Menu' }))
 

--- a/apps/web/src/components/__tests__/Navigation.test.tsx
+++ b/apps/web/src/components/__tests__/Navigation.test.tsx
@@ -49,7 +49,7 @@ describe('Navigation', () => {
   })
 
   it('should highlight the active category when on a category page', () => {
-    mockPathname = '/category/drawing_painting'
+    mockPathname = '/category/drawing-painting'
     render(<Navigation />)
 
     const activeLink = screen.getByRole('link', { name: 'Drawing & Painting' })

--- a/apps/web/src/lib/__tests__/category-slugs.test.ts
+++ b/apps/web/src/lib/__tests__/category-slugs.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { categoryToUrlSlug, urlSlugToCategory } from '../category-slugs'
+import { Category } from '@surfaced-art/types'
+
+describe('categoryToUrlSlug', () => {
+  it('should convert ceramics (no change needed)', () => {
+    expect(categoryToUrlSlug('ceramics')).toBe('ceramics')
+  })
+
+  it('should convert drawing_painting to drawing-painting', () => {
+    expect(categoryToUrlSlug('drawing_painting')).toBe('drawing-painting')
+  })
+
+  it('should convert printmaking_photography to printmaking-photography', () => {
+    expect(categoryToUrlSlug('printmaking_photography')).toBe('printmaking-photography')
+  })
+
+  it('should convert mixed_media_3d to mixed-media-3d', () => {
+    expect(categoryToUrlSlug('mixed_media_3d')).toBe('mixed-media-3d')
+  })
+
+  it('should handle all Category enum values', () => {
+    for (const cat of Object.values(Category)) {
+      const urlSlug = categoryToUrlSlug(cat)
+      expect(urlSlug).not.toContain('_')
+    }
+  })
+})
+
+describe('urlSlugToCategory', () => {
+  it('should convert ceramics (no change needed)', () => {
+    expect(urlSlugToCategory('ceramics')).toBe('ceramics')
+  })
+
+  it('should convert drawing-painting to drawing_painting', () => {
+    expect(urlSlugToCategory('drawing-painting')).toBe('drawing_painting')
+  })
+
+  it('should convert printmaking-photography to printmaking_photography', () => {
+    expect(urlSlugToCategory('printmaking-photography')).toBe('printmaking_photography')
+  })
+
+  it('should convert mixed-media-3d to mixed_media_3d', () => {
+    expect(urlSlugToCategory('mixed-media-3d')).toBe('mixed_media_3d')
+  })
+
+  it('should return undefined for invalid slugs', () => {
+    expect(urlSlugToCategory('nonexistent')).toBeUndefined()
+    expect(urlSlugToCategory('painting')).toBeUndefined()
+    expect(urlSlugToCategory('jewelry')).toBeUndefined()
+  })
+
+  it('should roundtrip all Category values', () => {
+    for (const cat of Object.values(Category)) {
+      const urlSlug = categoryToUrlSlug(cat)
+      expect(urlSlugToCategory(urlSlug)).toBe(cat)
+    }
+  })
+})

--- a/apps/web/src/lib/categories.ts
+++ b/apps/web/src/lib/categories.ts
@@ -1,4 +1,5 @@
 import type { CategoryType } from '@surfaced-art/types'
+import { categoryToUrlSlug } from './category-slugs'
 
 export interface CategoryLink {
   label: string
@@ -9,10 +10,13 @@ export interface CategoryLink {
 /**
  * All 4 art categories with display labels and URL paths.
  * Used by Header navigation, Footer links, and category pages.
+ *
+ * Note: `slug` is the CategoryType enum value (underscored).
+ * `href` uses hyphenated URL slugs for SEO-friendly URLs.
  */
 export const CATEGORIES: CategoryLink[] = [
-  { label: 'Ceramics', slug: 'ceramics', href: '/category/ceramics' },
-  { label: 'Drawing & Painting', slug: 'drawing_painting', href: '/category/drawing_painting' },
-  { label: 'Printmaking & Photography', slug: 'printmaking_photography', href: '/category/printmaking_photography' },
-  { label: 'Mixed Media & 3D', slug: 'mixed_media_3d', href: '/category/mixed_media_3d' },
+  { label: 'Ceramics', slug: 'ceramics', href: `/category/${categoryToUrlSlug('ceramics')}` },
+  { label: 'Drawing & Painting', slug: 'drawing_painting', href: `/category/${categoryToUrlSlug('drawing_painting')}` },
+  { label: 'Printmaking & Photography', slug: 'printmaking_photography', href: `/category/${categoryToUrlSlug('printmaking_photography')}` },
+  { label: 'Mixed Media & 3D', slug: 'mixed_media_3d', href: `/category/${categoryToUrlSlug('mixed_media_3d')}` },
 ]

--- a/apps/web/src/lib/category-slugs.ts
+++ b/apps/web/src/lib/category-slugs.ts
@@ -1,0 +1,25 @@
+import { Category } from '@surfaced-art/types'
+import type { CategoryType } from '@surfaced-art/types'
+
+const validCategories = new Set(Object.values(Category))
+
+/**
+ * Convert a CategoryType enum value (underscored) to a URL-friendly slug (hyphenated).
+ * e.g., 'drawing_painting' → 'drawing-painting'
+ */
+export function categoryToUrlSlug(category: CategoryType): string {
+  return category.replace(/_/g, '-')
+}
+
+/**
+ * Convert a URL slug (hyphenated) back to a CategoryType enum value (underscored).
+ * Returns undefined if the slug doesn't map to a valid category.
+ * e.g., 'drawing-painting' → 'drawing_painting'
+ */
+export function urlSlugToCategory(slug: string): CategoryType | undefined {
+  const candidate = slug.replace(/-/g, '_')
+  if (validCategories.has(candidate as CategoryType)) {
+    return candidate as CategoryType
+  }
+  return undefined
+}

--- a/tools/artist-scraper/src/extraction/claude-extract.ts
+++ b/tools/artist-scraper/src/extraction/claude-extract.ts
@@ -234,7 +234,7 @@ async function suggestCategoriesWithClaude(
     max_tokens: 256,
     system: `You are classifying an artist into platform categories.
 
-Available categories: ceramics, painting, print, jewelry, illustration, photography, woodworking, fibers, mixed_media
+Available categories: ceramics, drawing_painting, printmaking_photography, mixed_media_3d
 
 Return a JSON array of 1-3 category strings that best describe this artist's work. Return ONLY the JSON array.`,
     messages: [
@@ -254,8 +254,7 @@ Return a JSON array of 1-3 category strings that best describe this artist's wor
   try {
     const parsed = JSON.parse(jsonMatch[0]) as string[]
     const validCategories: CategoryType[] = [
-      'ceramics', 'painting', 'print', 'jewelry', 'illustration',
-      'photography', 'woodworking', 'fibers', 'mixed_media',
+      'ceramics', 'drawing_painting', 'printmaking_photography', 'mixed_media_3d',
     ]
     return parsed.filter((c) => validCategories.includes(c as CategoryType)) as CategoryType[]
   } catch {


### PR DESCRIPTION
## Summary

- Add `category-slugs.ts` helpers to convert between enum values (`drawing_painting`) and URL slugs (`drawing-painting`)
- Update all category page URLs to use hyphenated format for better SEO
- Add 11 permanent redirects in `next.config.ts` for old 9-category URLs and old underscore URLs
- Update category page routing, sitemap, revalidation route, and CategoryFilterBar to use hyphenated URLs
- Update Navigation/MobileNav active state detection for new URL format
- Fix artist-scraper category references for 4-category system
- 11 new tests for slug conversion helpers; all existing tests updated

## Changes

| Area | What changed |
|------|-------------|
| `category-slugs.ts` | New module: `categoryToUrlSlug()` and `urlSlugToCategory()` |
| `categories.ts` | `href` now uses hyphenated URL slugs |
| `next.config.ts` | 11 permanent redirects for old category URLs |
| `category/[category]/page.tsx` | Converts hyphenated URL param to enum value |
| `revalidate/route.ts` | Uses hyphenated URLs for category revalidation paths |
| `sitemap.ts` | Uses `cat.href` for category URLs |
| `CategoryFilterBar.tsx` | Default href builder uses `categoryToUrlSlug` |
| E2E + unit tests | All updated to hyphenated URLs |
| `artist-scraper` | Updated to 4-category enum values |

## Test plan

- [x] 11 new `category-slugs.test.ts` tests (roundtrip, edge cases, invalid slugs)
- [x] All 452 tests pass
- [x] Lint passes
- [x] Typecheck passes
- [x] Build passes
- [x] Verified no remaining underscore category URL references in source or tests

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)