### PR TITLE
chore(ci): align GitHub Actions versions across workflows

### DIFF
--- a/.github/workflows/ai-review-notify.yml
+++ b/.github/workflows/ai-review-notify.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Fetch review comments and post digest
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SLACK_AI_REVIEW_WEBHOOK_URL: ${{ secrets.SLACK_AI_REVIEW_WEBHOOK_URL }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Check for infrastructure changes
         id: infra_changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -118,7 +118,7 @@ jobs:
 
       - name: Post plan as PR comment
         if: steps.infra_changes.outputs.changed == 'true' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -55,21 +55,21 @@ jobs:
         run: npm run test
 
       - name: Upload API artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: api-dist
           path: apps/api/dist/
           retention-days: 1
 
       - name: Upload migrate artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: migrate-dist
           path: tools/migrate/dist/
           retention-days: 1
 
       - name: Upload image-processor artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: image-processor-dist
           path: apps/image-processor/dist/
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.5'
           terraform_wrapper: false
@@ -602,7 +602,7 @@ jobs:
     steps:
       - name: Gather PR data
         id: pr_data
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -647,7 +647,7 @@ jobs:
       - name: Get failure context
         id: failure
         if: steps.status.outputs.result == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       # The specific CVEs from that hoisted package are suppressed in .trivyignore —
       # only those CVEs, not the entire @prisma directory tree.
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -75,7 +75,7 @@ jobs:
 
       # --- Trivy IaC scan ---
       - name: Run Trivy IaC scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'config'
           scan-ref: 'infrastructure/terraform'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       # The specific CVEs from that hoisted package are suppressed in .trivyignore —
       # only those CVEs, not the entire @prisma directory tree.
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -75,7 +75,7 @@ jobs:
 
       # --- Trivy IaC scan ---
       - name: Run Trivy IaC scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'config'
           scan-ref: 'infrastructure/terraform'


### PR DESCRIPTION
## Summary
- **SUR-215**: Standardize all GitHub Actions to their latest stable versions across all 11 workflows

## Changes
| Action | Before | After | Affected Workflow |
|--------|--------|-------|-------------------|
| `actions/upload-artifact` | `@v6` | `@v7` | `deploy-dev.yml` |
| `hashicorp/setup-terraform` | `@v3` | `@v4` | `deploy-dev.yml` |
| `actions/github-script` | `@v7` | `@v8` | `deploy-dev.yml`, `ci.yml`, `ai-review-notify.yml` |
| `aquasecurity/trivy-action` | `@master` | `@0.28.0` | `security.yml` |

## Test plan
- [x] Verified all `uses:` directives are consistent across workflows
- [ ] CI workflow runs successfully on this PR (validates the action versions work)