### PR TITLE
fix(api): add ADDITIONAL_CORS_ORIGINS for multi-domain support

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -30,7 +30,11 @@ if (!FRONTEND_URL) {
 }
 // Support both bare domain and www variant (e.g. surfacedart.com + www.surfacedart.com)
 const wwwVariant = FRONTEND_URL.replace('https://', 'https://www.')
-const allowedOrigins = [FRONTEND_URL, wwwVariant, 'http://localhost:3000']
+// ADDITIONAL_CORS_ORIGINS: comma-separated list of extra allowed origins (e.g. alternate domains)
+const additionalOrigins = process.env.ADDITIONAL_CORS_ORIGINS
+  ? process.env.ADDITIONAL_CORS_ORIGINS.split(',').map((o) => o.trim()).filter(Boolean)
+  : []
+const allowedOrigins = [FRONTEND_URL, wwwVariant, 'http://localhost:3000', ...additionalOrigins]
 
 // Create Hono app
 const app = new Hono()

--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('@surfaced-art/utils', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
 vi.mock('@surfaced-art/db', () => ({
   prisma: {
     $queryRawUnsafe: vi.fn().mockResolvedValue([{ now: new Date() }]),
@@ -15,6 +23,7 @@ vi.mock('@surfaced-art/db', () => ({
 }))
 
 vi.stubEnv('FRONTEND_URL', 'https://surfacedart.com')
+vi.stubEnv('ADDITIONAL_CORS_ORIGINS', 'https://surfaced.art,https://www.surfaced.art,https://dev.surfaced.art')
 
 const { app } = await import('../index')
 
@@ -61,6 +70,30 @@ describe('CORS configuration', () => {
       },
     })
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://surfaced-art-abc123.vercel.app')
+  })
+
+  it('should allow requests from ADDITIONAL_CORS_ORIGINS', async () => {
+    const res = await app.request('/health', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://surfaced.art',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://surfaced.art')
+  })
+
+  it('should allow requests from all additional origins', async () => {
+    for (const origin of ['https://www.surfaced.art', 'https://dev.surfaced.art']) {
+      const res = await app.request('/health', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'GET',
+        },
+      })
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin)
+    }
   })
 
   it('should reject requests from unauthorized origins', async () => {

--- a/infrastructure/terraform/environments/dev.tfvars
+++ b/infrastructure/terraform/environments/dev.tfvars
@@ -12,10 +12,15 @@ api_reserved_concurrency   = 10
 
 # URLs
 frontend_url = "https://dev.surfacedart.com"
+additional_cors_origins = [
+  "https://dev.surfaced.art",
+  "https://www.dev.surfaced.art",
+]
 
 # S3 CORS
 cors_allowed_origins = [
   "https://dev.surfacedart.com",
+  "https://dev.surfaced.art",
   "http://localhost:3000",
 ]
 

--- a/infrastructure/terraform/environments/prod.tfvars
+++ b/infrastructure/terraform/environments/prod.tfvars
@@ -14,10 +14,16 @@ seed_mode = "real"
 
 # URLs
 frontend_url = "https://surfacedart.com"
+additional_cors_origins = [
+  "https://surfaced.art",
+  "https://www.surfaced.art",
+]
 
 # S3 CORS
 cors_allowed_origins = [
   "https://surfacedart.com",
   "https://www.surfacedart.com",
+  "https://surfaced.art",
+  "https://www.surfaced.art",
   "http://localhost:3000",
 ]

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -246,6 +246,7 @@ module "lambda_api" {
   timeout                      = var.lambda_timeout
   lambda_role_arn              = module.iam.lambda_role_arn
   frontend_url                 = var.frontend_url
+  additional_cors_origins      = var.additional_cors_origins
   placeholder_image_uri        = var.placeholder_image_uri
   reserved_concurrent_executions = var.api_reserved_concurrency
 

--- a/infrastructure/terraform/modules/lambda-api/main.tf
+++ b/infrastructure/terraform/modules/lambda-api/main.tf
@@ -61,7 +61,8 @@ resource "aws_lambda_function" "api" {
       S3_BUCKET_NAME        = var.s3_bucket_name
       CLOUDFRONT_URL        = var.cloudfront_url
       CLOUDFRONT_DOMAIN     = var.cloudfront_domain
-      FRONTEND_URL          = var.frontend_url
+      FRONTEND_URL              = var.frontend_url
+      ADDITIONAL_CORS_ORIGINS   = join(",", var.additional_cors_origins)
       SES_FROM_ADDRESS      = var.ses_from_address
       SES_CONFIGURATION_SET = var.ses_configuration_set_name
       STRIPE_SECRET_KEY      = var.stripe_secret_key
@@ -92,7 +93,7 @@ resource "aws_apigatewayv2_api" "main" {
   protocol_type = "HTTP"
 
   cors_configuration {
-    allow_origins     = [var.frontend_url, replace(var.frontend_url, "https://", "https://www."), "http://localhost:3000"]
+    allow_origins     = concat([var.frontend_url, replace(var.frontend_url, "https://", "https://www."), "http://localhost:3000"], var.additional_cors_origins)
     allow_methods     = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
     allow_headers     = ["Content-Type", "Authorization", "X-Amz-Date", "X-Api-Key"]
     expose_headers    = ["Content-Length", "Content-Type", "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "Retry-After"]

--- a/infrastructure/terraform/modules/lambda-api/variables.tf
+++ b/infrastructure/terraform/modules/lambda-api/variables.tf
@@ -50,6 +50,12 @@ variable "frontend_url" {
   type        = string
 }
 
+variable "additional_cors_origins" {
+  description = "Additional allowed origins for API CORS (e.g. alternate domains, dev subdomains)"
+  type        = list(string)
+  default     = []
+}
+
 variable "database_url" {
   description = "PostgreSQL connection string"
   type        = string

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -150,6 +150,12 @@ variable "frontend_url" {
   default     = "https://surfaced.art"
 }
 
+variable "additional_cors_origins" {
+  description = "Additional allowed origins for API CORS (e.g. alternate domains, dev subdomains)"
+  type        = list(string)
+  default     = []
+}
+
 variable "migrate_ecr_max_images" {
   description = "Maximum number of images to retain in the migration ECR repository"
   type        = number


### PR DESCRIPTION
## Summary
- Adds `ADDITIONAL_CORS_ORIGINS` env var (comma-separated) to the Hono API, allowing extra origins beyond the primary `FRONTEND_URL` + its `www.` variant
- Adds `additional_cors_origins` Terraform variable (list of strings) that feeds both the API Gateway CORS config and the Lambda env var
- Updates dev.tfvars to allow `dev.surfaced.art` and prod.tfvars to allow `surfaced.art` / `www.surfaced.art`
- Also adds `surfaced.art` domains to S3 CORS (`cors_allowed_origins`) for browser uploads

## Context
`https://dev.surfaced.art` was being blocked by CORS because the API only recognized the primary `FRONTEND_URL` (`dev.surfacedart.com`). This configurable approach supports both domain families without hardcoding.

## Test plan
- [x] New CORS tests pass (9/9) verifying additional origins are accepted
- [x] Full test suite passes (629/629)
- [x] Typecheck clean
- [x] Build succeeds
- [ ] After Terraform apply on dev, verify `https://dev.surfaced.art` can call the API without CORS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)