### PR TITLE
feat(ci): auto-merge PRs targeting dev when CI passes

### DIFF
--- a/.github/workflows/auto-merge-dev.yml
+++ b/.github/workflows/auto-merge-dev.yml
@@ -1,0 +1,26 @@
+name: Auto-merge to dev
+
+# Automatically enable squash auto-merge on PRs targeting dev.
+# GitHub will merge once all required status checks pass.
+# This means feature→dev PRs never need manual merging.
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    # Skip Dependabot PRs (handled by dependabot-auto-merge.yml)
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --auto --repo ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,17 +251,22 @@ When starting work on an issue:
 
 ### Merge Strategy (CRITICAL)
 
-| PR direction | Strategy | Why |
+| PR direction | Strategy | Automation |
 |---|---|---|
-| feature → `dev` | **Squash merge** | Collapses noisy WIP commits into one clean commit on `dev` |
-| `dev` → `main` | **Regular merge commit** | Preserves commit parentage so git never sees dev as diverged from main |
+| feature → `dev` | **Squash merge** | **Auto-merged** by `auto-merge-dev.yml` when CI passes |
+| `dev` → `main` | **Regular merge commit** | **Manual only** — human merges via GitHub UI |
+
+**Feature → dev auto-merge:** The `auto-merge-dev.yml` workflow automatically enables squash auto-merge on every PR targeting `dev`. Once all required checks pass, GitHub merges it automatically. No manual merge step needed. Claude should **not** run `gh pr merge` for feature→dev PRs — just open the PR and auto-merge handles the rest.
 
 **Never squash dev → main.** Squash rewriting history on that direction causes permanent divergence: every subsequent dev→main PR conflicts on any file touched by the squash. Since features are already squashed before hitting dev, dev's log is already clean — a regular merge gives main the same readable history without rewriting it.
+
+**Repo settings:** Merge commit is the default merge type. Rebase merging is disabled. The only manual merge action is dev→main, which defaults to merge commit in the GitHub UI.
 
 ### Pull Request Rules (CRITICAL)
 
 - **NEVER merge to `main`** — merging to main is always a human action
 - When work is ready to merge, open a PR from CLI with a full description and stop
+- **Do NOT run `gh pr merge` for feature→dev PRs** — auto-merge handles this automatically
 - Update PR descriptions with accurate summaries of what changed and why
 - Prepare commit messages for human review, but do not execute the merge
 - `dev` → `main` merges require **explicit user permission** — never merge to main autonomously


### PR DESCRIPTION
## Summary
- Add `auto-merge-dev.yml` workflow that automatically enables squash auto-merge on every PR targeting `dev`
- When all required CI checks pass, GitHub merges the PR automatically — no manual merge step
- Update CLAUDE.md merge strategy docs to reflect new automation and repo settings

## How it works
1. PR is opened targeting `dev`
2. `auto-merge-dev.yml` runs and enables squash auto-merge via `gh pr merge --squash --auto`
3. CI runs (quality gates, integration tests, etc.)
4. Once all required checks pass, GitHub automatically squash-merges the PR
5. Branch is automatically deleted (repo setting)

## Repo settings changes (done manually)
- Default merge type: merge commit (for dev→main manual merges)
- Rebase merging: disabled
- Auto-merge: enabled
- Automatically delete head branches: enabled

## Test plan
- [x] Lint passes
- [x] Tests pass
- [ ] This PR itself should auto-merge once CI passes (first test of the workflow!)