### PR TITLE
feat(api): capture image dimensions at upload time

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -3112,6 +3112,90 @@ describe('POST /me/listings/:id/images', () => {
     expect(body).toHaveProperty('url')
     expect(body).not.toHaveProperty('listingId')
   })
+
+  it('should extract dimensions from image URL and store them', async () => {
+    // Build a minimal PNG buffer (1920x1080)
+    const pngBuf = Buffer.alloc(24)
+    pngBuf[0] = 0x89; pngBuf[1] = 0x50; pngBuf[2] = 0x4e; pngBuf[3] = 0x47
+    pngBuf[4] = 0x0d; pngBuf[5] = 0x0a; pngBuf[6] = 0x1a; pngBuf[7] = 0x0a
+    pngBuf.writeUInt32BE(13, 8)
+    pngBuf.write('IHDR', 12, 'ascii')
+    pngBuf.writeUInt32BE(1920, 16)
+    pngBuf.writeUInt32BE(1080, 20)
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(pngBuf.buffer.slice(pngBuf.byteOffset, pngBuf.byteOffset + pngBuf.byteLength)),
+    }) as unknown as typeof fetch
+
+    try {
+      const created = { ...mockListingImageForTest, width: 1920, height: 1080 }
+      const prisma = createMockPrisma({ createdListingImage: created })
+      ;(prisma.listing.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(mockListingDb)
+      const app = createTestApp(prisma)
+
+      const res = await postListingImage(app, LISTING_ID_1, {
+        url: 'https://d2agn4aoo0e7ji.cloudfront.net/uploads/listing/img1.jpg',
+      }, 'valid-token')
+      expect(res.status).toBe(201)
+
+      const createCall = (prisma.listingImage.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(createCall.data.width).toBe(1920)
+      expect(createCall.data.height).toBe(1080)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('should still create image if dimension fetch fails', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error')) as unknown as typeof fetch
+
+    try {
+      const created = { ...mockListingImageForTest }
+      const prisma = createMockPrisma({ createdListingImage: created })
+      ;(prisma.listing.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(mockListingDb)
+      const app = createTestApp(prisma)
+
+      const res = await postListingImage(app, LISTING_ID_1, {
+        url: 'https://d2agn4aoo0e7ji.cloudfront.net/uploads/listing/img1.jpg',
+      }, 'valid-token')
+      expect(res.status).toBe(201)
+
+      const createCall = (prisma.listingImage.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(createCall.data.width).toBeNull()
+      expect(createCall.data.height).toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('should still create image if dimension parsing returns null', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)), // not a valid image
+    }) as unknown as typeof fetch
+
+    try {
+      const created = { ...mockListingImageForTest }
+      const prisma = createMockPrisma({ createdListingImage: created })
+      ;(prisma.listing.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(mockListingDb)
+      const app = createTestApp(prisma)
+
+      const res = await postListingImage(app, LISTING_ID_1, {
+        url: 'https://d2agn4aoo0e7ji.cloudfront.net/uploads/listing/img1.jpg',
+      }, 'valid-token')
+      expect(res.status).toBe(201)
+
+      const createCall = (prisma.listingImage.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(createCall.data.width).toBeNull()
+      expect(createCall.data.height).toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })
 
 // ─── DELETE /me/listings/:id/images/:imageId ──────────────────────────

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -4,7 +4,7 @@ import type { CategoryType as PrismaCategoryType } from '@surfaced-art/db'
 import type { CategoriesUpdateResponse, CvEntryResponse, CvEntryListResponse, MyListingImageResponse, MyListingResponse, ProcessMediaResponse, ProcessMediaListResponse, ProfileUpdateResponse, StripeOnboardingResponse, StripeStatusResponse, TagsUpdateResponse, Tag } from '@surfaced-art/types'
 import { fetchDashboard, fetchUserListings } from '../lib/artist-queries'
 import { categoriesUpdateBody, cvEntryBody, cvEntryReorderBody, listingAvailabilityBody, listingCreateBody, listingImageBody, listingImageReorderBody, listingTagsUpdateBody, listingUpdateBody, myListingsQuery, processMediaPhotoBody, processMediaVideoBody, processMediaReorderBody, profileUpdateBody, sanitizeText, tagsUpdateBody } from '@surfaced-art/types'
-import { logger } from '@surfaced-art/utils'
+import { logger, readImageDimensions } from '@surfaced-art/utils'
 import { authMiddleware, requireRole, type AuthUser } from '../middleware/auth'
 import { notFound, badRequest, validationError, conflict, internalError } from '../errors'
 import { triggerRevalidation } from '../lib/revalidation'
@@ -1312,14 +1312,36 @@ export function createMeRoutes(prisma: PrismaClient) {
       where: { listingId },
     })
 
+    // Extract dimensions from the image binary header (best-effort)
+    let width: number | null = parsed.data.width ?? null
+    let height: number | null = parsed.data.height ?? null
+    if (width === null || height === null) {
+      try {
+        const imgResponse = await fetch(parsed.data.url)
+        if (imgResponse.ok) {
+          const buffer = Buffer.from(await imgResponse.arrayBuffer())
+          const dims = readImageDimensions(buffer)
+          if (dims) {
+            width = dims.width
+            height = dims.height
+          }
+        }
+      } catch (err) {
+        logger.warn('Failed to extract image dimensions', {
+          url: parsed.data.url,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
     const created = await prisma.listingImage.create({
       data: {
         listingId,
         url: parsed.data.url,
         isProcessPhoto: parsed.data.isProcessPhoto,
         sortOrder: imageCount,
-        width: parsed.data.width ?? null,
-        height: parsed.data.height ?? null,
+        width,
+        height,
       },
     })
 

--- a/packages/utils/src/image-dimensions.test.ts
+++ b/packages/utils/src/image-dimensions.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest'
+import { readImageDimensions } from './image-dimensions'
+
+// ─── Helper: build minimal image buffers for testing ─────────────────
+
+/** Build a minimal valid PNG buffer with given dimensions. */
+function makePng(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24)
+  // PNG signature
+  buf[0] = 0x89
+  buf[1] = 0x50 // P
+  buf[2] = 0x4e // N
+  buf[3] = 0x47 // G
+  buf[4] = 0x0d
+  buf[5] = 0x0a
+  buf[6] = 0x1a
+  buf[7] = 0x0a
+  // IHDR chunk length (placeholder)
+  buf.writeUInt32BE(13, 8)
+  // IHDR chunk type
+  buf.write('IHDR', 12, 'ascii')
+  // Width at offset 16, height at offset 20
+  buf.writeUInt32BE(width, 16)
+  buf.writeUInt32BE(height, 20)
+  return buf
+}
+
+/** Build a minimal valid JPEG buffer with SOF0 marker at given dimensions. */
+function makeJpeg(width: number, height: number): Buffer {
+  // SOI + APP0 (minimal) + SOF0 with dimensions
+  const buf = Buffer.alloc(20)
+  // SOI marker
+  buf[0] = 0xff
+  buf[1] = 0xd8
+  // APP0 marker
+  buf[2] = 0xff
+  buf[3] = 0xe0
+  // APP0 segment length (small)
+  buf.writeUInt16BE(4, 4)
+  // SOF0 marker at offset 8 (after SOI + APP0)
+  buf[8] = 0xff
+  buf[9] = 0xc0
+  // SOF0 segment length
+  buf.writeUInt16BE(8, 10)
+  // Precision byte
+  buf[12] = 8
+  // Height at offset 13, width at offset 15
+  buf.writeUInt16BE(height, 13)
+  buf.writeUInt16BE(width, 15)
+  return buf
+}
+
+/** Build a minimal valid JPEG buffer with SOF2 (progressive) marker. */
+function makeJpegProgressive(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(20)
+  buf[0] = 0xff
+  buf[1] = 0xd8
+  buf[2] = 0xff
+  buf[3] = 0xe0
+  buf.writeUInt16BE(4, 4)
+  buf[8] = 0xff
+  buf[9] = 0xc2 // SOF2
+  buf.writeUInt16BE(8, 10)
+  buf[12] = 8
+  buf.writeUInt16BE(height, 13)
+  buf.writeUInt16BE(width, 15)
+  return buf
+}
+
+/** Build a minimal VP8 (lossy) WebP buffer. */
+function makeWebpVp8(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(30)
+  buf.write('RIFF', 0, 'ascii')
+  buf.writeUInt32LE(22, 4) // file size - 8
+  buf.write('WEBP', 8, 'ascii')
+  buf.write('VP8 ', 12, 'ascii')
+  buf.writeUInt32LE(10, 16) // chunk size
+  // VP8 bitstream header (3 bytes frame tag + 3 bytes sync code)
+  buf[20] = 0x9d
+  buf[21] = 0x01
+  buf[22] = 0x2a
+  // Width and height at offsets 26 and 28 (LE, 14-bit)
+  buf.writeUInt16LE(width & 0x3fff, 26)
+  buf.writeUInt16LE(height & 0x3fff, 28)
+  return buf
+}
+
+/** Build a minimal VP8L (lossless) WebP buffer. */
+function makeWebpVp8l(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(25)
+  buf.write('RIFF', 0, 'ascii')
+  buf.writeUInt32LE(17, 4)
+  buf.write('WEBP', 8, 'ascii')
+  buf.write('VP8L', 12, 'ascii')
+  buf.writeUInt32LE(5, 16) // chunk size
+  // Signature byte
+  buf[20] = 0x2f
+  // Encoded dimensions: (width-1) in bits 0-13, (height-1) in bits 14-27
+  const bits = ((width - 1) & 0x3fff) | (((height - 1) & 0x3fff) << 14)
+  buf.writeUInt32LE(bits, 21)
+  return buf
+}
+
+/** Build a minimal VP8X (extended) WebP buffer. */
+function makeWebpVp8x(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(30)
+  buf.write('RIFF', 0, 'ascii')
+  buf.writeUInt32LE(22, 4)
+  buf.write('WEBP', 8, 'ascii')
+  buf.write('VP8X', 12, 'ascii')
+  buf.writeUInt32LE(10, 16) // chunk size
+  // Flags byte at offset 20
+  buf[20] = 0x00
+  // Reserved bytes 21-23
+  // Canvas width - 1 at offset 24 (3 bytes LE)
+  const w = width - 1
+  buf[24] = w & 0xff
+  buf[25] = (w >> 8) & 0xff
+  buf[26] = (w >> 16) & 0xff
+  // Canvas height - 1 at offset 27 (3 bytes LE)
+  const h = height - 1
+  buf[27] = h & 0xff
+  buf[28] = (h >> 8) & 0xff
+  buf[29] = (h >> 16) & 0xff
+  return buf
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe('readImageDimensions', () => {
+  describe('PNG', () => {
+    it('should read dimensions from a PNG buffer', () => {
+      const result = readImageDimensions(makePng(1920, 1080))
+      expect(result).toEqual({ width: 1920, height: 1080 })
+    })
+
+    it('should handle small PNG dimensions', () => {
+      const result = readImageDimensions(makePng(1, 1))
+      expect(result).toEqual({ width: 1, height: 1 })
+    })
+
+    it('should handle large PNG dimensions', () => {
+      const result = readImageDimensions(makePng(4096, 3072))
+      expect(result).toEqual({ width: 4096, height: 3072 })
+    })
+  })
+
+  describe('JPEG', () => {
+    it('should read dimensions from a JPEG with SOF0 marker', () => {
+      const result = readImageDimensions(makeJpeg(800, 600))
+      expect(result).toEqual({ width: 800, height: 600 })
+    })
+
+    it('should read dimensions from a progressive JPEG (SOF2)', () => {
+      const result = readImageDimensions(makeJpegProgressive(1024, 768))
+      expect(result).toEqual({ width: 1024, height: 768 })
+    })
+  })
+
+  describe('WebP', () => {
+    it('should read dimensions from VP8 (lossy) WebP', () => {
+      const result = readImageDimensions(makeWebpVp8(640, 480))
+      expect(result).toEqual({ width: 640, height: 480 })
+    })
+
+    it('should read dimensions from VP8L (lossless) WebP', () => {
+      const result = readImageDimensions(makeWebpVp8l(1200, 900))
+      expect(result).toEqual({ width: 1200, height: 900 })
+    })
+
+    it('should read dimensions from VP8X (extended) WebP', () => {
+      const result = readImageDimensions(makeWebpVp8x(2048, 1536))
+      expect(result).toEqual({ width: 2048, height: 1536 })
+    })
+  })
+
+  describe('unsupported / invalid', () => {
+    it('should return null for an empty buffer', () => {
+      expect(readImageDimensions(Buffer.alloc(0))).toBeNull()
+    })
+
+    it('should return null for an unrecognised format', () => {
+      const buf = Buffer.from('This is just plain text, not an image')
+      expect(readImageDimensions(buf)).toBeNull()
+    })
+
+    it('should return null for a buffer too short to contain headers', () => {
+      const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47]) // PNG sig, but truncated
+      expect(readImageDimensions(buf)).toBeNull()
+    })
+  })
+})

--- a/packages/utils/src/image-dimensions.ts
+++ b/packages/utils/src/image-dimensions.ts
@@ -1,0 +1,68 @@
+/**
+ * Read width/height from image binary data by parsing format headers.
+ * Supports PNG, JPEG, and WebP without external dependencies.
+ */
+export function readImageDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 4) return null
+
+  // PNG: bytes 0-7 are signature, IHDR chunk starts at byte 8
+  // Width at offset 16, height at offset 20 (big-endian uint32)
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
+    if (buf.length < 24) return null
+    const width = buf.readUInt32BE(16)
+    const height = buf.readUInt32BE(20)
+    return { width, height }
+  }
+
+  // JPEG: SOI marker (0xFFD8), then scan for SOF0/SOF2 markers
+  if (buf[0] === 0xff && buf[1] === 0xd8) {
+    let offset = 2
+    while (offset < buf.length - 1) {
+      if (buf[offset] !== 0xff) break
+      const marker = buf[offset + 1]!
+      // SOF0 (0xC0) or SOF2 (0xC2) — contains dimensions
+      if (marker === 0xc0 || marker === 0xc2) {
+        if (offset + 9 > buf.length) return null
+        const height = buf.readUInt16BE(offset + 5)
+        const width = buf.readUInt16BE(offset + 7)
+        return { width, height }
+      }
+      // Skip to next marker
+      if (marker === 0xd9) break // EOI
+      if (offset + 4 > buf.length) return null
+      const segLength = buf.readUInt16BE(offset + 2)
+      offset += 2 + segLength
+    }
+    return null
+  }
+
+  // WebP: RIFF header, then "WEBP" at offset 8
+  if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') {
+    if (buf.length < 16) return null
+    const chunk = buf.toString('ascii', 12, 16)
+    if (chunk === 'VP8 ') {
+      // Lossy WebP: dimensions at offset 26-29
+      if (buf.length < 30) return null
+      const width = buf.readUInt16LE(26) & 0x3fff
+      const height = buf.readUInt16LE(28) & 0x3fff
+      return { width, height }
+    }
+    if (chunk === 'VP8L') {
+      // Lossless WebP: dimensions encoded in first 4 bytes of bitstream at offset 21
+      if (buf.length < 25) return null
+      const bits = buf.readUInt32LE(21)
+      const width = (bits & 0x3fff) + 1
+      const height = ((bits >> 14) & 0x3fff) + 1
+      return { width, height }
+    }
+    if (chunk === 'VP8X') {
+      // Extended WebP: width at 24 (3 bytes LE), height at 27 (3 bytes LE)
+      if (buf.length < 30) return null
+      const width = (buf[24]! | (buf[25]! << 8) | (buf[26]! << 16)) + 1
+      const height = (buf[27]! | (buf[28]! << 8) | (buf[29]! << 16)) + 1
+      return { width, height }
+    }
+  }
+
+  return null
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -26,6 +26,9 @@ export { generateSlug, validateSlug } from './slug'
 // Logger utilities
 export { logger, type LogLevel, type LogEntry } from './logger'
 
+// Image dimension parsing
+export { readImageDimensions } from './image-dimensions'
+
 // Upload constants
 export {
   UPLOAD_MAX_FILE_SIZE,

--- a/scripts/backfill-image-dimensions.ts
+++ b/scripts/backfill-image-dimensions.ts
@@ -16,6 +16,7 @@
 
 import { PrismaClient } from '../packages/db/src/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
+import { readImageDimensions } from '../packages/utils/src/image-dimensions'
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -54,9 +55,6 @@ async function getImageDimensionsFromUrl(url: string): Promise<{ width: number; 
     }
 
     const buffer = Buffer.from(await response.arrayBuffer())
-
-    // Read dimensions from image headers without a heavy dependency.
-    // Support PNG, JPEG, and WebP formats.
     const dims = readImageDimensions(buffer)
     if (!dims) {
       console.warn(`  SKIP: Could not parse dimensions from ${url}`)
@@ -68,66 +66,6 @@ async function getImageDimensionsFromUrl(url: string): Promise<{ width: number; 
     console.warn(`  SKIP: Fetch error for ${url}: ${err instanceof Error ? err.message : err}`)
     return null
   }
-}
-
-/**
- * Read width/height from image binary data by parsing format headers.
- * Supports PNG, JPEG, and WebP without external dependencies.
- */
-function readImageDimensions(buf: Buffer): { width: number; height: number } | null {
-  // PNG: bytes 0-7 are signature, IHDR chunk starts at byte 8
-  // Width at offset 16, height at offset 20 (big-endian uint32)
-  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
-    const width = buf.readUInt32BE(16)
-    const height = buf.readUInt32BE(20)
-    return { width, height }
-  }
-
-  // JPEG: SOI marker (0xFFD8), then scan for SOF0/SOF2 markers
-  if (buf[0] === 0xff && buf[1] === 0xd8) {
-    let offset = 2
-    while (offset < buf.length - 1) {
-      if (buf[offset] !== 0xff) break
-      const marker = buf[offset + 1]!
-      // SOF0 (0xC0) or SOF2 (0xC2) — contains dimensions
-      if (marker === 0xc0 || marker === 0xc2) {
-        const height = buf.readUInt16BE(offset + 5)
-        const width = buf.readUInt16BE(offset + 7)
-        return { width, height }
-      }
-      // Skip to next marker
-      if (marker === 0xd9) break // EOI
-      const segLength = buf.readUInt16BE(offset + 2)
-      offset += 2 + segLength
-    }
-    return null
-  }
-
-  // WebP: RIFF header, then "WEBP" at offset 8
-  if (buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') {
-    const chunk = buf.toString('ascii', 12, 16)
-    if (chunk === 'VP8 ') {
-      // Lossy WebP: dimensions at offset 26-29
-      const width = buf.readUInt16LE(26) & 0x3fff
-      const height = buf.readUInt16LE(28) & 0x3fff
-      return { width, height }
-    }
-    if (chunk === 'VP8L') {
-      // Lossless WebP: dimensions encoded in first 4 bytes of bitstream at offset 21
-      const bits = buf.readUInt32LE(21)
-      const width = (bits & 0x3fff) + 1
-      const height = ((bits >> 14) & 0x3fff) + 1
-      return { width, height }
-    }
-    if (chunk === 'VP8X') {
-      // Extended WebP: width at 24 (3 bytes LE), height at 27 (3 bytes LE)
-      const width = (buf[24]! | (buf[25]! << 8) | (buf[26]! << 16)) + 1
-      const height = (buf[27]! | (buf[28]! << 8) | (buf[29]! << 16)) + 1
-      return { width, height }
-    }
-  }
-
-  return null
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract `readImageDimensions()` from `scripts/backfill-image-dimensions.ts` into `packages/utils/src/image-dimensions.ts` as a shared utility
- Upload endpoint (`POST /me/listings/:id/images`) now fetches the image from CloudFront and parses PNG/JPEG/WebP binary headers to populate `width`/`height` at creation time
- Graceful fallback: if the fetch fails or dimensions can't be parsed, the image is still created with `null` dimensions (backfill script remains as safety net)
- Backfill script refactored to import from the shared utility instead of its inline copy

SUR-202

## Test plan

- [x] 11 unit tests for `readImageDimensions()` covering PNG, JPEG (SOF0 + SOF2), WebP (VP8/VP8L/VP8X), edge cases (empty buffer, truncated, unrecognised format)
- [x] Integration test: dimension extraction stores width/height from a PNG buffer via mocked fetch
- [x] Integration test: image still created when fetch fails (network error)
- [x] Integration test: image still created when parsing returns null (invalid image data)
- [x] All quality gates pass (test, lint, typecheck, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)