### PR TITLE
feat(api,web): artist-aware waitlist with context capture

### DIFF
--- a/apps/api/src/routes/waitlist.test.ts
+++ b/apps/api/src/routes/waitlist.test.ts
@@ -61,6 +61,40 @@ describe('POST /waitlist', () => {
       })
     })
 
+    it('should store optional context fields (source, artistId, listingId)', async () => {
+      await app.request('/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'fan@example.com',
+          source: 'listing',
+          artistId: '550e8400-e29b-41d4-a716-446655440001',
+          listingId: '550e8400-e29b-41d4-a716-446655440002',
+        }),
+      })
+
+      expect(mockPrisma.waitlist.create).toHaveBeenCalledWith({
+        data: {
+          email: 'fan@example.com',
+          source: 'listing',
+          artistId: '550e8400-e29b-41d4-a716-446655440001',
+          listingId: '550e8400-e29b-41d4-a716-446655440002',
+        },
+      })
+    })
+
+    it('should accept email-only requests without context fields', async () => {
+      await app.request('/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'simple@example.com' }),
+      })
+
+      expect(mockPrisma.waitlist.create).toHaveBeenCalledWith({
+        data: { email: 'simple@example.com' },
+      })
+    })
+
     it('should normalize email to lowercase', async () => {
       await app.request('/waitlist', {
         method: 'POST',

--- a/apps/api/src/routes/waitlist.ts
+++ b/apps/api/src/routes/waitlist.ts
@@ -28,10 +28,16 @@ export function createWaitlistRoutes(prisma: PrismaClient) {
     }
 
     const normalizedEmail = parsed.data.email.trim().toLowerCase()
+    const { source, artistId, listingId } = parsed.data
 
     try {
       await prisma.waitlist.create({
-        data: { email: normalizedEmail },
+        data: {
+          email: normalizedEmail,
+          ...(source && { source }),
+          ...(artistId && { artistId }),
+          ...(listingId && { listingId }),
+        },
       })
 
       logger.info('Waitlist signup', {

--- a/apps/web/src/app/(main)/listing/[id]/page.tsx
+++ b/apps/web/src/app/(main)/listing/[id]/page.tsx
@@ -203,7 +203,12 @@ export default async function ListingDetailPage({ params }: Props) {
                 This gallery opens to buyers soon. Leave your email to be
                 the first to know.
               </p>
-              <WaitlistForm />
+              <WaitlistForm
+                artistName={listing.artist.displayName}
+                source="listing"
+                artistId={listing.artistId}
+                listingId={listing.id}
+              />
             </div>
           )}
 

--- a/apps/web/src/components/WaitlistForm.tsx
+++ b/apps/web/src/components/WaitlistForm.tsx
@@ -8,10 +8,22 @@ import { trackWaitlistSignup } from '@/lib/analytics'
 
 type WaitlistState = 'idle' | 'submitting' | 'success' | 'error'
 
-export function WaitlistForm() {
+interface WaitlistFormProps {
+  artistName?: string
+  source?: string
+  artistId?: string
+  listingId?: string
+}
+
+export function WaitlistForm({ artistName, source, artistId, listingId }: WaitlistFormProps) {
   const [email, setEmail] = useState('')
   const [state, setState] = useState<WaitlistState>('idle')
   const [errorMessage, setErrorMessage] = useState('')
+
+  const context =
+    source || artistId || listingId
+      ? { source, artistId, listingId }
+      : undefined
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -36,7 +48,7 @@ export function WaitlistForm() {
     setErrorMessage('')
 
     try {
-      await joinWaitlist(trimmed)
+      await joinWaitlist(trimmed, context)
       setState('success')
       setEmail('')
       trackWaitlistSignup()
@@ -51,7 +63,9 @@ export function WaitlistForm() {
       <div data-testid="waitlist-success" className="text-center">
         <p className="font-serif text-lg text-foreground">You&rsquo;re on the list.</p>
         <p className="mt-2 text-sm text-muted-text">
-          We&rsquo;ll let you know when the gallery opens to buyers.
+          {artistName
+            ? `We\u2019ll notify you when ${artistName} lists new work.`
+            : 'We\u2019ll let you know when the gallery opens to buyers.'}
         </p>
       </div>
     )
@@ -59,6 +73,11 @@ export function WaitlistForm() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col items-center gap-3 sm:flex-row sm:gap-2">
+      {artistName && (
+        <p className="mb-2 w-full text-center text-sm text-muted-text sm:mb-0 sm:text-left">
+          We&rsquo;ll notify you when {artistName} lists new work.
+        </p>
+      )}
       <Input
         data-testid="waitlist-email-input"
         type="text"
@@ -76,7 +95,7 @@ export function WaitlistForm() {
         disabled={state === 'submitting'}
         className="w-full sm:w-auto"
       >
-        {state === 'submitting' ? 'Joining…' : 'Join the Waitlist'}
+        {state === 'submitting' ? 'Joining\u2026' : 'Join the Waitlist'}
       </Button>
       {state === 'error' && (
         <p data-testid="waitlist-error" className="text-sm text-error" role="alert">

--- a/apps/web/src/components/__tests__/WaitlistForm.test.tsx
+++ b/apps/web/src/components/__tests__/WaitlistForm.test.tsx
@@ -15,6 +15,77 @@ vi.mock('@/lib/analytics', () => ({
 
 import { WaitlistForm } from '../WaitlistForm'
 
+describe('WaitlistForm artist-aware messaging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockJoinWaitlist.mockResolvedValue(undefined)
+  })
+
+  it('should show artist-aware CTA text when artistName is provided', () => {
+    render(<WaitlistForm artistName="Jane Doe" />)
+    expect(
+      screen.getByText(/notify you when Jane Doe/i)
+    ).toBeInTheDocument()
+  })
+
+  it('should show generic CTA text when no artistName is provided', () => {
+    render(<WaitlistForm />)
+    expect(
+      screen.queryByText(/notify you when/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('should pass context fields to joinWaitlist when provided', async () => {
+    const user = userEvent.setup()
+    render(
+      <WaitlistForm
+        artistName="Jane Doe"
+        source="listing"
+        artistId="artist-123"
+        listingId="listing-456"
+      />
+    )
+
+    await user.type(screen.getByTestId('waitlist-email-input'), 'fan@example.com')
+    await user.click(screen.getByTestId('waitlist-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('waitlist-success')).toBeInTheDocument()
+    })
+    expect(mockJoinWaitlist).toHaveBeenCalledWith('fan@example.com', {
+      source: 'listing',
+      artistId: 'artist-123',
+      listingId: 'listing-456',
+    })
+  })
+
+  it('should call joinWaitlist without context when no props provided', async () => {
+    const user = userEvent.setup()
+    render(<WaitlistForm />)
+
+    await user.type(screen.getByTestId('waitlist-email-input'), 'fan@example.com')
+    await user.click(screen.getByTestId('waitlist-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('waitlist-success')).toBeInTheDocument()
+    })
+    expect(mockJoinWaitlist).toHaveBeenCalledWith('fan@example.com', undefined)
+  })
+
+  it('should show artist-aware success message when artistName is provided', async () => {
+    const user = userEvent.setup()
+    render(<WaitlistForm artistName="Jane Doe" />)
+
+    await user.type(screen.getByTestId('waitlist-email-input'), 'fan@example.com')
+    await user.click(screen.getByTestId('waitlist-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('waitlist-success')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument()
+  })
+})
+
 describe('WaitlistForm analytics tracking', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -129,10 +129,13 @@ export const getListingDetail = cache(async (id: string): Promise<ListingDetailR
   return apiFetch<ListingDetailResponse>(`/listings/${encodeURIComponent(id)}`)
 })
 
-export async function joinWaitlist(email: string): Promise<{ message: string }> {
+export async function joinWaitlist(
+  email: string,
+  context?: { source?: string; artistId?: string; listingId?: string },
+): Promise<{ message: string }> {
   return apiFetch<{ message: string }>('/waitlist', {
     method: 'POST',
-    body: JSON.stringify({ email }),
+    body: JSON.stringify({ email, ...context }),
   })
 }
 

--- a/packages/db/prisma/migrations/20260310000000_add_waitlist_context_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260310000000_add_waitlist_context_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "waitlist" ADD COLUMN "source" TEXT,
+ADD COLUMN "artist_id" UUID,
+ADD COLUMN "listing_id" UUID;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -478,6 +478,9 @@ model Follow {
 model Waitlist {
   id        String   @id @default(uuid()) @db.Uuid
   email     String   @unique
+  source    String?
+  artistId  String?  @map("artist_id") @db.Uuid
+  listingId String?  @map("listing_id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
 
   @@map("waitlist")

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -101,6 +101,9 @@ export const listingsQuery = z.object({
 /** POST /waitlist body */
 export const waitlistBody = z.object({
   email: z.string().min(1, 'Email is required').email('Invalid email address'),
+  source: z.string().max(50).optional(),
+  artistId: z.string().uuid('Invalid artist ID').optional(),
+  listingId: z.string().uuid('Invalid listing ID').optional(),
 })
 
 /** POST /artists/apply body */


### PR DESCRIPTION
## Summary
- Add optional `source`, `artistId`, `listingId` fields to the Waitlist Prisma model with a database migration
- Extend the `waitlistBody` zod schema to accept optional context fields
- API route now stores context fields alongside the email
- `joinWaitlist()` client function accepts an optional context parameter
- `WaitlistForm` component accepts `artistName`, `source`, `artistId`, `listingId` props
- When `artistName` is provided, shows personalised CTA ("We'll notify you when {artist} lists new work") and artist-aware success message
- Listing detail page passes artist context to WaitlistForm
- Homepage waitlist remains generic (no props)

Closes SUR-216

## Test plan
- [x] API tests: context fields stored in Prisma create call (2 new tests)
- [x] API tests: email-only requests still work without context (backward compatible)
- [x] WaitlistForm tests: artist-aware CTA shown when `artistName` prop provided (1 new test)
- [x] WaitlistForm tests: generic CTA when no `artistName` (1 new test)
- [x] WaitlistForm tests: context fields passed to `joinWaitlist` (1 new test)
- [x] WaitlistForm tests: no context passed when no props (1 new test)
- [x] WaitlistForm tests: artist-aware success message (1 new test)
- [x] All 1153 tests pass across all workspaces
- [x] Typecheck, lint, build all pass