### PR TITLE
fix(web): make SplitHero env-aware and use demo artist images

### DIFF
--- a/apps/web/src/components/SplitHero.tsx
+++ b/apps/web/src/components/SplitHero.tsx
@@ -2,27 +2,36 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 
-const HERO_IMAGES = [
+function getCloudfrontDomain(): string {
+  return process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN || ''
+}
+
+const HERO_IMAGE_PATHS = [
   {
-    src: 'https://dmfu4c7s6z2cc.cloudfront.net/uploads/seed/artists/abbey-peters/cover/1200w.webp',
-    alt: 'Ceramics studio of Abbey Peters with handmade stoneware',
+    path: 'uploads/seed/artists/elena-cordova/cover/1200w.webp',
+    alt: 'Oil paintings by Elena Cordova inspired by the desert landscape',
   },
   {
-    src: 'https://dmfu4c7s6z2cc.cloudfront.net/uploads/seed/artists/david-morrison/cover/1200w.webp',
-    alt: 'Woodworking studio of David Morrison',
+    path: 'uploads/seed/artists/james-okafor/cover/1200w.webp',
+    alt: 'Bold acrylic paintings by James Okafor',
   },
   {
-    src: 'https://dmfu4c7s6z2cc.cloudfront.net/uploads/seed/artists/karina-yanes/cover/1200w.webp',
-    alt: 'Artwork by Karina Yanes',
+    path: 'uploads/seed/artists/tomoko-ishida/cover/1200w.webp',
+    alt: 'Silver gelatin photography by Tomoko Ishida',
   },
   {
-    src: 'https://dmfu4c7s6z2cc.cloudfront.net/uploads/seed/artists/abbey-peters/process/studio/1200w.webp',
-    alt: 'Abbey Peters working in her ceramics studio',
+    path: 'uploads/seed/artists/amara-osei/process/studio/1200w.webp',
+    alt: 'Amara Osei working in her jewelry studio',
   },
 ]
 
 function pickHeroImage() {
-  return HERO_IMAGES[Math.floor(Math.random() * HERO_IMAGES.length)]
+  const entry = HERO_IMAGE_PATHS[Math.floor(Math.random() * HERO_IMAGE_PATHS.length)]
+  const domain = getCloudfrontDomain()
+  return {
+    src: domain ? `https://${domain}/${entry.path}` : `/${entry.path}`,
+    alt: entry.alt,
+  }
 }
 
 export function SplitHero() {

--- a/apps/web/src/components/__tests__/SplitHero.test.tsx
+++ b/apps/web/src/components/__tests__/SplitHero.test.tsx
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { SplitHero } from '../SplitHero'
 
 describe('SplitHero', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN = 'test.cloudfront.net'
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN
+    vi.restoreAllMocks()
+  })
+
   it('should render the hero section with data-testid', () => {
     render(<SplitHero />)
     expect(screen.getByTestId('hero')).toBeInTheDocument()
@@ -15,10 +24,33 @@ describe('SplitHero', () => {
     ).toBeInTheDocument()
   })
 
-  it('should render an artwork image', () => {
+  it('should render an artwork image with env-aware CDN URL', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
     render(<SplitHero />)
     const images = screen.getAllByRole('img')
     expect(images.length).toBeGreaterThanOrEqual(1)
+    expect(images[0]).toHaveAttribute(
+      'src',
+      expect.stringContaining('test.cloudfront.net')
+    )
+  })
+
+  it('should not contain hardcoded prod CloudFront URLs', () => {
+    render(<SplitHero />)
+    const images = screen.getAllByRole('img')
+    for (const img of images) {
+      expect(img.getAttribute('src')).not.toContain('dmfu4c7s6z2cc.cloudfront.net')
+    }
+  })
+
+  it('should use demo artist slugs, not real artist slugs', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    render(<SplitHero />)
+    const img = screen.getAllByRole('img')[0]
+    const src = img.getAttribute('src') || ''
+    expect(src).not.toContain('abbey-peters')
+    expect(src).not.toContain('david-morrison')
+    expect(src).not.toContain('karina-yanes')
   })
 
   it('should render the primary CTA linking to /apply', () => {


### PR DESCRIPTION
## Summary
- Replace hardcoded prod CloudFront URLs in `SplitHero` with environment-aware `NEXT_PUBLIC_CLOUDFRONT_DOMAIN` env var (consistent with existing pattern in `image-upload.tsx` and `listing-images.tsx`)
- Swap real artist image references (abbey-peters, david-morrison, karina-yanes) for demo artist images (elena-cordova, james-okafor, tomoko-ishida, amara-osei) that exist in both dev and prod S3 buckets
- Ensures dev environment only shows fabricated/demo data

## Context
The dev deployment showed broken hero images because:
1. URLs were hardcoded to the prod CloudFront domain (`dmfu4c7s6z2cc.cloudfront.net`)
2. The 3 real artists (abbey-peters, david-morrison, karina-yanes) don't have images in the dev S3 bucket — only prod

## Test plan
- [x] New tests verify CDN URL is built from env var
- [x] New tests verify no hardcoded prod CloudFront URLs
- [x] New tests verify no real artist slugs in hero images
- [x] All existing SplitHero tests pass
- [x] Build passes