### PR TITLE
fix(db): avoid subquery in ALTER COLUMN USING for artist_applications

### DIFF
--- a/packages/db/prisma/migrations/20260307000000_categories_tags_restructure/migration.sql
+++ b/packages/db/prisma/migrations/20260307000000_categories_tags_restructure/migration.sql
@@ -51,18 +51,24 @@ ALTER TABLE "listings" ALTER COLUMN "category" TYPE "CategoryType_new" USING (
   END
 )::"CategoryType_new";
 
-ALTER TABLE "artist_applications" ALTER COLUMN "categories" TYPE "CategoryType_new"[] USING (
-  ARRAY(
-    SELECT DISTINCT (CASE
-      WHEN cat::text = 'ceramics' THEN 'ceramics'
-      WHEN cat::text IN ('painting', 'illustration') THEN 'drawing_painting'
-      WHEN cat::text IN ('print', 'photography') THEN 'printmaking_photography'
-      WHEN cat::text IN ('jewelry', 'woodworking', 'fibers', 'mixed_media') THEN 'mixed_media_3d'
-      ELSE cat::text
-    END)::"CategoryType_new"
-    FROM unnest("categories") AS cat
-  )
-);
+-- artist_applications: PostgreSQL doesn't allow subqueries in USING, so
+-- first cast the column to text[], UPDATE with mapped values, then cast to new enum[].
+ALTER TABLE "artist_applications" ALTER COLUMN "categories" TYPE text[] USING ("categories"::text[]);
+
+UPDATE "artist_applications"
+SET "categories" = (
+  SELECT array_agg(DISTINCT CASE
+    WHEN cat = 'ceramics' THEN 'ceramics'
+    WHEN cat IN ('painting', 'illustration') THEN 'drawing_painting'
+    WHEN cat IN ('print', 'photography') THEN 'printmaking_photography'
+    WHEN cat IN ('jewelry', 'woodworking', 'fibers', 'mixed_media') THEN 'mixed_media_3d'
+    ELSE cat
+  END)
+  FROM unnest("categories") AS cat
+)
+WHERE array_length("categories", 1) > 0;
+
+ALTER TABLE "artist_applications" ALTER COLUMN "categories" TYPE "CategoryType_new"[] USING ("categories"::"CategoryType_new"[]);
 
 -- Step 4: Drop old enum and rename new one
 DROP TYPE "CategoryType";


### PR DESCRIPTION
## Summary
- Fixes the second migration failure (P3018/0A000) where PostgreSQL rejected `ARRAY(SELECT ...)` inside `ALTER COLUMN ... USING`
- Splits the `artist_applications.categories` type change into 3 steps: cast to `text[]`, UPDATE with mapped values, then cast to `CategoryType_new[]`

## Recovery steps after merge
The dev database is in a dirty state from previous failed migration attempts. After this deploys:

```bash
echo '{"command":"force-reapply-baseline"}' > "$USERPROFILE/migrate-payload.json"
MSYS_NO_PATHCONV=1 aws lambda invoke --function-name surfaced-art-dev-migrate --payload "fileb://$USERPROFILE/migrate-payload.json" "$USERPROFILE/migrate-response.json" && cat "$USERPROFILE/migrate-response.json"
```

## Test plan
- [x] All tests pass
- [x] Lint errors are pre-existing (for-artists-prototype-v5/v7), not from this change
- [ ] After merge + deploy: run `force-reapply-baseline` to wipe and rebuild dev DB
- [ ] Verify migration applies cleanly from scratch