### PR TITLE
feat(web): condensed navbar with scroll animation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -170,6 +170,10 @@
     }
   }
 
+  html {
+    overflow-x: hidden;
+  }
+
   body {
     background-color: var(--background);
     color: var(--foreground);

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { Navigation } from './Navigation'
 import { MobileNav } from './MobileNav'
@@ -6,26 +9,57 @@ import { ThemeToggle } from './ThemeToggle'
 import { AuthButton } from './AuthButton'
 import { Wordmark } from './Wordmark'
 import { Container } from './ui/container'
+import { cn } from '@/lib/utils'
+
+const SCROLL_THRESHOLD = 50
 
 /**
  * Global site header with brand name, category navigation, and mobile menu.
  *
  * Layout:
- * - Top bar: brand name (left), future sign-in placeholder (right), mobile hamburger (right on small screens)
+ * - Top bar: brand name (left), sign-in + search + theme toggle (right), mobile hamburger (right on small screens)
  * - Below top bar: horizontal category nav (desktop only)
+ *
+ * On scroll, the header condenses: wordmark shrinks, vertical padding reduces,
+ * and categories tuck closer to the top.
  */
 export function Header() {
+  const [isCondensed, setIsCondensed] = useState(false)
+
+  useEffect(() => {
+    function handleScroll() {
+      setIsCondensed(window.scrollY > SCROLL_THRESHOLD)
+    }
+
+    // Check initial scroll position (e.g. page refresh mid-scroll)
+    handleScroll()
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
   return (
-    <header data-testid="site-header" className="sticky top-0 z-30 bg-background/95 backdrop-blur-sm">
+    <header
+      data-testid="site-header"
+      className={cn(
+        'sticky top-0 z-30 bg-background/95 backdrop-blur-sm transition-all duration-300',
+        isCondensed && 'shadow-sm'
+      )}
+    >
       {/* Top bar */}
       <Container>
-        <div className="flex items-center justify-between h-16 md:h-20">
+        <div
+          className={cn(
+            'flex items-center justify-between transition-all duration-300',
+            isCondensed ? 'h-10 md:h-11' : 'h-12 md:h-14'
+          )}
+        >
           {/* Brand wordmark */}
           <Link
             href="/"
             className="hover:opacity-80 transition-opacity"
           >
-            <Wordmark size="nav" />
+            <Wordmark size={isCondensed ? 'nav-condensed' : 'nav'} />
           </Link>
 
           {/* Right side: search + auth + theme toggle + mobile nav */}
@@ -43,7 +77,7 @@ export function Header() {
       </Container>
 
       {/* Desktop category navigation */}
-      <Navigation />
+      <Navigation condensed={isCondensed} />
     </header>
   )
 }

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -6,12 +6,16 @@ import { CATEGORIES } from '@/lib/categories'
 import { cn } from '@/lib/utils'
 import { Container } from './ui/container'
 
+type NavigationProps = {
+  condensed?: boolean
+}
+
 /**
  * Desktop category navigation bar.
- * Renders all 9 art categories as horizontal links with active state.
+ * Renders all 4 art categories as horizontal links with active state.
  * Hidden on mobile (use MobileNav instead).
  */
-export function Navigation() {
+export function Navigation({ condensed = false }: NavigationProps) {
   const pathname = usePathname()
 
   return (
@@ -31,7 +35,8 @@ export function Navigation() {
                   href={category.href}
                   aria-current={isActive ? 'page' : undefined}
                   className={cn(
-                    'inline-block whitespace-nowrap text-sm tracking-wide transition-colors py-3',
+                    'inline-block whitespace-nowrap text-sm tracking-wide transition-all duration-300',
+                    condensed ? 'py-1.5' : 'py-2.5',
                     isActive
                       ? 'text-foreground border-b-2 border-accent-primary'
                       : 'text-muted-foreground hover:text-foreground'

--- a/apps/web/src/components/Wordmark.tsx
+++ b/apps/web/src/components/Wordmark.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils'
 
 const sizeClasses = {
   nav: 'text-xl',
+  'nav-condensed': 'text-base',
   hero: 'text-[32px]',
 } as const
 


### PR DESCRIPTION
## Summary
- Reduce default header height for a more compact look (`h-12 md:h-14` down from `h-16 md:h-20`)
- Animate header to a further condensed state on scroll: smaller wordmark, tighter category nav padding, subtle shadow
- Fix horizontal scrollbar on Windows caused by `100vw` in the `.full-bleed` CSS utility (`overflow-x: hidden` on `html`)

## Test plan
- [ ] Verify header is more compact on page load
- [ ] Scroll down and confirm smooth transition: wordmark shrinks, categories tuck tighter, shadow appears
- [ ] Scroll back to top and confirm it expands back
- [ ] Verify no horizontal scrollbar on Windows (or any OS)
- [ ] Check mobile — condensed behavior works, hamburger menu still functions
- [ ] Existing Header and Navigation tests still pass