### PR TITLE
fix(web): clamp extreme portrait aspect ratios in ListingCard

### DIFF
--- a/apps/web/src/components/ListingCard.tsx
+++ b/apps/web/src/components/ListingCard.tsx
@@ -30,11 +30,20 @@ export function ListingCard({
   const isSold = listing.status === 'sold'
   const href = `/listing/${listing.id}`
 
-  // Use natural aspect ratio if dimensions are known, fall back to square
+  // Use natural aspect ratio if dimensions are known, fall back to square.
+  // Clamp extreme portrait ratios to 2:3 (w:h) so tall narrow artwork
+  // doesn't blow out masonry columns.
   const hasNaturalRatio = listing.primaryImageWidth && listing.primaryImageHeight
-  const aspectStyle = hasNaturalRatio
-    ? { aspectRatio: `${listing.primaryImageWidth} / ${listing.primaryImageHeight}` }
-    : undefined
+  const MIN_RATIO = 2 / 3 // most portrait allowed (height = 1.5× width)
+  let aspectStyle: { aspectRatio: string } | undefined
+  if (hasNaturalRatio) {
+    const naturalRatio = listing.primaryImageWidth! / listing.primaryImageHeight!
+    if (naturalRatio < MIN_RATIO) {
+      aspectStyle = { aspectRatio: '2 / 3' }
+    } else {
+      aspectStyle = { aspectRatio: `${listing.primaryImageWidth} / ${listing.primaryImageHeight}` }
+    }
+  }
   const aspectClass = hasNaturalRatio ? '' : 'aspect-square'
 
   return (

--- a/apps/web/src/components/__tests__/ListingCard.test.tsx
+++ b/apps/web/src/components/__tests__/ListingCard.test.tsx
@@ -118,6 +118,61 @@ describe('ListingCard', () => {
     expect(link).toHaveAttribute('href', `/listing/${baseListing.id}`)
   })
 
+  it('should clamp extreme portrait aspect ratios to max 2:3', () => {
+    render(
+      <ListingCard
+        listing={{
+          ...baseListing,
+          // Extreme portrait: 200px wide × 1200px tall (1:6 ratio)
+          primaryImageWidth: 200,
+          primaryImageHeight: 1200,
+        }}
+        artistName="Abbey Peters"
+      />
+    )
+
+    const card = screen.getByTestId('listing-card')
+    const imageContainer = card.querySelector('[class*="overflow-hidden"]') as HTMLElement
+    // Should be clamped to 2/3 (max portrait), not the natural 200/1200
+    expect(imageContainer?.style.aspectRatio).toBe('2 / 3')
+  })
+
+  it('should not clamp moderate portrait aspect ratios', () => {
+    render(
+      <ListingCard
+        listing={{
+          ...baseListing,
+          // Normal portrait: 800px wide × 1000px tall (4:5 ratio)
+          primaryImageWidth: 800,
+          primaryImageHeight: 1000,
+        }}
+        artistName="Abbey Peters"
+      />
+    )
+
+    const card = screen.getByTestId('listing-card')
+    const imageContainer = card.querySelector('[class*="overflow-hidden"]') as HTMLElement
+    expect(imageContainer?.style.aspectRatio).toBe('800 / 1000')
+  })
+
+  it('should not clamp landscape aspect ratios', () => {
+    render(
+      <ListingCard
+        listing={{
+          ...baseListing,
+          // Wide landscape: 1200px × 400px (3:1 ratio)
+          primaryImageWidth: 1200,
+          primaryImageHeight: 400,
+        }}
+        artistName="Abbey Peters"
+      />
+    )
+
+    const card = screen.getByTestId('listing-card')
+    const imageContainer = card.querySelector('[class*="overflow-hidden"]') as HTMLElement
+    expect(imageContainer?.style.aspectRatio).toBe('1200 / 400')
+  })
+
   it('should apply data-testid', () => {
     render(
       <ListingCard


### PR DESCRIPTION
## Summary
- Tall narrow artwork (e.g. scarves at ~1:6 ratio) blew out masonry grid columns, creating massive empty space in adjacent columns
- Clamp the image container aspect ratio to a minimum of 2:3 (w:h) — the tallest a card can be is 1.5× its width
- Images beyond this ratio use `object-cover` to show the center portion, preserving the masonry grid balance
- Standard portrait ratios (4:5, 3:4, 2:3) and all landscape ratios are unaffected

## Test plan
- [x] 3 new tests: extreme portrait clamped, moderate portrait unchanged, landscape unchanged
- [x] All 478 web tests pass
- [x] Lint, typecheck, build all pass
- [ ] After deploy: verify tall artwork cards are reasonably sized in masonry grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)