### PR TITLE
fix(ci): add security scans and integration tests to dev PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Test
         run: npm run test
 
+      - name: Integration Tests
+        run: npm run test:integration
+
   terraform-plan-dev:
     name: Terraform Plan (dev)
     runs-on: ubuntu-latest
@@ -75,7 +78,7 @@ jobs:
 
       - name: Setup Terraform
         if: steps.infra_changes.outputs.changed == 'true'
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.5'
           terraform_wrapper: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: Security Scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [dev, main]
   schedule:
     # Run weekly on Sundays at midnight
     - cron: '0 0 * * 0'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,15 +233,17 @@ When starting work on an issue:
 
 1. **Write tests first** (TDD approach using Vitest)
 2. **Implement code** to make tests pass
-3. **Run quality gates**:
+3. **Sync dependencies** — if any `package.json` was modified (new deps, version bumps, workspace changes), run `npm install` to update `package-lock.json` and commit the lockfile. Verify with `npm ci` (must succeed without errors).
+4. **Run quality gates locally** — all five must pass before committing:
    ```bash
+   npm ci              # Verify lockfile is in sync (catches what CI catches)
    npm run test        # Vitest test suite
    npm run lint        # ESLint
    npm run typecheck   # tsc --noEmit
    npm run build       # Turborepo build
    ```
-4. **Commit to dev branch** with conventional commit message
-5. **Run regression tests** before pushing
+5. **Commit to feature branch** with conventional commit message
+6. **Never push code that hasn't passed all local quality gates** — CI failures should never be the first time you discover a problem
 
 ### Branch Strategy
 
@@ -516,6 +518,7 @@ If any of these arise, pause and present the user with:
 
 ## Quality Checklist Before Each Commit
 
+- [ ] Lockfile in sync (`npm ci` succeeds — if any `package.json` changed, run `npm install` first)
 - [ ] Tests pass (`npm run test`)
 - [ ] No lint errors (`npm run lint`)
 - [ ] No type errors (`npm run typecheck`)

--- a/apps/web/src/app/(main)/(auth)/__tests__/sign-in.test.tsx
+++ b/apps/web/src/app/(main)/(auth)/__tests__/sign-in.test.tsx
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SignInForm as SignInPage } from '../sign-in/sign-in-form'
 
 // Mock the auth provider
 const mockSignIn = vi.fn()
+const mockCompleteNewPassword = vi.fn()
+const mockCompleteMfa = vi.fn()
 const mockAuth = {
   user: null,
   loading: false,
@@ -16,6 +18,9 @@ const mockAuth = {
   forgotPassword: vi.fn(),
   confirmPassword: vi.fn(),
   getIdToken: vi.fn(),
+  pendingChallenge: null as string | null,
+  completeNewPassword: mockCompleteNewPassword,
+  completeMfa: mockCompleteMfa,
 }
 
 vi.mock('@/lib/auth', () => ({
@@ -54,7 +59,7 @@ describe('Sign In Page', () => {
 
   it('should call signIn and redirect on successful submission', async () => {
     const user = userEvent.setup()
-    mockSignIn.mockResolvedValue(undefined)
+    mockSignIn.mockResolvedValue(true)
 
     render(<SignInPage />)
 
@@ -106,5 +111,110 @@ describe('Sign In Page', () => {
     await user.click(screen.getByRole('button', { name: /sign in/i }))
 
     expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled()
+  })
+})
+
+describe('Sign In - New Password Required', () => {
+  beforeEach(() => {
+    mockAuth.pendingChallenge = 'NEW_PASSWORD_REQUIRED'
+  })
+
+  afterEach(() => {
+    mockAuth.pendingChallenge = null
+  })
+
+  it('should show new password form when pendingChallenge is NEW_PASSWORD_REQUIRED', () => {
+    render(<SignInPage />)
+
+    expect(screen.getByText(/set a new password/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('New password')).toBeInTheDocument()
+    expect(screen.getByLabelText('Confirm new password')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /set password/i })).toBeInTheDocument()
+    // Should NOT show the sign-in form
+    expect(screen.queryByTestId('sign-in-form')).not.toBeInTheDocument()
+  })
+
+  it('should call completeNewPassword and redirect on successful submission', async () => {
+    const user = userEvent.setup()
+    mockCompleteNewPassword.mockResolvedValue(undefined)
+
+    render(<SignInPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'NewPassword1!')
+    await user.type(screen.getByLabelText('Confirm new password'), 'NewPassword1!')
+    await user.click(screen.getByRole('button', { name: /set password/i }))
+
+    expect(mockCompleteNewPassword).toHaveBeenCalledWith('NewPassword1!')
+    expect(mockPush).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('should show error when passwords do not match', async () => {
+    const user = userEvent.setup()
+
+    render(<SignInPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'NewPassword1!')
+    await user.type(screen.getByLabelText('Confirm new password'), 'DifferentPass1!')
+    await user.click(screen.getByRole('button', { name: /set password/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/passwords do not match/i)
+    expect(mockCompleteNewPassword).not.toHaveBeenCalled()
+  })
+
+  it('should show error when completeNewPassword fails', async () => {
+    const user = userEvent.setup()
+    mockCompleteNewPassword.mockRejectedValue(new Error('Password does not meet requirements'))
+
+    render(<SignInPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'weak')
+    await user.type(screen.getByLabelText('Confirm new password'), 'weak')
+    await user.click(screen.getByRole('button', { name: /set password/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/password does not meet requirements/i)
+  })
+})
+
+describe('Sign In - MFA Required', () => {
+  beforeEach(() => {
+    mockAuth.pendingChallenge = 'MFA_REQUIRED'
+  })
+
+  afterEach(() => {
+    mockAuth.pendingChallenge = null
+  })
+
+  it('should show MFA code form when pendingChallenge is MFA_REQUIRED', () => {
+    render(<SignInPage />)
+
+    expect(screen.getByTestId('mfa-form')).toBeInTheDocument()
+    expect(screen.getByLabelText(/code/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /verify/i })).toBeInTheDocument()
+    expect(screen.queryByTestId('sign-in-form')).not.toBeInTheDocument()
+  })
+
+  it('should call completeMfa and redirect on successful submission', async () => {
+    const user = userEvent.setup()
+    mockCompleteMfa.mockResolvedValue(undefined)
+
+    render(<SignInPage />)
+
+    await user.type(screen.getByLabelText(/code/i), '123456')
+    await user.click(screen.getByRole('button', { name: /verify/i }))
+
+    expect(mockCompleteMfa).toHaveBeenCalledWith('123456')
+    expect(mockPush).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('should show error when MFA verification fails', async () => {
+    const user = userEvent.setup()
+    mockCompleteMfa.mockRejectedValue(new Error('Invalid code'))
+
+    render(<SignInPage />)
+
+    await user.type(screen.getByLabelText(/code/i), '000000')
+    await user.click(screen.getByRole('button', { name: /verify/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/invalid code/i)
   })
 })

--- a/apps/web/src/app/(main)/(auth)/sign-in/sign-in-form.tsx
+++ b/apps/web/src/app/(main)/(auth)/sign-in/sign-in-form.tsx
@@ -10,7 +10,7 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 
 export function SignInForm() {
-  const { signIn } = useAuth()
+  const { signIn, pendingChallenge, completeNewPassword, completeMfa } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -18,6 +18,13 @@ export function SignInForm() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+
+  // New password challenge state
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmNewPassword, setConfirmNewPassword] = useState('')
+
+  // MFA challenge state
+  const [mfaCode, setMfaCode] = useState('')
 
   const verified = searchParams.get('verified') === 'true'
   const reset = searchParams.get('reset') === 'true'
@@ -29,8 +36,12 @@ export function SignInForm() {
     setSubmitting(true)
 
     try {
-      await signIn(email, password)
-      router.push(redirect)
+      const success = await signIn(email, password)
+      if (success) {
+        router.push(redirect)
+        return
+      }
+      // Challenge was set — form will re-render to show challenge UI
     } catch (err) {
       if (err instanceof Error && err.name === 'UserNotConfirmedException') {
         router.push(`/verify-email?email=${encodeURIComponent(email)}`)
@@ -42,6 +53,142 @@ export function SignInForm() {
     }
   }
 
+  async function handleNewPassword(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (newPassword !== confirmNewPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      await completeNewPassword(newPassword)
+      router.push(redirect)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleMfa(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+
+    try {
+      await completeMfa(mfaCode)
+      router.push(redirect)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // NEW_PASSWORD_REQUIRED challenge UI
+  if (pendingChallenge === 'NEW_PASSWORD_REQUIRED') {
+    return (
+      <Card className="border border-border shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">Set a New Password</CardTitle>
+          <CardDescription>
+            Your account requires a new password. Please choose a secure password.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form data-testid="new-password-form" onSubmit={handleNewPassword} className="space-y-4">
+            {error && (
+              <div className="rounded-md bg-error/10 p-3 text-sm text-error" role="alert">
+                {error}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="newPassword">New password</Label>
+              <Input
+                id="newPassword"
+                type="password"
+                required
+                autoComplete="new-password"
+                minLength={8}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                data-testid="new-password-input"
+              />
+              <p className="text-xs text-muted-foreground">
+                At least 8 characters, with uppercase, lowercase, and a number
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmNewPassword">Confirm new password</Label>
+              <Input
+                id="confirmNewPassword"
+                type="password"
+                required
+                autoComplete="new-password"
+                value={confirmNewPassword}
+                onChange={(e) => setConfirmNewPassword(e.target.value)}
+                data-testid="confirm-new-password-input"
+              />
+            </div>
+
+            <Button type="submit" className="w-full" disabled={submitting}>
+              {submitting ? 'Setting password...' : 'Set password'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // MFA_REQUIRED challenge UI
+  if (pendingChallenge === 'MFA_REQUIRED') {
+    return (
+      <Card className="border border-border shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">Verification Code</CardTitle>
+          <CardDescription>
+            Enter the verification code sent to your device.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form data-testid="mfa-form" onSubmit={handleMfa} className="space-y-4">
+            {error && (
+              <div className="rounded-md bg-error/10 p-3 text-sm text-error" role="alert">
+                {error}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="mfaCode">Code</Label>
+              <Input
+                id="mfaCode"
+                type="text"
+                required
+                autoComplete="one-time-code"
+                inputMode="numeric"
+                maxLength={6}
+                value={mfaCode}
+                onChange={(e) => setMfaCode(e.target.value)}
+                data-testid="mfa-code-input"
+              />
+            </div>
+
+            <Button type="submit" className="w-full" disabled={submitting}>
+              {submitting ? 'Verifying...' : 'Verify'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Default sign-in form
   return (
     <Card className="border border-border shadow-sm">
       <CardHeader>

--- a/apps/web/src/lib/auth/__tests__/auth-provider.test.tsx
+++ b/apps/web/src/lib/auth/__tests__/auth-provider.test.tsx
@@ -12,6 +12,8 @@ vi.mock('../cognito', () => ({
   getCurrentSession: vi.fn(),
   forgotPassword: vi.fn(),
   confirmPassword: vi.fn(),
+  completeNewPassword: vi.fn(),
+  completeMfaChallenge: vi.fn(),
 }))
 
 import * as cognito from '../cognito'
@@ -32,8 +34,11 @@ function TestConsumer() {
       <span data-testid="loading">{String(auth.loading)}</span>
       <span data-testid="user-email">{auth.user?.email ?? 'none'}</span>
       <span data-testid="user-name">{auth.user?.name ?? 'none'}</span>
+      <span data-testid="challenge">{auth.pendingChallenge ?? 'none'}</span>
       <button onClick={() => auth.signIn('test@example.com', 'Password1')}>Sign In</button>
       <button onClick={() => auth.signOut()}>Sign Out</button>
+      <button onClick={() => auth.completeNewPassword('NewPassword1')}>Complete New Password</button>
+      <button onClick={() => auth.completeMfa('123456')}>Complete MFA</button>
     </div>
   )
 }
@@ -94,7 +99,7 @@ describe('AuthProvider', () => {
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
     }
-    mockedCognito.signIn.mockResolvedValue(tokens)
+    mockedCognito.signIn.mockResolvedValue({ type: 'success', tokens })
 
     render(
       <AuthProvider>
@@ -112,6 +117,143 @@ describe('AuthProvider', () => {
     })
 
     expect(screen.getByTestId('user-email').textContent).toBe('bob@example.com')
+    expect(screen.getByTestId('challenge').textContent).toBe('none')
+  })
+
+  it('should set pendingChallenge when sign-in returns NEW_PASSWORD_REQUIRED', async () => {
+    mockedCognito.getCurrentSession.mockResolvedValue(null)
+    const fakeCognitoUser = {} as never
+    mockedCognito.signIn.mockResolvedValue({
+      type: 'newPasswordRequired',
+      cognitoUser: fakeCognitoUser,
+      requiredAttributes: {},
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    await act(async () => {
+      screen.getByText('Sign In').click()
+    })
+
+    expect(screen.getByTestId('challenge').textContent).toBe('NEW_PASSWORD_REQUIRED')
+    expect(screen.getByTestId('user-email').textContent).toBe('none')
+  })
+
+  it('should complete new password challenge and sign in user', async () => {
+    mockedCognito.getCurrentSession.mockResolvedValue(null)
+    const fakeCognitoUser = {} as never
+    mockedCognito.signIn.mockResolvedValue({
+      type: 'newPasswordRequired',
+      cognitoUser: fakeCognitoUser,
+      requiredAttributes: {},
+    })
+
+    const tokens = {
+      idToken: fakeIdToken({ email: 'bob@example.com', name: 'Bob' }),
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    }
+    mockedCognito.completeNewPassword.mockResolvedValue(tokens)
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    // Trigger new password challenge
+    await act(async () => {
+      screen.getByText('Sign In').click()
+    })
+
+    expect(screen.getByTestId('challenge').textContent).toBe('NEW_PASSWORD_REQUIRED')
+
+    // Complete the challenge
+    await act(async () => {
+      screen.getByText('Complete New Password').click()
+    })
+
+    expect(screen.getByTestId('challenge').textContent).toBe('none')
+    expect(screen.getByTestId('user-email').textContent).toBe('bob@example.com')
+    expect(mockedCognito.completeNewPassword).toHaveBeenCalledWith(fakeCognitoUser, 'NewPassword1')
+  })
+
+  it('should set pendingChallenge when sign-in returns MFA_REQUIRED', async () => {
+    mockedCognito.getCurrentSession.mockResolvedValue(null)
+    const fakeCognitoUser = {} as never
+    mockedCognito.signIn.mockResolvedValue({
+      type: 'mfaRequired',
+      cognitoUser: fakeCognitoUser,
+      mfaType: 'SMS_MFA',
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    await act(async () => {
+      screen.getByText('Sign In').click()
+    })
+
+    expect(screen.getByTestId('challenge').textContent).toBe('MFA_REQUIRED')
+  })
+
+  it('should complete MFA challenge and sign in user', async () => {
+    mockedCognito.getCurrentSession.mockResolvedValue(null)
+    const fakeCognitoUser = {} as never
+    mockedCognito.signIn.mockResolvedValue({
+      type: 'mfaRequired',
+      cognitoUser: fakeCognitoUser,
+      mfaType: 'SMS_MFA',
+    })
+
+    const tokens = {
+      idToken: fakeIdToken({ email: 'carol@example.com', name: 'Carol' }),
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    }
+    mockedCognito.completeMfaChallenge.mockResolvedValue(tokens)
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    await act(async () => {
+      screen.getByText('Sign In').click()
+    })
+
+    expect(screen.getByTestId('challenge').textContent).toBe('MFA_REQUIRED')
+
+    await act(async () => {
+      screen.getByText('Complete MFA').click()
+    })
+
+    expect(screen.getByTestId('challenge').textContent).toBe('none')
+    expect(screen.getByTestId('user-email').textContent).toBe('carol@example.com')
   })
 
   it('should clear user on sign-out', async () => {

--- a/apps/web/src/lib/auth/__tests__/cognito.test.ts
+++ b/apps/web/src/lib/auth/__tests__/cognito.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Set required env vars before cognito module reads them at import time.
+// vi.hoisted runs before all imports, ensuring the env is set before cognito.ts
+// reads process.env at module scope.
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID = 'us-east-1_testpool'
+  process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = 'testclientid'
+})
+
+// Mock amazon-cognito-identity-js
+const mockAuthenticateUser = vi.fn()
+const mockCompleteNewPasswordChallenge = vi.fn()
+const mockSendMFACode = vi.fn()
+
+vi.mock('amazon-cognito-identity-js', () => {
+  class MockCognitoUserPool {}
+  class MockCognitoUser {
+    authenticateUser = mockAuthenticateUser
+    completeNewPasswordChallenge = mockCompleteNewPasswordChallenge
+    sendMFACode = mockSendMFACode
+  }
+  class MockAuthenticationDetails {
+    constructor(public details: { Username: string; Password: string }) {}
+  }
+  class MockCognitoUserAttribute {}
+
+  return {
+    CognitoUserPool: MockCognitoUserPool,
+    CognitoUser: MockCognitoUser,
+    AuthenticationDetails: MockAuthenticationDetails,
+    CognitoUserAttribute: MockCognitoUserAttribute,
+    CognitoUserSession: vi.fn(),
+  }
+})
+
+import { signIn, completeNewPassword } from '../cognito'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function fakeSession() {
+  return {
+    getIdToken: () => ({ getJwtToken: () => 'id-token' }),
+    getAccessToken: () => ({ getJwtToken: () => 'access-token' }),
+    getRefreshToken: () => ({ getToken: () => 'refresh-token' }),
+  }
+}
+
+describe('signIn', () => {
+  it('should return tokens on successful authentication', async () => {
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { onSuccess: (session: ReturnType<typeof fakeSession>) => void }) => {
+      callbacks.onSuccess(fakeSession())
+    })
+
+    const result = await signIn('test@example.com', 'Password1')
+
+    expect(result).toEqual({
+      type: 'success',
+      tokens: {
+        idToken: 'id-token',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      },
+    })
+  })
+
+  it('should return a NEW_PASSWORD_REQUIRED challenge when Cognito requires a new password', async () => {
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { newPasswordRequired: (userAttributes: Record<string, string>) => void }) => {
+      callbacks.newPasswordRequired({ email: 'test@example.com' })
+    })
+
+    const result = await signIn('test@example.com', 'TempPass1')
+
+    expect(result.type).toBe('newPasswordRequired')
+    if (result.type === 'newPasswordRequired') {
+      expect(result.requiredAttributes).toEqual({ email: 'test@example.com' })
+    }
+  })
+
+  it('should return an MFA_REQUIRED challenge when Cognito requires MFA', async () => {
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { mfaRequired: (challengeName: string) => void }) => {
+      callbacks.mfaRequired('SMS_MFA')
+    })
+
+    const result = await signIn('test@example.com', 'Password1')
+
+    expect(result.type).toBe('mfaRequired')
+    if (result.type === 'mfaRequired') {
+      expect(result.mfaType).toBe('SMS_MFA')
+    }
+  })
+
+  it('should return a TOTP challenge when Cognito requires software token MFA', async () => {
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { totpRequired: (challengeName: string) => void }) => {
+      callbacks.totpRequired('SOFTWARE_TOKEN_MFA')
+    })
+
+    const result = await signIn('test@example.com', 'Password1')
+
+    expect(result.type).toBe('mfaRequired')
+    if (result.type === 'mfaRequired') {
+      expect(result.mfaType).toBe('SOFTWARE_TOKEN_MFA')
+    }
+  })
+
+  it('should reject on authentication failure', async () => {
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { onFailure: (err: Error) => void }) => {
+      callbacks.onFailure(new Error('Incorrect username or password.'))
+    })
+
+    await expect(signIn('test@example.com', 'WrongPass')).rejects.toThrow('Incorrect username or password.')
+  })
+})
+
+describe('completeNewPassword', () => {
+  it('should resolve with tokens after setting new password', async () => {
+    // First sign in to get a challenge result with cognitoUser reference
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { newPasswordRequired: (userAttributes: Record<string, string>) => void }) => {
+      callbacks.newPasswordRequired({ email: 'test@example.com' })
+    })
+
+    const signInResult = await signIn('test@example.com', 'TempPass1')
+    expect(signInResult.type).toBe('newPasswordRequired')
+
+    if (signInResult.type !== 'newPasswordRequired') return
+
+    // Now complete the challenge
+    mockCompleteNewPasswordChallenge.mockImplementation(
+      (_newPassword: string, _attrs: Record<string, string>, callbacks: { onSuccess: (session: ReturnType<typeof fakeSession>) => void }) => {
+        callbacks.onSuccess(fakeSession())
+      }
+    )
+
+    const tokens = await completeNewPassword(signInResult.cognitoUser, 'NewPassword1')
+
+    expect(tokens).toEqual({
+      idToken: 'id-token',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    })
+    expect(mockCompleteNewPasswordChallenge).toHaveBeenCalledWith(
+      'NewPassword1',
+      {},
+      expect.objectContaining({ onSuccess: expect.any(Function), onFailure: expect.any(Function) })
+    )
+  })
+
+  it('should reject when completeNewPasswordChallenge fails', async () => {
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { newPasswordRequired: (userAttributes: Record<string, string>) => void }) => {
+      callbacks.newPasswordRequired({})
+    })
+
+    const signInResult = await signIn('test@example.com', 'TempPass1')
+    if (signInResult.type !== 'newPasswordRequired') return
+
+    mockCompleteNewPasswordChallenge.mockImplementation(
+      (_newPassword: string, _attrs: Record<string, string>, callbacks: { onFailure: (err: Error) => void }) => {
+        callbacks.onFailure(new Error('Password does not meet requirements'))
+      }
+    )
+
+    await expect(completeNewPassword(signInResult.cognitoUser, 'weak')).rejects.toThrow(
+      'Password does not meet requirements'
+    )
+  })
+})
+
+describe('completeMfaChallenge', () => {
+  it('should resolve with tokens after submitting MFA code', async () => {
+    // Get an MFA challenge
+    mockAuthenticateUser.mockImplementation((_details: unknown, callbacks: { mfaRequired: (challengeName: string) => void }) => {
+      callbacks.mfaRequired('SMS_MFA')
+    })
+
+    const signInResult = await signIn('test@example.com', 'Password1')
+    expect(signInResult.type).toBe('mfaRequired')
+    if (signInResult.type !== 'mfaRequired') return
+
+    // Import the function we need
+    const { completeMfaChallenge } = await import('../cognito')
+
+    mockSendMFACode.mockImplementation(
+      (_code: string, callbacks: { onSuccess: (session: ReturnType<typeof fakeSession>) => void })  => {
+        callbacks.onSuccess(fakeSession())
+      }
+    )
+
+    const tokens = await completeMfaChallenge(signInResult.cognitoUser, '123456')
+
+    expect(tokens).toEqual({
+      idToken: 'id-token',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    })
+  })
+})

--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import type { ReactNode } from 'react'
 import * as cognito from './cognito'
 import type { AuthTokens } from './cognito'
+import type { CognitoUser } from 'amazon-cognito-identity-js'
 import { AUTH_COOKIE_NAME } from './constants'
 
 export interface AuthUser {
@@ -11,13 +12,17 @@ export interface AuthUser {
   name: string
 }
 
+export type PendingChallenge = 'NEW_PASSWORD_REQUIRED' | 'MFA_REQUIRED' | null
+
 export interface AuthContextValue {
   /** Current authenticated user, or null if not signed in */
   user: AuthUser | null
   /** True while the initial session check is in progress */
   loading: boolean
-  /** Sign in with email and password */
-  signIn: (email: string, password: string) => Promise<void>
+  /** Active auth challenge requiring user input, or null */
+  pendingChallenge: PendingChallenge
+  /** Sign in with email and password. Returns true if auth completed, false if a challenge is pending. */
+  signIn: (email: string, password: string) => Promise<boolean>
   /** Sign up with email, password, and full name */
   signUp: (email: string, password: string, fullName: string) => Promise<{ userConfirmed: boolean }>
   /** Confirm email verification code after sign-up */
@@ -30,6 +35,10 @@ export interface AuthContextValue {
   forgotPassword: (email: string) => Promise<void>
   /** Confirm new password with verification code */
   confirmPassword: (email: string, code: string, newPassword: string) => Promise<void>
+  /** Complete the NEW_PASSWORD_REQUIRED challenge */
+  completeNewPassword: (newPassword: string) => Promise<void>
+  /** Complete an MFA challenge with a verification code */
+  completeMfa: (code: string) => Promise<void>
   /** Get current ID token for API calls, or null if not signed in */
   getIdToken: () => Promise<string | null>
 }
@@ -71,6 +80,8 @@ interface AuthProviderProps {
 export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [loading, setLoading] = useState(true)
+  const [pendingChallenge, setPendingChallenge] = useState<PendingChallenge>(null)
+  const [challengeUser, setChallengeUser] = useState<CognitoUser | null>(null)
 
   // Check for existing session on mount
   useEffect(() => {
@@ -97,10 +108,25 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return () => { cancelled = true }
   }, [])
 
-  const handleSignIn = useCallback(async (email: string, password: string) => {
-    const tokens = await cognito.signIn(email, password)
-    setUser(extractUserFromTokens(tokens))
-    setAuthCookie()
+  const handleSignIn = useCallback(async (email: string, password: string): Promise<boolean> => {
+    const result = await cognito.signIn(email, password)
+
+    switch (result.type) {
+      case 'success':
+        setUser(extractUserFromTokens(result.tokens))
+        setAuthCookie()
+        setPendingChallenge(null)
+        setChallengeUser(null)
+        return true
+      case 'newPasswordRequired':
+        setChallengeUser(result.cognitoUser)
+        setPendingChallenge('NEW_PASSWORD_REQUIRED')
+        return false
+      case 'mfaRequired':
+        setChallengeUser(result.cognitoUser)
+        setPendingChallenge('MFA_REQUIRED')
+        return false
+    }
   }, [])
 
   const handleSignUp = useCallback(async (email: string, password: string, fullName: string) => {
@@ -130,6 +156,28 @@ export function AuthProvider({ children }: AuthProviderProps) {
     await cognito.confirmPassword(email, code, newPassword)
   }, [])
 
+  const handleCompleteNewPassword = useCallback(async (newPassword: string) => {
+    if (!challengeUser) {
+      throw new Error('No pending new password challenge')
+    }
+    const tokens = await cognito.completeNewPassword(challengeUser, newPassword)
+    setUser(extractUserFromTokens(tokens))
+    setAuthCookie()
+    setPendingChallenge(null)
+    setChallengeUser(null)
+  }, [challengeUser])
+
+  const handleCompleteMfa = useCallback(async (code: string) => {
+    if (!challengeUser) {
+      throw new Error('No pending MFA challenge')
+    }
+    const tokens = await cognito.completeMfaChallenge(challengeUser, code)
+    setUser(extractUserFromTokens(tokens))
+    setAuthCookie()
+    setPendingChallenge(null)
+    setChallengeUser(null)
+  }, [challengeUser])
+
   const getIdToken = useCallback(async (): Promise<string | null> => {
     const tokens = await cognito.getCurrentSession()
     return tokens?.idToken ?? null
@@ -138,6 +186,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const value = useMemo<AuthContextValue>(() => ({
     user,
     loading,
+    pendingChallenge,
     signIn: handleSignIn,
     signUp: handleSignUp,
     confirmSignUp: handleConfirmSignUp,
@@ -145,8 +194,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     signOut: handleSignOut,
     forgotPassword: handleForgotPassword,
     confirmPassword: handleConfirmPassword,
+    completeNewPassword: handleCompleteNewPassword,
+    completeMfa: handleCompleteMfa,
     getIdToken,
-  }), [user, loading, handleSignIn, handleSignUp, handleConfirmSignUp, handleResendCode, handleSignOut, handleForgotPassword, handleConfirmPassword, getIdToken])
+  }), [user, loading, pendingChallenge, handleSignIn, handleSignUp, handleConfirmSignUp, handleResendCode, handleSignOut, handleForgotPassword, handleConfirmPassword, handleCompleteNewPassword, handleCompleteMfa, getIdToken])
 
   return (
     <AuthContext.Provider value={value}>

--- a/apps/web/src/lib/auth/cognito.ts
+++ b/apps/web/src/lib/auth/cognito.ts
@@ -6,6 +6,9 @@ import {
   CognitoUserSession,
 } from 'amazon-cognito-identity-js'
 
+// Re-export CognitoUser type for challenge references
+export type { CognitoUser } from 'amazon-cognito-identity-js'
+
 // Environment config — these must be set as NEXT_PUBLIC_ env vars
 const USER_POOL_ID = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? ''
 const CLIENT_ID = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? ''
@@ -32,6 +35,25 @@ export interface AuthTokens {
   accessToken: string
   refreshToken: string
 }
+
+export interface SignInSuccess {
+  type: 'success'
+  tokens: AuthTokens
+}
+
+export interface NewPasswordChallenge {
+  type: 'newPasswordRequired'
+  cognitoUser: CognitoUser
+  requiredAttributes: Record<string, string>
+}
+
+export interface MfaChallenge {
+  type: 'mfaRequired'
+  cognitoUser: CognitoUser
+  mfaType: string
+}
+
+export type SignInResult = SignInSuccess | NewPasswordChallenge | MfaChallenge
 
 export interface SignUpResult {
   userConfirmed: boolean
@@ -102,8 +124,10 @@ export function resendConfirmationCode(email: string): Promise<void> {
 
 /**
  * Sign in with email and password using SRP auth flow.
+ * Returns a discriminated union: success with tokens, or a challenge that
+ * the caller must complete (new password, MFA, etc.).
  */
-export function signIn(email: string, password: string): Promise<AuthTokens> {
+export function signIn(email: string, password: string): Promise<SignInResult> {
   const user = getCognitoUser(email)
   const authDetails = new AuthenticationDetails({
     Username: email,
@@ -112,6 +136,77 @@ export function signIn(email: string, password: string): Promise<AuthTokens> {
 
   return new Promise((resolve, reject) => {
     user.authenticateUser(authDetails, {
+      onSuccess: (session: CognitoUserSession) => {
+        resolve({
+          type: 'success',
+          tokens: {
+            idToken: session.getIdToken().getJwtToken(),
+            accessToken: session.getAccessToken().getJwtToken(),
+            refreshToken: session.getRefreshToken().getToken(),
+          },
+        })
+      },
+      onFailure: (err: Error) => {
+        reject(err)
+      },
+      newPasswordRequired: (userAttributes: Record<string, string>) => {
+        resolve({
+          type: 'newPasswordRequired',
+          cognitoUser: user,
+          requiredAttributes: userAttributes,
+        })
+      },
+      mfaRequired: (challengeName: string) => {
+        resolve({
+          type: 'mfaRequired',
+          cognitoUser: user,
+          mfaType: challengeName,
+        })
+      },
+      totpRequired: (challengeName: string) => {
+        resolve({
+          type: 'mfaRequired',
+          cognitoUser: user,
+          mfaType: challengeName,
+        })
+      },
+    })
+  })
+}
+
+/**
+ * Complete the NEW_PASSWORD_REQUIRED challenge after sign-in.
+ * Called when an admin-created user must set their own password on first login.
+ */
+export function completeNewPassword(
+  cognitoUser: CognitoUser,
+  newPassword: string,
+): Promise<AuthTokens> {
+  return new Promise((resolve, reject) => {
+    cognitoUser.completeNewPasswordChallenge(newPassword, {}, {
+      onSuccess: (session: CognitoUserSession) => {
+        resolve({
+          idToken: session.getIdToken().getJwtToken(),
+          accessToken: session.getAccessToken().getJwtToken(),
+          refreshToken: session.getRefreshToken().getToken(),
+        })
+      },
+      onFailure: (err: Error) => {
+        reject(err)
+      },
+    })
+  })
+}
+
+/**
+ * Complete an MFA challenge by submitting the verification code.
+ */
+export function completeMfaChallenge(
+  cognitoUser: CognitoUser,
+  code: string,
+): Promise<AuthTokens> {
+  return new Promise((resolve, reject) => {
+    cognitoUser.sendMFACode(code, {
       onSuccess: (session: CognitoUserSession) => {
         resolve({
           idToken: session.getIdToken().getJwtToken(),

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,3 +1,3 @@
 export { AuthProvider, useAuth } from './auth-provider'
-export type { AuthContextValue, AuthUser } from './auth-provider'
-export type { AuthTokens, SignUpResult } from './cognito'
+export type { AuthContextValue, AuthUser, PendingChallenge } from './auth-provider'
+export type { AuthTokens, SignUpResult, SignInResult } from './cognito'

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,15 +542,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "apps/web/node_modules/lucide-react": {
-      "version": "0.576.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.576.0.tgz",
-      "integrity": "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "apps/web/node_modules/posthog-js": {
       "version": "1.360.0",
       "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.360.0.tgz",
@@ -934,20 +925,71 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ses": {
+      "version": "3.1005.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1005.0.tgz",
+      "integrity": "sha512-Es0tQ9b9yuIl/27Zlzmx7FTvGtK9uTA3RraRzA1Xb4tLYy9KAnotqwrq0qJdfnWorpHS+1sOuXUg1WyyC2bwHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/credential-provider-node": "^3.972.19",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
-      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
+      "version": "3.973.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.19.tgz",
+      "integrity": "sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
         "@aws-sdk/xml-builder": "^3.972.10",
-        "@smithy/core": "^3.23.8",
+        "@smithy/core": "^3.23.9",
         "@smithy/node-config-provider": "^4.3.11",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/protocol-http": "^5.3.11",
         "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.11",
@@ -972,12 +1014,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
-      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.17.tgz",
+      "integrity": "sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/core": "^3.973.19",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/types": "^4.13.0",
@@ -988,18 +1030,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
-      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.19.tgz",
+      "integrity": "sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/core": "^3.973.19",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/fetch-http-handler": "^5.3.13",
         "@smithy/node-http-handler": "^4.4.14",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
         "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
@@ -1009,19 +1051,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.17.tgz",
-      "integrity": "sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.18.tgz",
+      "integrity": "sha512-vthIAXJISZnj2576HeyLBj4WTeX+I7PwWeRkbOa0mVX39K13SCGxCgOFuKj2ytm9qTlLOmXe4cdEnroteFtJfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-login": "^3.972.17",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.17",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
-        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/credential-provider-env": "^3.972.17",
+        "@aws-sdk/credential-provider-http": "^3.972.19",
+        "@aws-sdk/credential-provider-login": "^3.972.18",
+        "@aws-sdk/credential-provider-process": "^3.972.17",
+        "@aws-sdk/credential-provider-sso": "^3.972.18",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.18",
+        "@aws-sdk/nested-clients": "^3.996.8",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/credential-provider-imds": "^4.2.11",
         "@smithy/property-provider": "^4.2.11",
@@ -1034,13 +1076,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.17.tgz",
-      "integrity": "sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.18.tgz",
+      "integrity": "sha512-kINzc5BBxdYBkPZ0/i1AMPMOk5b5QaFNbYMElVw5QTX13AKj6jcxnv/YNl9oW9mg+Y08ti19hh01HhyEAxsSJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/protocol-http": "^5.3.11",
@@ -1053,17 +1095,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.18.tgz",
-      "integrity": "sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.19.tgz",
+      "integrity": "sha512-yDWQ9dFTr+IMxwanFe7+tbN5++q8psZBjlUwOiCXn1EzANoBgtqBwcpYcHaMGtn0Wlfj4NuXdf2JaEx1lz5RaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-ini": "^3.972.17",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.17",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
+        "@aws-sdk/credential-provider-env": "^3.972.17",
+        "@aws-sdk/credential-provider-http": "^3.972.19",
+        "@aws-sdk/credential-provider-ini": "^3.972.18",
+        "@aws-sdk/credential-provider-process": "^3.972.17",
+        "@aws-sdk/credential-provider-sso": "^3.972.18",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.18",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/credential-provider-imds": "^4.2.11",
         "@smithy/property-provider": "^4.2.11",
@@ -1076,12 +1118,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
-      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.17.tgz",
+      "integrity": "sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/core": "^3.973.19",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/shared-ini-file-loader": "^4.4.6",
@@ -1093,14 +1135,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.17.tgz",
-      "integrity": "sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.18.tgz",
+      "integrity": "sha512-YHYEfj5S2aqInRt5ub8nDOX8vAxgMvd84wm2Y3WVNfFa/53vOv9T7WOAqXI25qjj3uEcV46xxfqdDQk04h5XQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/token-providers": "3.1004.0",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/token-providers": "3.1005.0",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/shared-ini-file-loader": "^4.4.6",
@@ -1112,13 +1154,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.17.tgz",
-      "integrity": "sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.18.tgz",
+      "integrity": "sha512-OqlEQpJ+J3T5B96qtC1zLLwkBloechP+fezKbCH0sbd2cCc0Ra55XpxWpk/hRj69xAOYtHvoC4orx6eTa4zU7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/shared-ini-file-loader": "^4.4.6",
@@ -1286,15 +1328,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.19.tgz",
-      "integrity": "sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.20.tgz",
+      "integrity": "sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/core": "^3.973.19",
         "@aws-sdk/types": "^3.973.5",
         "@aws-sdk/util-endpoints": "^3.996.4",
-        "@smithy/core": "^3.23.8",
+        "@smithy/core": "^3.23.9",
         "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
         "@smithy/util-retry": "^4.2.11",
@@ -1305,44 +1347,44 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.7.tgz",
-      "integrity": "sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.8.tgz",
+      "integrity": "sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/core": "^3.973.19",
         "@aws-sdk/middleware-host-header": "^3.972.7",
         "@aws-sdk/middleware-logger": "^3.972.7",
         "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
         "@aws-sdk/region-config-resolver": "^3.972.7",
         "@aws-sdk/types": "^3.973.5",
         "@aws-sdk/util-endpoints": "^3.996.4",
         "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.4",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
         "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.8",
+        "@smithy/core": "^3.23.9",
         "@smithy/fetch-http-handler": "^5.3.13",
         "@smithy/hash-node": "^4.2.11",
         "@smithy/invalid-dependency": "^4.2.11",
         "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.22",
-        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
         "@smithy/middleware-serde": "^4.2.12",
         "@smithy/middleware-stack": "^4.2.11",
         "@smithy/node-config-provider": "^4.3.11",
         "@smithy/node-http-handler": "^4.4.14",
         "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/smithy-client": "^4.12.3",
         "@smithy/types": "^4.13.0",
         "@smithy/url-parser": "^4.2.11",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.38",
-        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
         "@smithy/util-endpoints": "^3.3.2",
         "@smithy/util-middleware": "^4.2.11",
         "@smithy/util-retry": "^4.2.11",
@@ -1407,13 +1449,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1004.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1004.0.tgz",
-      "integrity": "sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==",
+      "version": "3.1005.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1005.0.tgz",
+      "integrity": "sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/property-provider": "^4.2.11",
         "@smithy/shared-ini-file-loader": "^4.4.6",
@@ -1505,12 +1547,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.4.tgz",
-      "integrity": "sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.5.tgz",
+      "integrity": "sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
         "@aws-sdk/types": "^3.973.5",
         "@smithy/node-config-provider": "^4.3.11",
         "@smithy/types": "^4.13.0",
@@ -12526,7 +12568,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12548,7 +12589,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12570,7 +12610,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12592,7 +12631,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12614,7 +12652,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12636,7 +12673,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12658,7 +12694,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12680,7 +12715,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12702,7 +12736,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12724,7 +12757,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12746,7 +12778,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12863,6 +12894,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -17279,7 +17319,7 @@
       "name": "@surfaced-art/email",
       "version": "0.0.1",
       "dependencies": {
-        "@aws-sdk/client-ses": "^3.1000.0",
+        "@aws-sdk/client-ses": "^3.1004.0",
         "@react-email/components": "^1.0.8",
         "@react-email/render": "^2.0.4",
         "@surfaced-art/utils": "^0.0.1"
@@ -17292,57 +17332,6 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
-      }
-    },
-    "packages/email/node_modules/@aws-sdk/client-ses": {
-      "version": "3.1000.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1000.0.tgz",
-      "integrity": "sha512-JCNw8ep18XHFdSQ1PBAeWnFWBdsrgCq0sdJILlikpBJ6skd3hg3GwHb0yPgG/wxiahAXDvl8z+kpnWTn7Kb/aQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/credential-provider-node": "^3.972.14",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.15",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.0",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/util-waiter": "^4.2.10",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "packages/email/node_modules/@react-email/body": {


### PR DESCRIPTION
## Summary
- Security scans (`security.yml`) were only running on PRs to `main`, allowing vulnerabilities to merge to `dev` undetected. Now runs on PRs to both `dev` and `main`.
- Integration tests were missing from the dev CI pipeline (`ci.yml`). Now runs `npm run test:integration` after unit tests, matching `pr.yml`.
- Standardized `hashicorp/setup-terraform` from `@v3` to `@v4` in `ci.yml` to match all other workflows.
- Fixed out-of-sync `package-lock.json` that was causing `npm ci` failures across all branches.
- Merged `fix/auth-challenge-handling` branch (Cognito auth challenge handling for sign-in flow).

## Context
A CI pipeline audit revealed that PR #426 was auto-merged to `dev` despite `Quality Gates` failing, because no required status checks were configured on the `dev` branch. This PR fixes the code-level gaps; branch protection rules (required checks) must be configured separately in GitHub Settings.

## Manual steps required (not in this PR)
Configure branch protection in **Settings → Branches**:

**`dev` branch:**
- Require status checks: `Quality Gates`, `Terraform Plan (dev)`, `Security Scan`, `Analyze (actions)`, `Analyze (javascript-typescript)`

**`main` branch:**
- Require PR with 1 approval
- Require status checks: `Build & Test`, `Terraform Plan (prod)`, `Security Scan`, `Analyze (actions)`, `Analyze (javascript-typescript)`

## Test plan
- [ ] Verify CI runs security scans on this PR (targeting `dev`)
- [ ] Verify integration tests run as part of Quality Gates
- [ ] Verify Terraform plan step uses `@v4`
- [ ] Verify `npm ci` passes (lockfile in sync)
- [ ] After merge, configure branch protection rules in GitHub Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)