### PR TITLE
refactor(infra): shared Terraform layer for VPC/account singletons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,109 @@ jobs:
       - name: Quality Gates
         run: npm run check
 
+  terraform-plan-shared:
+    name: Terraform Plan (shared)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check for infrastructure changes
+        id: infra_changes
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const hasInfra = files.some(f => f.filename.startsWith('infrastructure/'));
+            core.setOutput('changed', hasInfra ? 'true' : 'false');
+
+      - name: Setup Terraform
+        if: steps.infra_changes.outputs.changed == 'true'
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: '1.5'
+          terraform_wrapper: false
+
+      - name: Configure AWS Credentials
+        if: steps.infra_changes.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init (shared)
+        if: steps.infra_changes.outputs.changed == 'true'
+        working-directory: infrastructure/terraform/shared
+        run: terraform init
+
+      - name: Terraform Plan (shared)
+        if: steps.infra_changes.outputs.changed == 'true'
+        id: shared_plan
+        working-directory: infrastructure/terraform/shared
+        run: |
+          set -o pipefail
+          terraform plan -no-color \
+            2>&1 | tee /tmp/shared-plan.txt
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Post shared plan as PR comment
+        if: steps.infra_changes.outputs.changed == 'true' && always()
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('/tmp/shared-plan.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.slice(-60000) + '\n\n[...truncated — see full run for details]' : plan;
+
+            const body = [
+              '## Terraform Plan (shared)',
+              '',
+              '<details><summary>Show plan</summary>',
+              '',
+              '```terraform',
+              truncated,
+              '```',
+              '',
+              '</details>',
+              '',
+              `Plan generated from commit ${context.sha.substring(0, 7)}.`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.startsWith('## Terraform Plan (shared)')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+
   terraform-plan-dev:
     name: Terraform Plan (dev)
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -75,10 +75,52 @@ jobs:
           path: apps/image-processor/dist/
           retention-days: 1
 
+  terraform-shared:
+    name: Terraform Apply (shared)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: '1.5'
+          terraform_wrapper: false
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init (shared)
+        working-directory: infrastructure/terraform/shared
+        run: terraform init
+
+      - name: Terraform Plan (shared)
+        id: shared_plan
+        working-directory: infrastructure/terraform/shared
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -input=false \
+            -out=shared.tfplan
+          EXIT_CODE=$?
+          set -e
+          if [ $EXIT_CODE -eq 1 ]; then echo "Terraform plan failed"; exit 1; fi
+          echo "has_changes=$( [ $EXIT_CODE -eq 2 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
+      - name: Terraform Apply (shared)
+        if: steps.shared_plan.outputs.has_changes == 'true'
+        working-directory: infrastructure/terraform/shared
+        run: terraform apply -auto-approve -input=false shared.tfplan
+
   terraform:
     name: Terraform Apply (dev)
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, terraform-shared]
     environment: dev
 
     outputs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,10 +79,52 @@ jobs:
           path: apps/image-processor/dist/
           retention-days: 1
 
+  terraform-shared:
+    name: Terraform Apply (shared)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: '1.5'
+          terraform_wrapper: false
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init (shared)
+        working-directory: infrastructure/terraform/shared
+        run: terraform init
+
+      - name: Terraform Plan (shared)
+        id: shared_plan
+        working-directory: infrastructure/terraform/shared
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -input=false \
+            -out=shared.tfplan
+          EXIT_CODE=$?
+          set -e
+          if [ $EXIT_CODE -eq 1 ]; then echo "Terraform plan failed"; exit 1; fi
+          echo "has_changes=$( [ $EXIT_CODE -eq 2 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
+      - name: Terraform Apply (shared)
+        if: steps.shared_plan.outputs.has_changes == 'true'
+        working-directory: infrastructure/terraform/shared
+        run: terraform apply -auto-approve -input=false shared.tfplan
+
   terraform:
     name: Terraform Apply (prod)
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, terraform-shared]
     environment: prod
 
     outputs:

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -24,23 +24,8 @@ data "aws_subnets" "default" {
 
 data "aws_caller_identity" "current" {}
 
-# Route tables for the default VPC — needed by the S3 gateway endpoint
-data "aws_route_tables" "default" {
-  vpc_id = data.aws_vpc.default.id
-}
-
-# S3 gateway endpoint — allows VPC-attached Lambdas (migrate) to reach S3
-# without traversing a NAT gateway or the public internet.
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = data.aws_vpc.default.id
-  service_name      = "com.amazonaws.${var.aws_region}.s3"
-  vpc_endpoint_type = "Gateway"
-  route_table_ids   = data.aws_route_tables.default.ids
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-s3-endpoint"
-  }
-}
+# Note: VPC-scoped singletons (S3 gateway endpoint) are managed in
+# infrastructure/terraform/shared/ — see shared/main.tf.
 
 # ECR repository for Lambda container images
 # Defined here (not in lambda-api module) so IAM can scope permissions to this ARN

--- a/infrastructure/terraform/observability.tf
+++ b/infrastructure/terraform/observability.tf
@@ -7,41 +7,8 @@
 # retention policies and naming are consistent across the platform.
 #
 
-# -----------------------------------------------------------------------------
-# API Gateway CloudWatch Logging — IAM Role & Account
-# -----------------------------------------------------------------------------
-# API Gateway requires a regional account-level setting to push logs to
-# CloudWatch. This is a one-time configuration per AWS account per region.
-# The IAM role grants API Gateway permission to create log streams and
-# put log events into any CloudWatch log group.
-
-resource "aws_iam_role" "api_gateway_cloudwatch" {
-  name = "${var.project_name}-${var.environment}-${var.aws_region}-api-gateway-cloudwatch"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "apigateway.amazonaws.com"
-      }
-    }]
-  })
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-${var.aws_region}-api-gateway-cloudwatch"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "api_gateway_cloudwatch" {
-  role       = aws_iam_role.api_gateway_cloudwatch.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
-}
-
-resource "aws_api_gateway_account" "main" {
-  cloudwatch_role_arn = aws_iam_role.api_gateway_cloudwatch.arn
-}
+# Note: API Gateway CloudWatch account-level config (aws_api_gateway_account,
+# IAM role) is managed in infrastructure/terraform/shared/ — see shared/main.tf.
 
 # -----------------------------------------------------------------------------
 # SNS Topic for Alarm Notifications

--- a/infrastructure/terraform/shared/README.md
+++ b/infrastructure/terraform/shared/README.md
@@ -1,0 +1,75 @@
+# Shared Terraform Layer
+
+This directory manages AWS resources that are **VPC-scoped or account-scoped singletons** — resources that cannot be duplicated per environment because AWS enforces uniqueness at the VPC or account level.
+
+## Resources managed here
+
+| Resource | Why it's shared |
+|---|---|
+| `aws_vpc_endpoint.s3` | Only one S3 gateway endpoint per VPC per service |
+| `aws_api_gateway_account` | Only one per AWS region per account |
+| `aws_iam_role.api_gateway_cloudwatch` | Supports the account-scoped API Gateway setting |
+
+## State
+
+- **Bucket**: `surfaced-art-terraform-state`
+- **Key**: `shared/terraform.tfstate` (hardcoded, not parameterized)
+- **Lock table**: `surfaced-art-terraform-locks`
+
+## Applying
+
+The shared layer is applied automatically in CI before environment-specific layers. To apply manually:
+
+```bash
+cd infrastructure/terraform/shared
+terraform init
+terraform plan
+terraform apply
+```
+
+## One-time migration (from per-environment state)
+
+Before the first deploy with this shared layer, existing resources must be imported into the shared state and removed from the dev/prod states. Run these commands with AWS credentials:
+
+```bash
+# 1. Initialize shared state
+cd infrastructure/terraform/shared
+terraform init
+
+# 2. Get the VPC endpoint ID
+VPCE_ID=$(aws ec2 describe-vpc-endpoints \
+  --filters "Name=service-name,Values=com.amazonaws.us-east-1.s3" \
+  --query "VpcEndpoints[0].VpcEndpointId" --output text)
+
+# 3. Import into shared state
+terraform import aws_vpc_endpoint.s3 "$VPCE_ID"
+terraform import aws_api_gateway_account.main api-gateway-account
+
+# Note: The IAM role will be created fresh with a new name (without environment
+# prefix). The old environment-specific roles can be deleted after migration.
+
+# 4. Apply to create the new IAM role and update API Gateway account
+terraform apply
+
+# 5. Remove from dev state
+cd ../
+terraform init -backend-config="key=dev/terraform.tfstate"
+terraform state rm aws_vpc_endpoint.s3
+terraform state rm aws_iam_role.api_gateway_cloudwatch
+terraform state rm aws_iam_role_policy_attachment.api_gateway_cloudwatch
+terraform state rm aws_api_gateway_account.main
+
+# 6. Remove from prod state
+terraform init -backend-config="key=prod/terraform.tfstate" -reconfigure
+terraform state rm aws_vpc_endpoint.s3
+terraform state rm aws_iam_role.api_gateway_cloudwatch
+terraform state rm aws_iam_role_policy_attachment.api_gateway_cloudwatch
+terraform state rm aws_api_gateway_account.main
+
+# 7. Verify all three states are clean
+cd shared && terraform plan              # Should show no changes
+cd .. && terraform init -backend-config="key=dev/terraform.tfstate" -reconfigure
+terraform plan -var-file="environments/dev.tfvars" ...   # No unexpected changes
+terraform init -backend-config="key=prod/terraform.tfstate" -reconfigure
+terraform plan -var-file="environments/prod.tfvars" ...  # No unexpected changes
+```

--- a/infrastructure/terraform/shared/backend.tf
+++ b/infrastructure/terraform/shared/backend.tf
@@ -1,0 +1,12 @@
+# Shared infrastructure state — VPC-scoped and account-scoped singletons.
+# Unlike per-environment configs, the key is hardcoded (only one shared layer).
+
+terraform {
+  backend "s3" {
+    bucket         = "surfaced-art-terraform-state"
+    key            = "shared/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "surfaced-art-terraform-locks"
+  }
+}

--- a/infrastructure/terraform/shared/main.tf
+++ b/infrastructure/terraform/shared/main.tf
@@ -1,0 +1,84 @@
+# =============================================================================
+# Shared Infrastructure — VPC-scoped and account-scoped singletons
+# =============================================================================
+#
+# Resources in this layer are shared across all environments (dev, prod).
+# They cannot be duplicated per environment because AWS enforces uniqueness
+# at the VPC or account level.
+#
+# This layer has its own Terraform state (shared/terraform.tfstate) and must
+# be applied before any per-environment config. Per-environment configs
+# reference these resources via data sources, not resource declarations.
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = var.project_name
+      Layer     = "shared"
+      ManagedBy = "terraform"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# VPC — default VPC used by all environments
+# -----------------------------------------------------------------------------
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_route_tables" "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+# S3 gateway endpoint — allows VPC-attached Lambdas to reach S3 without
+# traversing a NAT gateway or the public internet. Only one S3 gateway
+# endpoint can exist per VPC, so this must be in the shared layer.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = data.aws_vpc.default.id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = data.aws_route_tables.default.ids
+
+  tags = {
+    Name = "${var.project_name}-s3-endpoint"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# API Gateway CloudWatch Logging — account-scoped singleton
+# -----------------------------------------------------------------------------
+# API Gateway requires a regional account-level setting to push logs to
+# CloudWatch. Only one aws_api_gateway_account resource can exist per
+# region per AWS account, so this must be in the shared layer.
+
+resource "aws_iam_role" "api_gateway_cloudwatch" {
+  name = "${var.project_name}-${var.aws_region}-api-gateway-cloudwatch"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "apigateway.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = {
+    Name = "${var.project_name}-${var.aws_region}-api-gateway-cloudwatch"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "api_gateway_cloudwatch" {
+  role       = aws_iam_role.api_gateway_cloudwatch.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+}
+
+resource "aws_api_gateway_account" "main" {
+  cloudwatch_role_arn = aws_iam_role.api_gateway_cloudwatch.arn
+}

--- a/infrastructure/terraform/shared/outputs.tf
+++ b/infrastructure/terraform/shared/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc_endpoint_s3_id" {
+  description = "ID of the S3 VPC gateway endpoint"
+  value       = aws_vpc_endpoint.s3.id
+}
+
+output "api_gateway_cloudwatch_role_arn" {
+  description = "ARN of the IAM role for API Gateway CloudWatch logging"
+  value       = aws_iam_role.api_gateway_cloudwatch.arn
+}

--- a/infrastructure/terraform/shared/variables.tf
+++ b/infrastructure/terraform/shared/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name used in resource naming"
+  type        = string
+  default     = "surfaced-art"
+}

--- a/infrastructure/terraform/shared/versions.tf
+++ b/infrastructure/terraform/shared/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.33"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts VPC-scoped and account-scoped AWS singletons (S3 gateway endpoint, API Gateway CloudWatch account) into a dedicated `infrastructure/terraform/shared/` layer with its own state file
- Removes these resources from the per-environment Terraform config to prevent `RouteAlreadyExists` conflicts when dev and prod share the same VPC
- Updates CI and deploy workflows to plan/apply the shared layer before environment-specific layers

## Why
Dev and prod share the same default VPC but have separate Terraform states. Both declared the S3 VPC gateway endpoint (one per VPC) and API Gateway account setting (one per region), causing deploy failures when one environment was destroyed and redeployed.

## Migration Required (before merge)
**This PR requires a one-time state migration.** See `infrastructure/terraform/shared/README.md` for full steps:
1. `terraform import` existing VPC endpoint and API Gateway account into the new shared state
2. `terraform state rm` those resources from dev and prod states
3. Verify all three states show no unexpected changes

## Test plan
- [ ] Run `terraform plan` on shared layer — should show resources to create (or no changes after import)
- [ ] Run `terraform plan` on dev — should show no unexpected changes after state rm
- [ ] Run `terraform plan` on prod — should show no unexpected changes after state rm
- [ ] Deploy to dev succeeds
- [ ] Deploy to prod succeeds

## Summary by Sourcery

Introduce a dedicated shared Terraform layer for VPC- and account-scoped AWS singletons and ensure it is planned/applied before environment-specific infrastructure in CI and deployment workflows.

Enhancements:
- Extract VPC-scoped S3 gateway endpoint and account-scoped API Gateway CloudWatch configuration into a new infrastructure/terraform/shared Terraform layer with its own backend state.
- Document the shared Terraform layer, including managed resources, backend configuration, and one-time migration steps from per-environment states.
- Remove shared singleton resource declarations from per-environment Terraform modules and replace them with references to the shared layer.

CI:
- Add a Terraform Plan (shared) CI job that runs when infrastructure changes are detected and posts the plan as a PR comment.
- Update dev and prod deployment workflows to run a Terraform Apply for the shared layer before applying environment-specific Terraform changes.

Documentation:
- Add README documentation for the shared Terraform layer, including usage, state details, and migration procedure.