### PR TITLE
fix(db): update stale category value in illustration seed data

### DIFF
--- a/packages/db/prisma/seed-data/demo/illustration.ts
+++ b/packages/db/prisma/seed-data/demo/illustration.ts
@@ -154,7 +154,7 @@ const isaiahConfig: ArtistSeedConfig = {
       title: 'Motown Session',
       description: 'Three-color screenprint of musicians in a recording studio, inspired by the artist\'s visits to the Motown Museum. Printed in black, gold, and deep blue on heavyweight cream paper. Edition of twenty-five.',
       medium: 'screenprint on cotton rag, edition of 25',
-      category: 'print',
+      category: 'printmaking_photography',
       price: 8500,
       status: 'available',
       isDocumented: false,


### PR DESCRIPTION
## Summary
- Changes `'print'` to `'printmaking_photography'` in illustration seed data — last remaining old enum value causing seed failures on dev

## Context
The categories/tags migration (#396, #397) changed the enum from 9 values to 4, but this one seed data value was missed. The dev database migration is applied successfully but seeding fails.

## Test plan
- [ ] After merge + deploy: seed should succeed automatically in the pipeline
- [ ] If seed step in pipeline still fails, manually run: `echo '{"command":"seed"}' > "$USERPROFILE/migrate-payload.json" && MSYS_NO_PATHCONV=1 aws lambda invoke --function-name surfaced-art-dev-migrate --payload "fileb://$USERPROFILE/migrate-payload.json" "$USERPROFILE/migrate-response.json" && cat "$USERPROFILE/migrate-response.json"`