### PR TITLE
fix(api): allow www.surfacedart.com in CORS origins

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,12 +22,14 @@ import { createSearchRoutes } from './routes/search'
 import { createWebhookRoutes } from './routes/webhooks'
 
 // FRONTEND_URL is required — drives CORS allowed origins.
-// www redirect is handled at DNS/CDN level, not here.
+// Both bare domain and www variant are allowed.
 const FRONTEND_URL = process.env.FRONTEND_URL
 if (!FRONTEND_URL) {
   throw new Error('FRONTEND_URL is required')
 }
-const allowedOrigins = [FRONTEND_URL, 'http://localhost:3000']
+// Support both bare domain and www variant (e.g. surfacedart.com + www.surfacedart.com)
+const wwwVariant = FRONTEND_URL.replace('https://', 'https://www.')
+const allowedOrigins = [FRONTEND_URL, wwwVariant, 'http://localhost:3000']
 
 // Create Hono app
 const app = new Hono()

--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -30,6 +30,17 @@ describe('CORS configuration', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://surfacedart.com')
   })
 
+  it('should allow requests from the www variant of FRONTEND_URL', async () => {
+    const res = await app.request('/health', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://www.surfacedart.com',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://www.surfacedart.com')
+  })
+
   it('should allow requests from localhost:3000', async () => {
     const res = await app.request('/health', {
       method: 'OPTIONS',

--- a/infrastructure/terraform/modules/lambda-api/main.tf
+++ b/infrastructure/terraform/modules/lambda-api/main.tf
@@ -92,7 +92,7 @@ resource "aws_apigatewayv2_api" "main" {
   protocol_type = "HTTP"
 
   cors_configuration {
-    allow_origins     = [var.frontend_url, "http://localhost:3000"]
+    allow_origins     = [var.frontend_url, replace(var.frontend_url, "https://", "https://www."), "http://localhost:3000"]
     allow_methods     = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
     allow_headers     = ["Content-Type", "Authorization", "X-Amz-Date", "X-Api-Key"]
     expose_headers    = ["Content-Length", "Content-Type", "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "Retry-After"]


### PR DESCRIPTION
## Summary
- Adds the `www.` variant of `FRONTEND_URL` to CORS allowed origins in both the Hono middleware and API Gateway config
- Derives it automatically from `FRONTEND_URL` so no new env vars are needed
- Fixes dashboard "Failed to fetch" error when users access the site via `www.surfacedart.com`

## Changes
- `apps/api/src/index.ts` — derive `wwwVariant` and add to `allowedOrigins`
- `infrastructure/terraform/modules/lambda-api/main.tf` — add www variant to API Gateway `allow_origins`
- `apps/api/src/middleware/cors.test.ts` — add test for www origin

## Deploy steps
1. Merge PR → deploy Lambda with updated Hono code
2. Run `terraform apply -var-file=environments/prod.tfvars` to update API Gateway CORS

Both layers must be updated for the fix to take effect.

## Test plan
- [x] New test case for www variant passes
- [x] All existing CORS tests pass
- [x] All quality gates pass (test, lint, typecheck, build)
- [ ] After deploy: verify `www.surfacedart.com/me/dashboard` no longer shows CORS errors