### PR TITLE
fix: address AI code review findings (batch 2026-03-09)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ REVALIDATION_SECRET=generate-a-random-secret-here
 # ── CDN (CloudFront) ────────────────────────────────────────────────────────
 # Dev CloudFront distribution for seed/uploaded images.
 # See config/dev.env-reference for the dev URL.
-NEXT_PUBLIC_CDN_DOMAINS=https://d2agn4aoo0e7ji.cloudfront.net
+NEXT_PUBLIC_CDN_DOMAINS=https://your-cloudfront-distribution.cloudfront.net
 
 # ── Analytics (PostHog) ───────────────────────────────────────────────────────
 # Optional for local dev. Get key from posthog.com project settings.

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -15,6 +15,12 @@ vi.mock('@surfaced-art/db', () => ({
       findUnique: vi.fn(),
     },
   },
+  CategoryType: {
+    ceramics: 'ceramics',
+    drawing_painting: 'drawing_painting',
+    printmaking_photography: 'printmaking_photography',
+    mixed_media_3d: 'mixed_media_3d',
+  },
 }))
 
 const { app } = await import('./index')

--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -6,6 +6,12 @@ vi.mock('@surfaced-art/db', () => ({
     artistProfile: { findUnique: vi.fn(), findFirst: vi.fn().mockResolvedValue({ id: 'test-id' }) },
     listing: { findMany: vi.fn().mockResolvedValue([]), count: vi.fn().mockResolvedValue(0), findUnique: vi.fn() },
   },
+  CategoryType: {
+    ceramics: 'ceramics',
+    drawing_painting: 'drawing_painting',
+    printmaking_photography: 'printmaking_photography',
+    mixed_media_3d: 'mixed_media_3d',
+  },
 }))
 
 vi.stubEnv('FRONTEND_URL', 'https://surfacedart.com')

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -4026,7 +4026,8 @@ describe('PUT /me/tags', () => {
     const tagResults = [
       { id: 'at-1', artistId: 'artist-uuid-123', tagId: 'tag-1', tag: { id: 'tag-1', slug: 'oil', label: 'Oil', category: 'drawing_painting', sortOrder: 1 } },
     ]
-    const prisma = createMockPrisma({ tagResults })
+    const allTags = [{ id: '550e8400-e29b-41d4-a716-446655440000' }]
+    const prisma = createMockPrisma({ tagResults, allTags })
     const app = createTestApp(prisma)
 
     const res = await putTags(app, { tagIds: ['550e8400-e29b-41d4-a716-446655440000'] }, 'valid-token')
@@ -4051,10 +4052,11 @@ describe('PUT /me/tags', () => {
     const tagResults = [
       { id: 'at-1', artistId: 'artist-uuid-123', tagId: 'tag-1', tag: { id: 'tag-1', slug: 'oil', label: 'Oil', category: 'drawing_painting', sortOrder: 1 } },
     ]
-    const prisma = createMockPrisma({ tagResults })
+    const tagId = '550e8400-e29b-41d4-a716-446655440000'
+    const allTags = [{ id: tagId }]
+    const prisma = createMockPrisma({ tagResults, allTags })
     const app = createTestApp(prisma)
 
-    const tagId = '550e8400-e29b-41d4-a716-446655440000'
     const res = await putTags(app, { tagIds: [tagId, tagId] }, 'valid-token')
     expect(res.status).toBe(200)
 
@@ -4116,13 +4118,15 @@ describe('PUT /me/listings/:id/tags', () => {
 
   it('should replace listing tags in a transaction', async () => {
     const listing = { id: listingId, artistId: 'artist-uuid-123' }
+    const tagId = '550e8400-e29b-41d4-a716-446655440001'
     const listingTagResults = [
       { id: 'lt-1', listingId, tagId: 'tag-1', tag: { id: 'tag-1', slug: 'oil', label: 'Oil', category: 'drawing_painting', sortOrder: 1 } },
     ]
-    const prisma = createMockPrisma({ listings: [listing], listingTagResults })
+    const allTags = [{ id: tagId }]
+    const prisma = createMockPrisma({ listings: [listing], listingTagResults, allTags })
     const app = createTestApp(prisma)
 
-    const res = await putListingTags(app, listingId, { tagIds: ['550e8400-e29b-41d4-a716-446655440001'] }, 'valid-token')
+    const res = await putListingTags(app, listingId, { tagIds: [tagId] }, 'valid-token')
     expect(res.status).toBe(200)
 
     expect(prisma.$transaction).toHaveBeenCalled()

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -353,6 +353,19 @@ export function createMeRoutes(prisma: PrismaClient) {
     // Deduplicate tag IDs
     const uniqueTagIds = [...new Set(parsed.data.tagIds)]
 
+    // Validate all tag IDs exist in the database
+    if (uniqueTagIds.length > 0) {
+      const existingTags = await prisma.tag.findMany({
+        where: { id: { in: uniqueTagIds } },
+        select: { id: true },
+      })
+      const existingIds = new Set(existingTags.map((t) => t.id))
+      const invalidIds = uniqueTagIds.filter((id) => !existingIds.has(id))
+      if (invalidIds.length > 0) {
+        return badRequest(c, `Invalid tag IDs: ${invalidIds.join(', ')}`)
+      }
+    }
+
     const updatedTags = await prisma.$transaction(async (tx) => {
       await tx.artistTag.deleteMany({
         where: { artistId: artist.id },
@@ -430,6 +443,19 @@ export function createMeRoutes(prisma: PrismaClient) {
 
     // Deduplicate tag IDs
     const uniqueTagIds = [...new Set(parsed.data.tagIds)]
+
+    // Validate all tag IDs exist in the database
+    if (uniqueTagIds.length > 0) {
+      const existingTags = await prisma.tag.findMany({
+        where: { id: { in: uniqueTagIds } },
+        select: { id: true },
+      })
+      const existingIds = new Set(existingTags.map((t) => t.id))
+      const invalidIds = uniqueTagIds.filter((id) => !existingIds.has(id))
+      if (invalidIds.length > 0) {
+        return badRequest(c, `Invalid tag IDs: ${invalidIds.join(', ')}`)
+      }
+    }
 
     const updatedTags = await prisma.$transaction(async (tx) => {
       await tx.listingTag.deleteMany({

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -1,6 +1,9 @@
 import { Hono } from 'hono'
 import type { PrismaClient } from '@surfaced-art/db'
+import { CategoryType } from '@surfaced-art/db'
 import type { Tag } from '@surfaced-art/types'
+
+const validCategories = new Set(Object.values(CategoryType))
 
 export function createTagRoutes(prisma: PrismaClient) {
   const tags = new Hono()
@@ -15,6 +18,9 @@ export function createTagRoutes(prisma: PrismaClient) {
 
     const where: Record<string, string> = {}
     if (category) {
+      if (!validCategories.has(category as CategoryType)) {
+        return c.json({ error: `Invalid category: ${category}` }, 400)
+      }
       where.category = category
     }
 

--- a/apps/web/src/app/(main)/dashboard/listings/components/listing-form.tsx
+++ b/apps/web/src/app/(main)/dashboard/listings/components/listing-form.tsx
@@ -246,10 +246,8 @@ export function ListingForm({ mode, listingId }: ListingFormProps) {
         targetListingId = listingId!
       }
 
-      // Save tags for the listing
-      if (selectedTagIds.length > 0) {
-        await updateListingTags(token, targetListingId, selectedTagIds)
-      }
+      // Save tags for the listing (always call to support clearing all tags)
+      await updateListingTags(token, targetListingId, selectedTagIds)
 
       router.push('/dashboard/listings')
     } catch (err) {

--- a/apps/web/src/app/(main)/for-artists/ForArtistsContent.tsx
+++ b/apps/web/src/app/(main)/for-artists/ForArtistsContent.tsx
@@ -514,7 +514,7 @@ export default function ForArtistsContent() {
       {/* ============================================================ */}
       {/*  HERO                                                        */}
       {/* ============================================================ */}
-      <section id="v14-hero" data-testid="for-artists-hero" className="full-bleed overflow-hidden relative overflow-hidden">
+      <section id="v14-hero" data-testid="for-artists-hero" className="full-bleed overflow-hidden relative">
         <div className="absolute inset-0" style={{ background: 'var(--surface)' }} />
         <div className="absolute inset-0" style={{ background: 'linear-gradient(155deg, var(--surface) 50%, color-mix(in srgb, var(--accent-primary) 5%, var(--surface)) 50%)' }} />
         <CanvasDotOverlay />
@@ -952,7 +952,7 @@ export default function ForArtistsContent() {
               &ldquo;I was selling through DMs for two years. This is the first time my work has a real home online.&rdquo;
             </p>
             <footer className="mt-5">
-              <p className="text-sm font-medium" style={{ color: 'color-mix(in srgb, var(--primary-foreground) 80%, transparent)' }}>Artist Name, Ceramics</p>
+              <p className="text-sm font-medium" style={{ color: 'color-mix(in srgb, var(--primary-foreground) 80%, transparent)' }}>&mdash; Surfaced Art Creator</p>
             </footer>
           </blockquote>
         </Container>

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -43,8 +43,12 @@ export async function POST(request: Request) {
     revalidatePath('/')
     revalidated.push(`/listing/${body.id}`, '/')
     if (body.category) {
-      revalidatePath(`/category/${body.category}`)
-      revalidated.push(`/category/${body.category}`)
+      const validCategory = CATEGORIES.find((cat) => cat.slug === body.category)
+      if (!validCategory) {
+        return NextResponse.json({ error: 'Invalid category slug' }, { status: 400 })
+      }
+      revalidatePath(`/category/${validCategory.slug}`)
+      revalidated.push(`/category/${validCategory.slug}`)
     } else {
       for (const cat of CATEGORIES) {
         revalidatePath(`/category/${cat.slug}`)

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -106,7 +106,7 @@ export function Footer() {
           <p className="text-xs text-muted-foreground/60 text-center">
             &copy; {currentYear} Surfaced Art. All rights reserved.
           </p>
-          <nav className="flex gap-4">
+          <nav aria-label="Legal" className="flex gap-4">
             <Link
               href="/privacy"
               className="text-xs text-muted-foreground/60 transition-colors hover:text-foreground"

--- a/tools/migrate/src/index.ts
+++ b/tools/migrate/src/index.ts
@@ -116,6 +116,10 @@ export const handler = async (event: MigrateEvent): Promise<MigrateResult> => {
     if (!event.migration) {
       return { success: false, error: 'resolve-rolled-back requires a "migration" field with the migration name' }
     }
+    // Validate migration name to prevent command injection (alphanumeric + underscores only)
+    if (!/^[\w]+$/.test(event.migration)) {
+      return { success: false, error: `Invalid migration name: ${event.migration}. Only alphanumeric characters and underscores are allowed.` }
+    }
     try {
       const output = execSync(
         `${PRISMA_CMD} migrate resolve --rolled-back ${event.migration}`,


### PR DESCRIPTION
## Summary
Batch fix addressing AI code review findings from #ai-code-review Slack channel.
Triaged 32 unaddressed bot review messages across 16 PRs.

## Fixes Applied
| File | Issue | Source | Commit |
|------|-------|--------|--------|
| `.env.example` | Real CloudFront domain replaced with placeholder | Greptile (PR #414) | `0168453` |
| `apps/web/src/app/(main)/for-artists/ForArtistsContent.tsx` | Duplicate `overflow-hidden` class removed | Greptile (PR #405) | `c850884` |
| `apps/web/src/app/(main)/for-artists/ForArtistsContent.tsx` | Placeholder "Artist Name, Ceramics" testimonial attribution replaced | Greptile (PR #405) | `c850884` |
| `apps/web/src/app/(main)/dashboard/listings/components/listing-form.tsx` | Tags cannot be cleared from a listing — `if (selectedTagIds.length > 0)` guard removed | Greptile (PR #395, #396) | `37aa487` |
| `tools/migrate/src/index.ts` | Command injection via unsanitized `event.migration` — added alphanumeric validation | Greptile (PR #396) | `79bc192` |
| `apps/api/src/routes/tags.ts` | `?category=` query param not validated against `CategoryType` enum — added validation | Greptile (PR #395) | `49799ef` |
| `apps/api/src/routes/me.ts` | Tag IDs not validated before `createMany` — added pre-insert existence check (both artist + listing tags) | Greptile (PR #396) | `ceb03f3` |
| `apps/web/src/app/api/revalidate/route.ts` | `body.category` used without validation — now validated against `CATEGORIES` | Greptile (PR #394) | `ef68486` |
| `apps/web/src/components/Footer.tsx` | Missing `aria-label` on footer legal nav — added for screen readers | Greptile (PR #392) | `d94fa76` |

## Skipped (with reasoning)
| File | Issue | Reason |
|------|-------|--------|
| `SplitHero.tsx` | Negative top margin may overlap navigation | Intentional design pattern for full-bleed hero |
| `SplitHero.tsx` | Silent fallback produces broken images | Config error, not a runtime bug; build env requires the var |
| `SplitHero.test.tsx` | No test for missing env var fallback | Low priority given the above |
| `deploy.yml` / `deploy-dev.yml` | Exit codes silently skipped | Terraform only returns 0/1/2; other codes are safe (skip apply) |
| `MobileNav.tsx` | Inline subscribe function new ref per render | `useSyncExternalStore` designed for this; no observable bug |
| `MobileNav.tsx` | Portal guard removes nav from SSR | Complex SSR trade-off; would need major rearchitecture |
| `ForArtistsContent.tsx` | FadeIn renders invisible during SSR | Common animation pattern; acceptable trade-off |
| `canvas-texture.tsx` | 100vw trick can cause scrollbar | Mitigated by existing `overflow-x: hidden` on html |
| `globals.css` | `overflow-x: hidden` on html masks bugs | Removing it breaks the current layout; needs broader fix |
| `revalidate/route.ts` | Redundant slug conversion | Style nit, both approaches produce same paths |
| `deploy-dev.yml` | Hardcoded CloudFront domain | CI config preference, not a bug |
| `SplitHero.tsx` | Trim before splitting CDN domains | Marginal edge case; env vars with leading whitespace would be config error |
| Migration SQL | Will fail on non-empty databases | Already applied; informational only |
| `admin/orders.ts` | Complete orders unrefundable | Intentional business rule |
| `artist/[slug]/page.tsx` | displayName split on space | Edge case with mononyms works acceptably |
| All rate-limited Sourcery reviews | No review content | Sourcery rate limit reached; no findings to triage |
| PR #415 Sourcery | PR too large for review | Size limit; no findings |

## Source Reviews
- PR #414: https://github.com/nickcjordan/surfaced-art/pull/414
- PR #405: https://github.com/nickcjordan/surfaced-art/pull/405
- PR #402: https://github.com/nickcjordan/surfaced-art/pull/402
- PR #401: https://github.com/nickcjordan/surfaced-art/pull/401
- PR #400: https://github.com/nickcjordan/surfaced-art/pull/400
- PR #399: https://github.com/nickcjordan/surfaced-art/pull/399
- PR #398: https://github.com/nickcjordan/surfaced-art/pull/398
- PR #396: https://github.com/nickcjordan/surfaced-art/pull/396
- PR #395: https://github.com/nickcjordan/surfaced-art/pull/395
- PR #394: https://github.com/nickcjordan/surfaced-art/pull/394
- PR #393: https://github.com/nickcjordan/surfaced-art/pull/393
- PR #392: https://github.com/nickcjordan/surfaced-art/pull/392
- PR #388: https://github.com/nickcjordan/surfaced-art/pull/388
- PR #413: https://github.com/nickcjordan/surfaced-art/pull/413
- PR #412: https://github.com/nickcjordan/surfaced-art/pull/412
- PR #416: https://github.com/nickcjordan/surfaced-art/pull/416