### PR TITLE
fix(image-processor): robust Sharp Docker build + CI smoke test

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -403,25 +403,30 @@ jobs:
           ECR_REPOSITORY_URL: ${{ needs.terraform.outputs.image_processor_ecr_repository_url }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          echo "Checking image-processor container has required files..."
+          echo "Checking image-processor container..."
           docker run --rm --entrypoint="" \
             $ECR_REPOSITORY_URL:$IMAGE_TAG \
-            sh -c '
-              ok=true
-              for f in /var/task/index.js; do
-                if test -f "$f"; then
-                  echo "OK   $f"
-                else
-                  echo "MISSING $f" >&2; ok=false
-                fi
-              done
-              if test -d /var/task/node_modules/sharp; then
-                echo "OK   Sharp native binaries"
-              else
-                echo "MISSING Sharp native binaries" >&2; ok=false
-              fi
-              $ok && echo "All required files present." || { echo "Validation failed" >&2; exit 1; }
-            '
+            node --input-type=module -e "
+              import sharp from 'sharp';
+              import fs from 'fs';
+
+              // Verify bundle exists
+              if (!fs.existsSync('/var/task/index.js')) {
+                throw new Error('MISSING /var/task/index.js');
+              }
+              console.log('OK   /var/task/index.js');
+
+              // Smoke-test Sharp: create a tiny image, convert to WebP, verify
+              const buf = await sharp({
+                create: { width: 8, height: 8, channels: 3, background: '#ff0000' }
+              }).webp().toBuffer();
+              const meta = await sharp(buf).metadata();
+              if (meta.format !== 'webp' || meta.width !== 8) {
+                throw new Error('Sharp smoke test: unexpected output');
+              }
+              console.log('OK   Sharp smoke test passed (loaded, created, converted WebP)');
+              console.log('     Sharp version:', JSON.stringify(sharp.versions));
+            "
 
       - name: Push image-processor Docker image
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -414,25 +414,30 @@ jobs:
           ECR_REPOSITORY_URL: ${{ needs.terraform.outputs.image_processor_ecr_repository_url }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          echo "Checking image-processor container has required files..."
+          echo "Checking image-processor container..."
           docker run --rm --entrypoint="" \
             $ECR_REPOSITORY_URL:$IMAGE_TAG \
-            sh -c '
-              ok=true
-              for f in /var/task/index.js; do
-                if test -f "$f"; then
-                  echo "OK   $f"
-                else
-                  echo "MISSING $f" >&2; ok=false
-                fi
-              done
-              if test -d /var/task/node_modules/sharp; then
-                echo "OK   Sharp native binaries"
-              else
-                echo "MISSING Sharp native binaries" >&2; ok=false
-              fi
-              $ok && echo "All required files present." || { echo "Validation failed" >&2; exit 1; }
-            '
+            node --input-type=module -e "
+              import sharp from 'sharp';
+              import fs from 'fs';
+
+              // Verify bundle exists
+              if (!fs.existsSync('/var/task/index.js')) {
+                throw new Error('MISSING /var/task/index.js');
+              }
+              console.log('OK   /var/task/index.js');
+
+              // Smoke-test Sharp: create a tiny image, convert to WebP, verify
+              const buf = await sharp({
+                create: { width: 8, height: 8, channels: 3, background: '#ff0000' }
+              }).webp().toBuffer();
+              const meta = await sharp(buf).metadata();
+              if (meta.format !== 'webp' || meta.width !== 8) {
+                throw new Error('Sharp smoke test: unexpected output');
+              }
+              console.log('OK   Sharp smoke test passed (loaded, created, converted WebP)');
+              console.log('     Sharp version:', JSON.stringify(sharp.versions));
+            "
 
       - name: Push image-processor Docker image
         env:

--- a/apps/image-processor/Dockerfile
+++ b/apps/image-processor/Dockerfile
@@ -3,23 +3,21 @@
 # Sharp requires native binaries compiled for Amazon Linux, so we install
 # it inside the container rather than bundling it with tsup.
 
-FROM public.ecr.aws/lambda/nodejs:20
+# Pin platform to linux/amd64 — ensures correct native binaries even if
+# the Docker host or CI runner changes architecture in the future.
+FROM --platform=linux/amd64 public.ecr.aws/lambda/nodejs:20
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install sharp with native binaries for the Lambda runtime (Amazon Linux).
-# Use a temporary package.json to avoid workspace resolution issues from
-# the monorepo root, then remove it so we can copy the real one.
-#
-# IMPORTANT: This version must match apps/image-processor/package.json.
-# When upgrading sharp, update both files together.
-RUN echo '{"private":true}' > package.json && \
-    npm install sharp@0.34.5 && \
-    rm -f package.json package-lock.json
-
-# Root package.json provides "type": "module" so the Lambda Node 20
-# runtime loads the ESM bundle via import().
-COPY package.json ./
+# Install production dependencies using the image-processor's own package.json.
+# This is the single source of truth for the Sharp version — no hardcoded
+# version in this file. npm resolves @img/sharp-linux-x64 automatically
+# because we're inside an Amazon Linux x64 container.
+# AWS SDK is also installed (harmless — it's bundled in index.js by tsup).
+COPY apps/image-processor/package.json ./
+RUN npm install --omit=dev && \
+    npm cache clean --force && \
+    rm -f package-lock.json
 
 # Copy the pre-built self-contained bundle (produced by tsup in CI).
 # The tsup bundle is self-contained for @aws-sdk/client-s3 etc.


### PR DESCRIPTION
## Summary
- **Dockerfile**: Use `apps/image-processor/package.json` directly instead of hardcoding `sharp@0.34.5` in a fake `package.json`. Sharp version is now a single source of truth.
- **Dockerfile**: Pin `FROM --platform=linux/amd64` to prevent native binary architecture mismatch.
- **CI (deploy.yml + deploy-dev.yml)**: Replace superficial "directory exists" validation with a real Sharp smoke test that imports Sharp, creates an image, converts to WebP, and verifies the output. Broken builds now fail before push.

## Context
The prod image processor Lambda crashes on every invocation with `TypeError: fc._isUsingX64V2 is not a function` — a Sharp native binary mismatch. The dev Lambda (same code, different CI run) works fine. The old validation only checked `test -d node_modules/sharp` which passes even with corrupt binaries.

The previous Dockerfile required manually syncing the Sharp version between `package.json` and the Dockerfile's `npm install sharp@X.Y.Z` — this drift was the original root cause.

## Test plan
- [x] All quality gates pass (test, lint, typecheck, build)
- [ ] Dev deploy: smoke test passes, image processor generates WebP variants
- [ ] Prod deploy: smoke test passes, re-upload images to verify variant generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)