### PR TITLE
feat(web): Forest+Amber palette + theme picker for testing

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,8 +5,8 @@
 /*
  * Surfaced Art — Design tokens (Brand Design System v2.0)
  *
- * Palette: warm neutrals — moderately muted, warm but identifiable hues.
- * The artwork provides vibrancy; the platform is a quiet, warm frame.
+ * Palette: Forest + Amber — deep forest green with warm amber.
+ * Rich, natural, frames artwork like a well-lit gallery in the woods.
  * Typography: serif headings (DM Serif Display), clean sans body (DM Sans).
  * Variable names follow ShadCN/ui conventions for component compatibility.
  *
@@ -20,42 +20,42 @@
   --foreground: #1A1A1A;
   --muted: #6B6460;
   --border: #E5E0DB;
-  --accent-primary: #B8956A;
-  --accent-primary-hover: #A6845C;
-  --accent-secondary: #C4775A;
-  --accent-secondary-hover: #B5694D;
+  --accent-primary: #4A6B5A;
+  --accent-primary-hover: #3D5A4C;
+  --accent-secondary: #C49A5A;
+  --accent-secondary-hover: #B58A4D;
   --error: #C4534A;
   --success: #6B8F6B;
   --warning: #D4A054;
   --overlay: rgba(26, 26, 26, 0.6);
 
-  /* ShadCN alias tokens — Light Mode */
-  --card: #F2F0ED;
-  --card-foreground: #1A1A1A;
-  --popover: #FAFAF8;
-  --popover-foreground: #1A1A1A;
-  --primary: #B8956A;
+  /* ShadCN alias tokens — Light Mode (derived from brand tokens above) */
+  --card: var(--surface);
+  --card-foreground: var(--foreground);
+  --popover: var(--background);
+  --popover-foreground: var(--foreground);
+  --primary: var(--accent-primary);
   --primary-foreground: #FFFFFF;
-  --secondary: #F2F0ED;
-  --secondary-foreground: #1A1A1A;
-  --muted-foreground: #6B6460;
-  --accent: #F2F0ED;
-  --accent-foreground: #1A1A1A;
-  --destructive: #C4534A;
+  --secondary: var(--surface);
+  --secondary-foreground: var(--foreground);
+  --muted-foreground: var(--muted);
+  --accent: var(--surface);
+  --accent-foreground: var(--foreground);
+  --destructive: var(--error);
   --destructive-foreground: #FFFFFF;
-  --input: #E5E0DB;
-  --ring: #B8956A;
+  --input: var(--border);
+  --ring: var(--accent-primary);
   --radius: 5px;
 
-  /* Sidebar — Light Mode */
-  --sidebar: #F2F0ED;
-  --sidebar-foreground: #1A1A1A;
-  --sidebar-primary: #B8956A;
+  /* Sidebar — Light Mode (derived from brand tokens above) */
+  --sidebar: var(--surface);
+  --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--accent-primary);
   --sidebar-primary-foreground: #FFFFFF;
-  --sidebar-accent: #F2F0ED;
-  --sidebar-accent-foreground: #1A1A1A;
-  --sidebar-border: #E5E0DB;
-  --sidebar-ring: #B8956A;
+  --sidebar-accent: var(--surface);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--accent-primary);
 
   /* Font stacks — next/font injects --font-dm-serif and --font-dm-sans */
   --active-font-sans: var(--font-dm-sans, 'DM Sans', sans-serif);
@@ -69,41 +69,41 @@
   --foreground: #F5F2EE;
   --muted: #9C9590;
   --border: #3D3835;
-  --accent-primary: #C9A678;
-  --accent-primary-hover: #D4B48A;
-  --accent-secondary: #D08A6E;
-  --accent-secondary-hover: #DC9A7E;
+  --accent-primary: #6B9B7A;
+  --accent-primary-hover: #7DAE8C;
+  --accent-secondary: #D4AA6A;
+  --accent-secondary-hover: #E0BA7A;
   --error: #D4645C;
   --success: #7FA37F;
   --warning: #E0B060;
   --overlay: rgba(0, 0, 0, 0.7);
 
-  /* ShadCN alias tokens — Dark Mode */
-  --card: #282420;
-  --card-foreground: #F5F2EE;
-  --popover: #1C1917;
-  --popover-foreground: #F5F2EE;
-  --primary: #C9A678;
-  --primary-foreground: #1C1917;
-  --secondary: #282420;
-  --secondary-foreground: #F5F2EE;
-  --muted-foreground: #9C9590;
-  --accent: #282420;
-  --accent-foreground: #F5F2EE;
-  --destructive: #D4645C;
-  --destructive-foreground: #1C1917;
-  --input: #3D3835;
-  --ring: #C9A678;
+  /* ShadCN alias tokens — Dark Mode (derived from brand tokens above) */
+  --card: var(--surface);
+  --card-foreground: var(--foreground);
+  --popover: var(--background);
+  --popover-foreground: var(--foreground);
+  --primary: var(--accent-primary);
+  --primary-foreground: var(--background);
+  --secondary: var(--surface);
+  --secondary-foreground: var(--foreground);
+  --muted-foreground: var(--muted);
+  --accent: var(--surface);
+  --accent-foreground: var(--foreground);
+  --destructive: var(--error);
+  --destructive-foreground: var(--background);
+  --input: var(--border);
+  --ring: var(--accent-primary);
 
-  /* Sidebar — Dark Mode */
-  --sidebar: #282420;
-  --sidebar-foreground: #F5F2EE;
-  --sidebar-primary: #C9A678;
-  --sidebar-primary-foreground: #1C1917;
-  --sidebar-accent: #282420;
-  --sidebar-accent-foreground: #F5F2EE;
-  --sidebar-border: #3D3835;
-  --sidebar-ring: #C9A678;
+  /* Sidebar — Dark Mode (derived from brand tokens above) */
+  --sidebar: var(--surface);
+  --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--accent-primary);
+  --sidebar-primary-foreground: var(--background);
+  --sidebar-accent: var(--surface);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--accent-primary);
 
   /* Font stacks (same as light mode) */
   --active-font-sans: var(--font-dm-sans, 'DM Sans', sans-serif);

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { Navigation } from './Navigation'
 import { MobileNav } from './MobileNav'
 import { SearchInput } from './SearchInput'
 import { ThemeToggle } from './ThemeToggle'
+import { ThemePicker } from './ThemePicker'
 import { AuthButton } from './AuthButton'
 import { Wordmark } from './Wordmark'
 import { SkipToContent } from './SkipToContent'
@@ -100,6 +101,7 @@ export function Header() {
             <div className="hidden md:block">
               <AuthButton />
             </div>
+            <ThemePicker />
             <ThemeToggle />
             <MobileNav />
           </div>

--- a/apps/web/src/components/ThemePicker.tsx
+++ b/apps/web/src/components/ThemePicker.tsx
@@ -1,0 +1,245 @@
+'use client'
+
+import { useState, useEffect, useRef, useSyncExternalStore } from 'react'
+import { Palette } from 'lucide-react'
+
+/**
+ * Temporary palette picker for manual testing.
+ * Overrides brand CSS custom properties on <html> to preview different color palettes.
+ * DELETE THIS COMPONENT before shipping to production.
+ */
+
+const PALETTES = [
+  {
+    id: 'forest-amber',
+    name: 'Forest + Amber',
+    swatch: '#4A6B5A',
+    light: {
+      '--accent-primary': '#4A6B5A',
+      '--accent-primary-hover': '#3D5A4C',
+      '--accent-secondary': '#C49A5A',
+      '--accent-secondary-hover': '#B58A4D',
+    },
+    dark: {
+      '--accent-primary': '#6B9B7A',
+      '--accent-primary-hover': '#7DAE8C',
+      '--accent-secondary': '#D4AA6A',
+      '--accent-secondary-hover': '#E0BA7A',
+    },
+  },
+  {
+    id: 'espresso-cream',
+    name: 'Espresso + Cream',
+    swatch: '#5C4033',
+    light: {
+      '--accent-primary': '#5C4033',
+      '--accent-primary-hover': '#4D3529',
+      '--accent-secondary': '#C4AA8A',
+      '--accent-secondary-hover': '#B59A7A',
+    },
+    dark: {
+      '--accent-primary': '#8C6B55',
+      '--accent-primary-hover': '#9E7D67',
+      '--accent-secondary': '#D4BA9A',
+      '--accent-secondary-hover': '#E0CAAA',
+    },
+  },
+  {
+    id: 'teal-gold',
+    name: 'Deep Teal + Gold',
+    swatch: '#2A7B7B',
+    light: {
+      '--accent-primary': '#2A7B7B',
+      '--accent-primary-hover': '#226666',
+      '--accent-secondary': '#B8956A',
+      '--accent-secondary-hover': '#A6845C',
+    },
+    dark: {
+      '--accent-primary': '#4AABAB',
+      '--accent-primary-hover': '#5CBDBD',
+      '--accent-secondary': '#C8A57A',
+      '--accent-secondary-hover': '#D8B58A',
+    },
+  },
+  {
+    id: 'slate-gold',
+    name: 'Slate + Gold',
+    swatch: '#5A6A78',
+    light: {
+      '--accent-primary': '#5A6A78',
+      '--accent-primary-hover': '#4D5C6A',
+      '--accent-secondary': '#B8956A',
+      '--accent-secondary-hover': '#A6845C',
+    },
+    dark: {
+      '--accent-primary': '#8A9AAA',
+      '--accent-primary-hover': '#9CAABC',
+      '--accent-secondary': '#C8A57A',
+      '--accent-secondary-hover': '#D8B58A',
+    },
+  },
+  {
+    id: 'bronze-charcoal',
+    name: 'Bronze + Charcoal',
+    swatch: '#8B7355',
+    light: {
+      '--accent-primary': '#8B7355',
+      '--accent-primary-hover': '#7A6548',
+      '--accent-secondary': '#5A5550',
+      '--accent-secondary-hover': '#4A4540',
+    },
+    dark: {
+      '--accent-primary': '#BB9D75',
+      '--accent-primary-hover': '#CDAF87',
+      '--accent-secondary': '#8A8580',
+      '--accent-secondary-hover': '#9C9792',
+    },
+  },
+] as const
+
+const STORAGE_KEY = 'sa-theme-palette'
+const OVERRIDE_PROPS = ['--accent-primary', '--accent-primary-hover', '--accent-secondary', '--accent-secondary-hover']
+
+// Track client-side mount without useState/useEffect
+const emptySubscribe = () => () => {}
+function useMounted() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  )
+}
+
+function getStoredPaletteId(): string | null {
+  if (typeof window === 'undefined') return null
+  const saved = localStorage.getItem(STORAGE_KEY)
+  return saved && PALETTES.some(p => p.id === saved) ? saved : null
+}
+
+function applyPalette(id: string, isDark: boolean) {
+  const palette = PALETTES.find(p => p.id === id)
+  if (!palette) return
+
+  const tokens = isDark ? palette.dark : palette.light
+  const root = document.documentElement
+
+  for (const [prop, value] of Object.entries(tokens)) {
+    root.style.setProperty(prop, value)
+  }
+}
+
+function clearPaletteOverrides() {
+  const root = document.documentElement
+  for (const prop of OVERRIDE_PROPS) {
+    root.style.removeProperty(prop)
+  }
+}
+
+export function ThemePicker() {
+  const mounted = useMounted()
+  const [isOpen, setIsOpen] = useState(false)
+  // Lazy initializer reads localStorage synchronously — no setState-in-effect needed
+  const [activeId, setActiveId] = useState<string | null>(getStoredPaletteId)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Apply palette whenever activeId or dark/light mode changes
+  useEffect(() => {
+    if (!activeId) {
+      clearPaletteOverrides()
+      return
+    }
+
+    const isDark = document.documentElement.classList.contains('dark')
+    applyPalette(activeId, isDark)
+
+    // Watch for dark mode class changes
+    const observer = new MutationObserver(() => {
+      const nowDark = document.documentElement.classList.contains('dark')
+      applyPalette(activeId, nowDark)
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+
+    return () => observer.disconnect()
+  }, [activeId])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [isOpen])
+
+  if (!mounted) {
+    return <div className="w-9 h-9" />
+  }
+
+  function selectPalette(id: string) {
+    if (activeId === id) {
+      // Deselect — revert to CSS default (forest-amber from globals.css)
+      setActiveId(null)
+      localStorage.removeItem(STORAGE_KEY)
+      clearPaletteOverrides()
+    } else {
+      setActiveId(id)
+      localStorage.setItem(STORAGE_KEY, id)
+    }
+    setIsOpen(false)
+  }
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Switch color palette"
+        aria-expanded={isOpen}
+        className="inline-flex items-center justify-center w-9 h-9 rounded-md text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <Palette className="h-5 w-5" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-2 w-52 rounded-lg border border-border bg-background shadow-lg z-50 py-1">
+          <p className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+            Color Palette
+          </p>
+          {PALETTES.map(p => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => selectPalette(p.id)}
+              className={`w-full flex items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors hover:bg-surface ${
+                activeId === p.id ? 'text-foreground font-medium' : 'text-muted-foreground'
+              }`}
+            >
+              <div
+                className="w-4 h-4 rounded-full shrink-0 border border-border"
+                style={{ backgroundColor: p.swatch }}
+              />
+              <span className="truncate">{p.name}</span>
+              {activeId === p.id && (
+                <span className="ml-auto text-accent-primary text-xs">Active</span>
+              )}
+            </button>
+          ))}
+          {activeId && (
+            <div className="border-t border-border mt-1 pt-1">
+              <button
+                type="button"
+                onClick={() => selectPalette(activeId)}
+                className="w-full px-3 py-2 text-left text-xs text-muted-foreground hover:bg-surface transition-colors"
+              >
+                Reset to default
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **Forest+Amber palette**: Switch brand colors from Warm Gold/Terracotta to Forest+Amber (`#4A6B5A` primary, `#C49A5A` secondary)
- **Token refactor**: ShadCN/sidebar CSS tokens now use `var()` references to brand tokens instead of duplicating hex values — palette swaps are ~4 lines instead of ~20
- **Theme picker**: Temporary `ThemePicker` component in header (palette icon) for previewing 5 finalist palettes during manual testing. Persists selection in localStorage, adapts to dark mode toggle.

## Test plan
- [ ] Forest+Amber renders correctly in light and dark mode
- [ ] ThemePicker dropdown switches palettes live across the whole site
- [ ] Selection persists across page refreshes (localStorage)
- [ ] Dark mode toggle re-applies the correct palette variant
- [ ] All existing components still render correctly with new token structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new Forest + Amber brand palette and a temporary palette testing UI while refactoring theme tokens to derive ShadCN and sidebar variables from core brand tokens.

New Features:
- Add a temporary ThemePicker component in the header to switch between multiple candidate color palettes with persistence in localStorage.

Enhancements:
- Update global design tokens to use the new Forest + Amber primary/secondary colors for light and dark modes.
- Refactor ShadCN and sidebar CSS variables to reference core brand tokens instead of duplicating hex values, simplifying future palette swaps.