### PR TITLE
fix(db): revert seed dimensions, add backfill pipeline step

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -531,6 +531,42 @@ jobs:
             console.log('Database seeded successfully');
           "
 
+  backfill-dimensions:
+    name: Backfill Image Dimensions
+    runs-on: ubuntu-latest
+    needs: [terraform, seed-database]
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Backfill image dimensions via Lambda
+        run: |
+          aws lambda invoke \
+            --function-name ${{ needs.terraform.outputs.migrate_function_name }} \
+            --payload '{"command":"backfill-dimensions"}' \
+            --cli-binary-format raw-in-base64-out \
+            --read-timeout 300 \
+            /tmp/backfill-response.json
+
+          echo "Backfill response:"
+          cat /tmp/backfill-response.json
+
+          node -e "
+            const r = JSON.parse(require('fs').readFileSync('/tmp/backfill-response.json', 'utf8'));
+            if (!r.success) { console.error('Backfill failed:', r.error); process.exit(1); }
+            console.log('Image dimensions backfilled successfully');
+          "
+
   verify:
     name: Verify Deployment
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -501,6 +501,42 @@ jobs:
             console.log('Migrations completed successfully');
           "
 
+  backfill-dimensions:
+    name: Backfill Image Dimensions
+    runs-on: ubuntu-latest
+    needs: [terraform, migrate-database]
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Backfill image dimensions via Lambda
+        run: |
+          aws lambda invoke \
+            --function-name ${{ needs.terraform.outputs.migrate_function_name }} \
+            --payload '{"command":"backfill-dimensions"}' \
+            --cli-binary-format raw-in-base64-out \
+            --read-timeout 300 \
+            /tmp/backfill-response.json
+
+          echo "Backfill response:"
+          cat /tmp/backfill-response.json
+
+          node -e "
+            const r = JSON.parse(require('fs').readFileSync('/tmp/backfill-response.json', 'utf8'));
+            if (!r.success) { console.error('Backfill failed:', r.error); process.exit(1); }
+            console.log('Image dimensions backfilled successfully');
+          "
+
   verify:
     name: Verify Deployment
     runs-on: ubuntu-latest

--- a/packages/db/prisma/backfill-dimensions.ts
+++ b/packages/db/prisma/backfill-dimensions.ts
@@ -1,0 +1,162 @@
+/**
+ * Backfill image dimensions for listing_images rows.
+ *
+ * Reads each image from its CloudFront URL, extracts pixel dimensions
+ * from format headers (PNG/JPEG/WebP), and updates the width/height
+ * columns. Only processes rows where width IS NULL (idempotent).
+ *
+ * Designed to run inside the migrate Lambda via tsx, following the
+ * same pattern as seed-safe.ts.
+ */
+import { PrismaClient } from '../src/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+if (!process.env.DATABASE_URL) {
+  console.error('ERROR: DATABASE_URL is not set.')
+  process.exit(1)
+}
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+  ssl:
+    process.env.NODE_ENV === 'development'
+      ? false
+      : process.env.DB_SSL_REJECT_UNAUTHORIZED === 'false'
+        ? { rejectUnauthorized: false }
+        : true,
+})
+
+const prisma = new PrismaClient({ adapter })
+
+// ---------------------------------------------------------------------------
+// Image dimension reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read width/height from image binary data by parsing format headers.
+ * Supports PNG, JPEG, and WebP without external dependencies.
+ */
+function readImageDimensions(buf: Buffer): { width: number; height: number } | null {
+  // PNG: bytes 0-7 are signature, IHDR chunk starts at byte 8
+  // Width at offset 16, height at offset 20 (big-endian uint32)
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
+    const width = buf.readUInt32BE(16)
+    const height = buf.readUInt32BE(20)
+    return { width, height }
+  }
+
+  // JPEG: SOI marker (0xFFD8), then scan for SOF0/SOF2 markers
+  if (buf[0] === 0xff && buf[1] === 0xd8) {
+    let offset = 2
+    while (offset < buf.length - 1) {
+      if (buf[offset] !== 0xff) break
+      const marker = buf[offset + 1]!
+      // SOF0 (0xC0) or SOF2 (0xC2) — contains dimensions
+      if (marker === 0xc0 || marker === 0xc2) {
+        const height = buf.readUInt16BE(offset + 5)
+        const width = buf.readUInt16BE(offset + 7)
+        return { width, height }
+      }
+      // Skip to next marker
+      if (marker === 0xd9) break // EOI
+      const segLength = buf.readUInt16BE(offset + 2)
+      offset += 2 + segLength
+    }
+    return null
+  }
+
+  // WebP: RIFF header, then "WEBP" at offset 8
+  if (buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') {
+    const chunk = buf.toString('ascii', 12, 16)
+    if (chunk === 'VP8 ') {
+      // Lossy WebP: dimensions at offset 26-29
+      const width = buf.readUInt16LE(26) & 0x3fff
+      const height = buf.readUInt16LE(28) & 0x3fff
+      return { width, height }
+    }
+    if (chunk === 'VP8L') {
+      // Lossless WebP: dimensions encoded in first 4 bytes of bitstream at offset 21
+      const bits = buf.readUInt32LE(21)
+      const width = (bits & 0x3fff) + 1
+      const height = ((bits >> 14) & 0x3fff) + 1
+      return { width, height }
+    }
+    if (chunk === 'VP8X') {
+      // Extended WebP: width at 24 (3 bytes LE), height at 27 (3 bytes LE)
+      const width = (buf[24]! | (buf[25]! << 8) | (buf[26]! << 16)) + 1
+      const height = (buf[27]! | (buf[28]! << 8) | (buf[29]! << 16)) + 1
+      return { width, height }
+    }
+  }
+
+  return null
+}
+
+async function getImageDimensionsFromUrl(url: string): Promise<{ width: number; height: number } | null> {
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      console.warn(`  SKIP: HTTP ${response.status} for ${url}`)
+      return null
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    const dims = readImageDimensions(buffer)
+    if (!dims) {
+      console.warn(`  SKIP: Could not parse dimensions from ${url}`)
+      return null
+    }
+
+    return dims
+  } catch (err) {
+    console.warn(`  SKIP: Fetch error for ${url}: ${err instanceof Error ? err.message : err}`)
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const images = await prisma.listingImage.findMany({
+    where: { width: null },
+    select: { id: true, url: true },
+  })
+
+  console.log(`Found ${images.length} images without dimensions`)
+
+  let updated = 0
+  let skipped = 0
+
+  for (const image of images) {
+    console.log(`Processing ${image.url}...`)
+    const dims = await getImageDimensionsFromUrl(image.url)
+
+    if (!dims) {
+      skipped++
+      continue
+    }
+
+    console.log(`  ${dims.width}x${dims.height}`)
+
+    await prisma.listingImage.update({
+      where: { id: image.id },
+      data: { width: dims.width, height: dims.height },
+    })
+
+    updated++
+  }
+
+  console.log(`\nDone: ${updated} updated, ${skipped} skipped`)
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })

--- a/packages/db/prisma/seed-logic.ts
+++ b/packages/db/prisma/seed-logic.ts
@@ -10,30 +10,6 @@ import type { ArtistSeedConfig } from './seed-data'
 
 type TransactionClient = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
 
-/**
- * Derives image pixel dimensions from artwork physical proportions.
- *
- * Product photos of artwork closely match the artwork's aspect ratio,
- * so we scale the physical dimensions (artworkLength × artworkWidth) to
- * pixel dimensions with the longest side at `maxPixels`.
- *
- * @param artworkLength - Physical height of the artwork (inches)
- * @param artworkWidth - Physical width of the artwork (inches)
- * @param maxPixels - Maximum pixel dimension for the longest side (default 1200)
- */
-export function artworkToImageDimensions(
-  artworkLength: number,
-  artworkWidth: number,
-  maxPixels = 1200
-): { width: number; height: number } {
-  const longest = Math.max(artworkLength, artworkWidth)
-  const scale = maxPixels / longest
-  return {
-    width: Math.round(artworkWidth * scale),
-    height: Math.round(artworkLength * scale),
-  }
-}
-
 export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) {
   // Upsert user
   const user = await tx.user.upsert({
@@ -142,15 +118,12 @@ export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) 
     // Create 2 images per listing: primary + one additional angle
     // For documented listings, second image is a process photo
     const listingImageBase = `${seedKey(data.profile.slug, 'listings')}/${listingSlug}`
-    const imageDimensions = artworkToImageDimensions(listingData.artworkLength, listingData.artworkWidth)
     await tx.listingImage.create({
       data: {
         listingId: listing.id,
         url: cdnUrl(`${listingImageBase}/front`),
         isProcessPhoto: false,
         sortOrder: 0,
-        width: imageDimensions.width,
-        height: imageDimensions.height,
       },
     })
     await tx.listingImage.create({
@@ -159,8 +132,6 @@ export async function seedArtist(tx: TransactionClient, data: ArtistSeedConfig) 
         url: cdnUrl(`${listingImageBase}/angle`),
         isProcessPhoto: listingData.isDocumented,
         sortOrder: 1,
-        width: imageDimensions.width,
-        height: imageDimensions.height,
       },
     })
   }

--- a/packages/db/prisma/seed.test.ts
+++ b/packages/db/prisma/seed.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { validateSlug } from '@surfaced-art/utils'
 import { artistConfigs, CDN_BASE, realArtistConfigs, demoArtistConfigs } from './seed-data'
-import { artworkToImageDimensions } from './seed-logic.js'
 
 /**
  * Seed data validation tests.
@@ -214,49 +213,6 @@ describe('Seed Data Validation', () => {
         await expect(import('./seed-data')).rejects.toThrow('Invalid SEED_MODE')
       } finally {
         vi.unstubAllEnvs()
-      }
-    })
-  })
-
-  describe('listing image dimensions', () => {
-    it('should derive image pixel dimensions from artwork physical proportions', () => {
-      // Landscape painting: 36" tall × 48" wide → landscape image
-      const landscape = artworkToImageDimensions(36, 48)
-      expect(landscape.width).toBe(1200)
-      expect(landscape.height).toBe(900)
-
-      // Portrait painting: 48" tall × 36" wide → portrait image
-      const portrait = artworkToImageDimensions(48, 36)
-      expect(portrait.width).toBe(900)
-      expect(portrait.height).toBe(1200)
-
-      // Square artwork: 24" × 24" → square image
-      const square = artworkToImageDimensions(24, 24)
-      expect(square.width).toBe(1200)
-      expect(square.height).toBe(1200)
-    })
-
-    it('should return integer pixel values', () => {
-      // 7" × 5" → ratio 7:5 → height=1200, width=857 (rounded)
-      const result = artworkToImageDimensions(7, 5)
-      expect(Number.isInteger(result.width)).toBe(true)
-      expect(Number.isInteger(result.height)).toBe(true)
-      expect(result.width).toBe(857)
-      expect(result.height).toBe(1200)
-    })
-
-    it('should scale to maxPixels parameter when provided', () => {
-      const result = artworkToImageDimensions(36, 48, 800)
-      expect(result.width).toBe(800)
-      expect(result.height).toBe(600)
-    })
-
-    it('should handle all seed listings (artworkLength and artworkWidth > 0)', () => {
-      for (const config of artistConfigs) {
-        for (const listing of config.listings) {
-          expect(listing.artworkLength).toBeGreaterThan(0)
-          expect(listing.artworkWidth).toBeGreaterThan(0)
-        }
       }
     })
   })

--- a/tools/migrate/src/index.ts
+++ b/tools/migrate/src/index.ts
@@ -9,7 +9,7 @@ const PRISMA_CLI = `${LAMBDA_ROOT}/node_modules/prisma/build/index.js`
 const PRISMA_CMD = `node ${PRISMA_CLI}`
 
 interface MigrateEvent {
-  command: 'migrate' | 'force-reapply-baseline' | 'reset-baseline' | 'resolve-rolled-back' | 'seed'
+  command: 'migrate' | 'force-reapply-baseline' | 'reset-baseline' | 'resolve-rolled-back' | 'seed' | 'backfill-dimensions'
   migration?: string
 }
 
@@ -19,7 +19,7 @@ interface MigrateResult {
 }
 
 export const handler = async (event: MigrateEvent): Promise<MigrateResult> => {
-  const validCommands = ['migrate', 'force-reapply-baseline', 'reset-baseline', 'resolve-rolled-back', 'seed']
+  const validCommands = ['migrate', 'force-reapply-baseline', 'reset-baseline', 'resolve-rolled-back', 'seed', 'backfill-dimensions']
   if (!validCommands.includes(event.command)) {
     return { success: false, error: `Unknown command: ${event.command}` }
   }
@@ -67,6 +67,36 @@ export const handler = async (event: MigrateEvent): Promise<MigrateResult> => {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err)
       console.error('Seed failed:', message)
+      return { success: false, error: message }
+    }
+  }
+
+  // backfill-dimensions: reads actual pixel dimensions from CloudFront image
+  // URLs and updates listing_images rows that have NULL width/height. This
+  // runs after seeding so that seed-created images get real dimensions from
+  // the CDN rather than derived-from-artwork approximations. Idempotent —
+  // only processes rows where width IS NULL.
+  if (event.command === 'backfill-dimensions') {
+    try {
+      const tsxPath = `${LAMBDA_ROOT}/node_modules/.bin/tsx`
+      const backfillScript = `${LAMBDA_ROOT}/prisma/backfill-dimensions.ts`
+
+      if (!fs.existsSync(backfillScript)) {
+        return {
+          success: false,
+          error: `Backfill script not found at ${backfillScript}. Ensure the Dockerfile copies prisma/backfill-dimensions.ts.`,
+        }
+      }
+
+      const output = execSync(
+        `node ${tsxPath} ${backfillScript}`,
+        { ...execOpts, timeout: 300000 } // 5 minute timeout for fetching images
+      )
+      console.log('Backfill output:', output)
+      return { success: true }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('Backfill dimensions failed:', message)
       return { success: false, error: message }
     }
   }


### PR DESCRIPTION
## Summary

- Reverts artwork-derived image dimensions from seed (PR #426) — artwork physical dimensions don't match product photo dimensions (e.g. coasters are square but photographed in landscape)
- Seeds listing images with NULL width/height again, as before #426
- Adds `backfill-dimensions` command to the migrate Lambda that reads real pixel dimensions from CloudFront image URLs (PNG/JPEG/WebP header parsing, no external deps)
- Adds `backfill-dimensions` pipeline step after seeding (dev) and after migrations (prod)
- Backfill is idempotent — only processes rows where `width IS NULL`

## Test plan

- [x] All 472 tests pass (seed dimension tests removed)
- [x] Lint passes
- [x] Typecheck passes
- [x] Build passes
- [ ] Deploy to dev triggers backfill step after seed
- [ ] Verify listing images get real dimensions from CDN
- [ ] Masonry grid displays with correct aspect ratios

Closes #426 revert