### PR TITLE
feat(web,api): skip-to-content link and X-Request-Id middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { prisma } from '@surfaced-art/db'
 import { logger } from '@surfaced-art/utils'
 
 import { securityHeaders } from './middleware/security-headers'
+import { requestId } from './middleware/request-id'
 import { rateLimiter } from './middleware/rate-limiter'
 import { cacheControl } from './middleware/cache-control'
 import { createHealthRoutes } from './routes/health'
@@ -35,6 +36,7 @@ const allowedOrigins = [FRONTEND_URL, wwwVariant, 'http://localhost:3000']
 const app = new Hono()
 
 // Middleware
+app.use('*', requestId())
 app.use('*', securityHeaders())
 app.use('*', honoLogger())
 // CORS — allow configured frontend URL, localhost for dev, and Vercel preview deploys

--- a/apps/api/src/middleware/request-id.test.ts
+++ b/apps/api/src/middleware/request-id.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import { requestId } from './request-id'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function createTestApp() {
+  const app = new Hono()
+  app.use('*', requestId())
+  app.get('/test', (c) => c.json({ ok: true }))
+  return app
+}
+
+describe('requestId middleware', () => {
+  it('should add X-Request-Id response header', async () => {
+    const app = createTestApp()
+    const res = await app.request('/test')
+    expect(res.headers.get('X-Request-Id')).toBeTruthy()
+  })
+
+  it('should generate a valid UUID v4', async () => {
+    const app = createTestApp()
+    const res = await app.request('/test')
+    const id = res.headers.get('X-Request-Id')!
+    expect(id).toMatch(UUID_REGEX)
+  })
+
+  it('should generate unique IDs for each request', async () => {
+    const app = createTestApp()
+    const res1 = await app.request('/test')
+    const res2 = await app.request('/test')
+    expect(res1.headers.get('X-Request-Id')).not.toBe(
+      res2.headers.get('X-Request-Id')
+    )
+  })
+
+  it('should preserve an incoming X-Request-Id header', async () => {
+    const app = createTestApp()
+    const incomingId = '550e8400-e29b-41d4-a716-446655440000'
+    const res = await app.request('/test', {
+      headers: { 'X-Request-Id': incomingId },
+    })
+    expect(res.headers.get('X-Request-Id')).toBe(incomingId)
+  })
+
+  it('should not interfere with the response body', async () => {
+    const app = createTestApp()
+    const res = await app.request('/test')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ ok: true })
+  })
+})

--- a/apps/api/src/middleware/request-id.ts
+++ b/apps/api/src/middleware/request-id.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from 'node:crypto'
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Adds an X-Request-Id header to every response.
+ * If the incoming request already has an X-Request-Id, it is preserved (passthrough).
+ * Otherwise a new UUID v4 is generated.
+ */
+export function requestId(): MiddlewareHandler {
+  return async (c, next) => {
+    const id = c.req.header('X-Request-Id') ?? randomUUID()
+    await next()
+    c.header('X-Request-Id', id)
+  }
+}

--- a/apps/web/src/app/(main)/__tests__/layout.test.tsx
+++ b/apps/web/src/app/(main)/__tests__/layout.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import MainLayout from '../layout'
+
+vi.mock('@/components/Header', () => ({
+  Header: () => <header data-testid="site-header">Header</header>,
+}))
+vi.mock('@/components/Footer', () => ({
+  Footer: () => <footer data-testid="site-footer">Footer</footer>,
+}))
+vi.mock('@/components/ScrollToTop', () => ({
+  ScrollToTop: () => null,
+}))
+vi.mock('@/components/CookieConsent', () => ({
+  CookieConsent: () => null,
+}))
+
+describe('MainLayout', () => {
+  it('should render main element with id="main-content" for skip-to-content', () => {
+    render(
+      <MainLayout>
+        <p>Page content</p>
+      </MainLayout>
+    )
+    const main = screen.getByRole('main')
+    expect(main).toHaveAttribute('id', 'main-content')
+  })
+})

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -13,7 +13,7 @@ export default function MainLayout({
     <>
       <ScrollToTop />
       <Header />
-      <main className="flex-1">
+      <main id="main-content" className="flex-1">
         <Container className="py-8 md:py-12">
           {children}
         </Container>

--- a/apps/web/src/app/(studio)/layout.tsx
+++ b/apps/web/src/app/(studio)/layout.tsx
@@ -7,7 +7,7 @@ export default function StudioLayout({
 }) {
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-1">{children}</main>
+      <main id="main-content" className="flex-1">{children}</main>
       <StudioFooter />
     </div>
   )

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { SearchInput } from './SearchInput'
 import { ThemeToggle } from './ThemeToggle'
 import { AuthButton } from './AuthButton'
 import { Wordmark } from './Wordmark'
+import { SkipToContent } from './SkipToContent'
 import { Container } from './ui/container'
 import { cn } from '@/lib/utils'
 
@@ -39,6 +40,8 @@ export function Header() {
   }, [])
 
   return (
+    <>
+    <SkipToContent />
     <header
       data-testid="site-header"
       className={cn(
@@ -79,5 +82,6 @@ export function Header() {
       {/* Desktop category navigation */}
       <Navigation condensed={isCondensed} />
     </header>
+    </>
   )
 }

--- a/apps/web/src/components/SkipToContent.tsx
+++ b/apps/web/src/components/SkipToContent.tsx
@@ -1,0 +1,14 @@
+/**
+ * Visually hidden skip-to-content link for keyboard/screen reader users.
+ * Becomes visible on focus. Should be the first focusable element on the page.
+ */
+export function SkipToContent() {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:text-foreground focus:shadow-md focus:ring-2 focus:ring-ring"
+    >
+      Skip to content
+    </a>
+  )
+}

--- a/apps/web/src/components/__tests__/SkipToContent.test.tsx
+++ b/apps/web/src/components/__tests__/SkipToContent.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SkipToContent } from '../SkipToContent'
+
+describe('SkipToContent', () => {
+  it('should render a link targeting #main-content', () => {
+    render(<SkipToContent />)
+    const link = screen.getByText('Skip to content')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '#main-content')
+  })
+
+  it('should be visually hidden by default (sr-only)', () => {
+    render(<SkipToContent />)
+    const link = screen.getByText('Skip to content')
+    expect(link.className).toContain('sr-only')
+  })
+
+  it('should become visible on focus', () => {
+    render(<SkipToContent />)
+    const link = screen.getByText('Skip to content')
+    // The focus-visible styles override sr-only
+    expect(link.className).toContain('focus:not-sr-only')
+  })
+})


### PR DESCRIPTION
## Summary
- **SUR-212**: Added a visually hidden skip-to-content link in the Header that becomes visible on keyboard focus, targeting `#main-content` on both main and studio layouts
- **SUR-209**: Added X-Request-Id middleware to the API that generates a UUID v4 per request (or preserves an incoming ID for distributed tracing)

## Changes
- New `SkipToContent` component with sr-only/focus styles
- `Header.tsx` renders `SkipToContent` as first focusable element
- Both `(main)/layout.tsx` and `(studio)/layout.tsx` have `id="main-content"` on `<main>`
- New `requestId()` Hono middleware in `apps/api/src/middleware/request-id.ts`
- Middleware wired first in the chain (before security headers) in `index.ts`
- 9 new tests (3 SkipToContent, 1 layout, 5 request-id)

## Test plan
- [x] SkipToContent renders with correct href and sr-only classes
- [x] Layout `<main>` has `id="main-content"`
- [x] Request-id generates valid UUID v4
- [x] Request-id preserves incoming X-Request-Id header
- [x] Unique IDs per request
- [x] All 493 tests pass, lint/typecheck/build clean