### PR TITLE
fix(db): populate listing image dimensions in seed data

### DIFF
--- a/packages/db/prisma/seed-logic.ts
+++ b/packages/db/prisma/seed-logic.ts
@@ -10,6 +10,30 @@ import type { ArtistSeedConfig } from './seed-data'
 
 type TransactionClient = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
 
+/**
+ * Derives image pixel dimensions from artwork physical proportions.
+ *
+ * Product photos of artwork closely match the artwork's aspect ratio,
+ * so we scale the physical dimensions (artworkLength × artworkWidth) to
+ * pixel dimensions with the longest side at `maxPixels`.
+ *
+ * @param artworkLength - Physical height of the artwork (inches)
+ * @param artworkWidth - Physical width of the artwork (inches)
+ * @param maxPixels - Maximum pixel dimension for the longest side (default 1200)
+ */
+export function artworkToImageDimensions(
+  artworkLength: number,
+  artworkWidth: number,
+  maxPixels = 1200
+): { width: number; height: number } {
+  const longest = Math.max(artworkLength, artworkWidth)
+  const scale = maxPixels / longest
+  return {
+    width: Math.round(artworkWidth * scale),
+    height: Math.round(artworkLength * scale),
+  }
+}
+
 export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) {
   // Upsert user
   const user = await tx.user.upsert({
@@ -118,12 +142,15 @@ export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) 
     // Create 2 images per listing: primary + one additional angle
     // For documented listings, second image is a process photo
     const listingImageBase = `${seedKey(data.profile.slug, 'listings')}/${listingSlug}`
+    const imageDimensions = artworkToImageDimensions(listingData.artworkLength, listingData.artworkWidth)
     await tx.listingImage.create({
       data: {
         listingId: listing.id,
         url: cdnUrl(`${listingImageBase}/front`),
         isProcessPhoto: false,
         sortOrder: 0,
+        width: imageDimensions.width,
+        height: imageDimensions.height,
       },
     })
     await tx.listingImage.create({
@@ -132,6 +159,8 @@ export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) 
         url: cdnUrl(`${listingImageBase}/angle`),
         isProcessPhoto: listingData.isDocumented,
         sortOrder: 1,
+        width: imageDimensions.width,
+        height: imageDimensions.height,
       },
     })
   }

--- a/packages/db/prisma/seed.test.ts
+++ b/packages/db/prisma/seed.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { validateSlug } from '@surfaced-art/utils'
 import { artistConfigs, CDN_BASE, realArtistConfigs, demoArtistConfigs } from './seed-data'
+import { artworkToImageDimensions } from './seed-logic.js'
 
 /**
  * Seed data validation tests.
@@ -213,6 +214,49 @@ describe('Seed Data Validation', () => {
         await expect(import('./seed-data')).rejects.toThrow('Invalid SEED_MODE')
       } finally {
         vi.unstubAllEnvs()
+      }
+    })
+  })
+
+  describe('listing image dimensions', () => {
+    it('should derive image pixel dimensions from artwork physical proportions', () => {
+      // Landscape painting: 36" tall × 48" wide → landscape image
+      const landscape = artworkToImageDimensions(36, 48)
+      expect(landscape.width).toBe(1200)
+      expect(landscape.height).toBe(900)
+
+      // Portrait painting: 48" tall × 36" wide → portrait image
+      const portrait = artworkToImageDimensions(48, 36)
+      expect(portrait.width).toBe(900)
+      expect(portrait.height).toBe(1200)
+
+      // Square artwork: 24" × 24" → square image
+      const square = artworkToImageDimensions(24, 24)
+      expect(square.width).toBe(1200)
+      expect(square.height).toBe(1200)
+    })
+
+    it('should return integer pixel values', () => {
+      // 7" × 5" → ratio 7:5 → height=1200, width=857 (rounded)
+      const result = artworkToImageDimensions(7, 5)
+      expect(Number.isInteger(result.width)).toBe(true)
+      expect(Number.isInteger(result.height)).toBe(true)
+      expect(result.width).toBe(857)
+      expect(result.height).toBe(1200)
+    })
+
+    it('should scale to maxPixels parameter when provided', () => {
+      const result = artworkToImageDimensions(36, 48, 800)
+      expect(result.width).toBe(800)
+      expect(result.height).toBe(600)
+    })
+
+    it('should handle all seed listings (artworkLength and artworkWidth > 0)', () => {
+      for (const config of artistConfigs) {
+        for (const listing of config.listings) {
+          expect(listing.artworkLength).toBeGreaterThan(0)
+          expect(listing.artworkWidth).toBeGreaterThan(0)
+        }
       }
     })
   })


### PR DESCRIPTION
## Summary
- Listing images had NULL `width`/`height` values in the database, causing every `ListingCard` to fall back to `aspect-square` — cropping non-square artwork and making the masonry grid visually ineffective (all items same height)
- Added `artworkToImageDimensions()` helper that derives pixel dimensions from artwork physical proportions (`artworkLength` × `artworkWidth`), scaled to 1200px on the longest side
- Seed logic now writes `width` and `height` when creating `ListingImage` records, enabling natural aspect ratios in the masonry grid

## Test plan
- [x] 4 new tests for `artworkToImageDimensions()` (landscape, portrait, square, integer rounding, custom maxPixels, all seed data validation)
- [x] All 34 seed tests pass
- [x] All 624 tests pass across all packages
- [x] Lint, typecheck, and build all pass
- [ ] After merge: re-run seed (`npm run db:seed`) to populate dimensions, verify masonry grid shows varied image heights

🤖 Generated with [Claude Code](https://claude.com/claude-code)