### PR TITLE
feat(web): redesign hero with dual-row scroll and frosted glass overlay

### DIFF
--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -1,7 +1,29 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 
 vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://surfaced.art')
 vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.surfaced.art')
+vi.stubEnv('NEXT_PUBLIC_CDN_DOMAINS', 'https://test.cloudfront.net')
+
+// SplitHero uses browser APIs unavailable in test environment
+vi.stubGlobal(
+  'matchMedia',
+  vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }),
+)
+vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(1))
+vi.stubGlobal('cancelAnimationFrame', vi.fn())
+vi.stubGlobal(
+  'IntersectionObserver',
+  class {
+    observe = vi.fn()
+    disconnect = vi.fn()
+    constructor(_cb: IntersectionObserverCallback, _opts?: IntersectionObserverInit) {}
+  },
+)
+
 import { render, screen } from '@testing-library/react'
 
 vi.mock('@/lib/api', () => ({
@@ -15,6 +37,10 @@ import Home from './page'
 describe('Home Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
   })
 
   it('should render the hero heading', async () => {

--- a/apps/web/src/components/SplitHero.tsx
+++ b/apps/web/src/components/SplitHero.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { Images, BadgeDollarSign, Users, Search } from 'lucide-react'
@@ -14,62 +14,153 @@ function getCdnBase(): string {
 type Artwork = { slug: string; listing: string; title: string }
 
 const ARTWORKS: Artwork[] = [
+  // Elena Cordova — painting
   { slug: 'elena-cordova', listing: 'arroyos-at-dusk', title: 'Arroyos at Dusk' },
-  { slug: 'james-okafor', listing: 'sunday-table', title: 'Sunday Table' },
   { slug: 'elena-cordova', listing: 'red-earth-blue-shadow', title: 'Red Earth, Blue Shadow' },
-  { slug: 'tomoko-ishida', listing: 'rain-on-glass-puget-sound', title: 'Rain on Glass, Puget Sound' },
   { slug: 'elena-cordova', listing: 'chamisa-in-october', title: 'Chamisa in October' },
-  { slug: 'james-okafor', listing: 'corner-store', title: 'Corner Store' },
-  { slug: 'tomoko-ishida', listing: 'three-vessels', title: 'Three Vessels' },
   { slug: 'elena-cordova', listing: 'acequia-study-no-3', title: 'Acequia Study No. 3' },
+  { slug: 'elena-cordova', listing: 'madre-tierra-sold', title: 'Madre Tierra' },
+  // James Okafor — painting
+  { slug: 'james-okafor', listing: 'sunday-table', title: 'Sunday Table' },
+  { slug: 'james-okafor', listing: 'corner-store', title: 'Corner Store' },
+  { slug: 'james-okafor', listing: 'wash-day', title: 'Wash Day' },
+  { slug: 'james-okafor', listing: 'lunchtime-decatur', title: 'Lunchtime, Decatur' },
+  { slug: 'james-okafor', listing: 'elders', title: 'Elders' },
+  // Tomoko Ishida — photography / ceramics
+  { slug: 'tomoko-ishida', listing: 'rain-on-glass-puget-sound', title: 'Rain on Glass, Puget Sound' },
+  { slug: 'tomoko-ishida', listing: 'three-vessels', title: 'Three Vessels' },
+  { slug: 'tomoko-ishida', listing: 'chawan-ash-glaze', title: 'Chawan, Ash Glaze' },
+  { slug: 'tomoko-ishida', listing: 'moss-and-stone', title: 'Moss and Stone' },
+  { slug: 'tomoko-ishida', listing: 'winter-light-studio', title: 'Winter Light, Studio' },
+  // Amara Osei — jewelry
+  { slug: 'amara-osei', listing: 'sankofa-cuff', title: 'Sankofa Cuff' },
+  { slug: 'amara-osei', listing: 'goldweight-earrings-geometric', title: 'Goldweight Earrings, Geometric' },
+  { slug: 'amara-osei', listing: 'adinkra-ring-gye-nyame', title: 'Adinkra Ring, Gye Nyame' },
+  { slug: 'amara-osei', listing: 'kente-pendant-large', title: 'Kente Pendant, Large' },
+  { slug: 'amara-osei', listing: 'goldweight-brooch-bird', title: 'Goldweight Brooch, Bird' },
 ]
 
 /**
- * Collage layout: columns with varying image counts for a salon-wall feel.
- * Heights: tall ≈ 53vh, medium ≈ 34vh, small ≈ 17vh.
- * Pattern avoids adjacent columns with the same type.
+ * Two rows of artwork, artists interleaved so adjacent images differ.
+ * Top row: 10 images, bottom row: 10 images.
  */
-type CollageColumn =
-  | { type: 'tall'; images: [Artwork] }
-  | { type: 'double'; images: [Artwork, Artwork] }
-  | { type: 'triple'; images: [Artwork, Artwork, Artwork] }
-  | { type: 'tall-short'; images: [Artwork, Artwork] }
-  | { type: 'short-tall'; images: [Artwork, Artwork] }
-
-const COLLAGE_COLUMNS: CollageColumn[] = [
-  { type: 'tall', images: [ARTWORKS[0]] },
-  { type: 'triple', images: [ARTWORKS[1], ARTWORKS[2], ARTWORKS[3]] },
-  { type: 'short-tall', images: [ARTWORKS[4], ARTWORKS[5]] },
-  { type: 'double', images: [ARTWORKS[6], ARTWORKS[7]] },
-  { type: 'tall-short', images: [ARTWORKS[3], ARTWORKS[1]] },
-  { type: 'triple', images: [ARTWORKS[5], ARTWORKS[0], ARTWORKS[4]] },
-  { type: 'tall', images: [ARTWORKS[2]] },
-  { type: 'double', images: [ARTWORKS[7], ARTWORKS[6]] },
+const TOP_ROW: Artwork[] = [
+  ARTWORKS[0],  // elena
+  ARTWORKS[5],  // james
+  ARTWORKS[10], // tomoko
+  ARTWORKS[15], // amara
+  ARTWORKS[1],  // elena
+  ARTWORKS[6],  // james
+  ARTWORKS[11], // tomoko
+  ARTWORKS[16], // amara
+  ARTWORKS[2],  // elena
+  ARTWORKS[7],  // james
 ]
 
-const COL_HEIGHTS: Record<CollageColumn['type'], string[]> = {
-  tall: ['h-[53vh]'],
-  double: ['h-[25vh]', 'h-[25vh]'],
-  triple: ['h-[16vh]', 'h-[16vh]', 'h-[16vh]'],
-  'tall-short': ['h-[35vh]', 'h-[16vh]'],
-  'short-tall': ['h-[16vh]', 'h-[35vh]'],
-}
+const BOTTOM_ROW: Artwork[] = [
+  ARTWORKS[12], // tomoko
+  ARTWORKS[17], // amara
+  ARTWORKS[3],  // elena
+  ARTWORKS[8],  // james
+  ARTWORKS[13], // tomoko
+  ARTWORKS[18], // amara
+  ARTWORKS[4],  // elena
+  ARTWORKS[9],  // james
+  ARTWORKS[14], // tomoko
+  ARTWORKS[19], // amara
+]
 
 function artworkImageUrl(slug: string, listing: string): string {
   const cdnBase = getCdnBase()
   return `${cdnBase}/uploads/seed/artists/${slug}/listings/${listing}/front/800w.webp`
 }
 
+/** Scroll speed in pixels per second. */
+const SCROLL_PX_PER_S = 30
+
 /**
- * Duration for one full scroll cycle in seconds.
- * The track contains duplicated artwork images; this controls how long it takes
- * to scroll through one full set before seamlessly looping.
+ * A single scrolling row of artwork. Renders two copies of the image set
+ * and uses rAF to scroll by the exact measured width of one copy.
  */
-const SCROLL_DURATION_S = 60
+function ScrollRow({
+  artworks,
+  height,
+  speedMultiplier = 1,
+  visible,
+}: {
+  artworks: Artwork[]
+  height: string
+  speedMultiplier?: number
+  visible: React.RefObject<boolean>
+}) {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const setARef = useRef<HTMLDivElement>(null)
+  const offsetRef = useRef(0)
+  const rafRef = useRef<number>(0)
+  const lastTimeRef = useRef<number>(0)
+
+  const tick = useCallback(
+    (now: number) => {
+      if (lastTimeRef.current === 0) {
+        lastTimeRef.current = now
+      }
+
+      const delta = now - lastTimeRef.current
+      lastTimeRef.current = now
+
+      if (visible.current && trackRef.current && setARef.current) {
+        const setWidth = setARef.current.offsetWidth
+        if (setWidth > 0) {
+          offsetRef.current =
+            (offsetRef.current + (delta / 1000) * SCROLL_PX_PER_S * speedMultiplier) % setWidth
+          trackRef.current.style.transform = `translateX(-${offsetRef.current}px)`
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(tick)
+    },
+    [speedMultiplier, visible],
+  )
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(rafRef.current)
+  }, [tick])
+
+  function renderSet(keyPrefix: string) {
+    return (
+      <div
+        ref={keyPrefix === 'a' ? setARef : undefined}
+        className="flex flex-shrink-0 items-center gap-4 pr-4"
+        aria-hidden={keyPrefix === 'b' || undefined}
+      >
+        {artworks.map((art, i) => (
+          <Image
+            key={`${keyPrefix}-${art.listing}-${i}`}
+            src={artworkImageUrl(art.slug, art.listing)}
+            alt={art.title}
+            width={800}
+            height={800}
+            unoptimized
+            loading={keyPrefix === 'a' && i < 3 ? 'eager' : 'lazy'}
+            className={`${height} w-auto flex-shrink-0 rounded-sm`}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex" ref={trackRef} style={{ willChange: 'transform' }}>
+      {renderSet('a')}
+      {renderSet('b')}
+    </div>
+  )
+}
 
 export function SplitHero() {
   const sectionRef = useRef<HTMLElement>(null)
-  const [paused, setPaused] = useState(false)
+  const visibleRef = useRef(true)
 
   useEffect(() => {
     const section = sectionRef.current
@@ -77,17 +168,26 @@ export function SplitHero() {
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        setPaused(!entry.isIntersecting)
+        visibleRef.current = entry.isIntersecting
       },
       { threshold: 0 },
     )
-
     observer.observe(section)
-    return () => observer.disconnect()
-  }, [])
 
-  // Duplicate columns for seamless infinite loop
-  const allColumns = [...COLLAGE_COLUMNS, ...COLLAGE_COLUMNS]
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    if (motionQuery.matches) {
+      visibleRef.current = false
+    }
+    const onMotionChange = (e: MediaQueryListEvent) => {
+      visibleRef.current = !e.matches
+    }
+    motionQuery.addEventListener('change', onMotionChange)
+
+    return () => {
+      observer.disconnect()
+      motionQuery.removeEventListener('change', onMotionChange)
+    }
+  }, [])
 
   return (
     <section
@@ -96,51 +196,40 @@ export function SplitHero() {
       className="full-bleed relative -mt-8 overflow-hidden md:-mt-12"
       style={{
         minHeight: '65vh',
-        background: 'linear-gradient(to bottom, color-mix(in srgb, var(--accent-primary) 25%, var(--background)) 0%, color-mix(in srgb, var(--accent-primary) 10%, var(--background)) 50%, var(--background) 85%, transparent 100%)',
+        background:
+          'linear-gradient(to bottom, color-mix(in srgb, var(--accent-primary) 25%, var(--background)) 0%, color-mix(in srgb, var(--accent-primary) 10%, var(--background)) 50%, var(--background) 85%, transparent 100%)',
       }}
     >
-      {/* Scrolling artwork track */}
-      <div className="absolute inset-0 flex items-center overflow-hidden">
-        <div
-          data-testid="hero-scroll-track"
-          className="flex gap-4 px-4"
-          style={{
-            willChange: 'transform',
-            animation: `hero-scroll ${SCROLL_DURATION_S}s linear infinite`,
-            animationPlayState: paused ? 'paused' : 'running',
-          }}
-        >
-          {allColumns.map((col, colIdx) => {
-            const heights = COL_HEIGHTS[col.type]
-            return (
-              <div
-                key={`${col.type}-${colIdx}`}
-                className="flex flex-shrink-0 flex-col items-center justify-center gap-3"
-              >
-                {col.images.map((art, imgIdx) => (
-                  <Image
-                    key={`${art.listing}-${colIdx}-${imgIdx}`}
-                    src={artworkImageUrl(art.slug, art.listing)}
-                    alt={art.title}
-                    width={col.images.length === 1 ? 800 : 400}
-                    height={col.images.length === 1 ? 800 : 400}
-                    unoptimized
-                    loading={colIdx < 3 ? 'eager' : 'lazy'}
-                    className={`${heights[imgIdx]} w-auto rounded-sm object-contain shadow-md`}
-                  />
-                ))}
-              </div>
-            )
-          })}
-        </div>
+      {/* Two staggered rows of scrolling artwork */}
+      <div
+        data-testid="hero-scroll-track"
+        className="absolute inset-0 flex flex-col items-start justify-center gap-4 overflow-hidden"
+      >
+        <ScrollRow
+          artworks={TOP_ROW}
+          height="h-[28vh]"
+          speedMultiplier={1}
+          visible={visibleRef}
+        />
+        <ScrollRow
+          artworks={BOTTOM_ROW}
+          height="h-[24vh]"
+          speedMultiplier={0.7}
+          visible={visibleRef}
+        />
       </div>
 
       {/* Frosted-glass CTA overlay */}
       <div className="absolute inset-0 flex items-center justify-center">
         <div
-          className="mx-6 max-w-md rounded-xl border border-border bg-background px-8 py-10 text-center"
+          className="mx-6 max-w-md rounded-xl px-8 py-10 text-center"
           style={{
-            boxShadow: '0 8px 40px rgba(0, 0, 0, 0.25), 0 0 80px rgba(0, 0, 0, 0.1)',
+            backgroundColor: 'color-mix(in srgb, var(--background) 82%, transparent)',
+            backdropFilter: 'blur(24px) saturate(1.2)',
+            WebkitBackdropFilter: 'blur(24px) saturate(1.2)',
+            boxShadow:
+              'inset 0 0 40px rgba(0, 0, 0, 0.05), 0 0 60px color-mix(in srgb, var(--background) 50%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--border) 30%, transparent)',
           }}
         >
           <h1 className="text-3xl tracking-tight text-foreground sm:text-4xl">
@@ -182,19 +271,6 @@ export function SplitHero() {
           </div>
         </div>
       </div>
-
-      {/* CSS keyframes for the scroll animation */}
-      <style>{`
-        @keyframes hero-scroll {
-          from { transform: translateX(0); }
-          to { transform: translateX(-50%); }
-        }
-        @media (prefers-reduced-motion: reduce) {
-          [data-testid="hero-scroll-track"] {
-            animation: none !important;
-          }
-        }
-      `}</style>
     </section>
   )
 }

--- a/apps/web/src/components/SplitHero.tsx
+++ b/apps/web/src/components/SplitHero.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { Images, BadgeDollarSign, Users, Search } from 'lucide-react'
@@ -95,37 +95,34 @@ function ScrollRow({
 }) {
   const trackRef = useRef<HTMLDivElement>(null)
   const setARef = useRef<HTMLDivElement>(null)
-  const offsetRef = useRef(0)
-  const rafRef = useRef<number>(0)
-  const lastTimeRef = useRef<number>(0)
 
-  const tick = useCallback(
-    (now: number) => {
-      if (lastTimeRef.current === 0) {
-        lastTimeRef.current = now
+  useEffect(() => {
+    let offset = 0
+    let lastTime = 0
+    let raf = 0
+
+    const tick = (now: number) => {
+      if (lastTime === 0) {
+        lastTime = now
       }
 
-      const delta = now - lastTimeRef.current
-      lastTimeRef.current = now
+      const delta = now - lastTime
+      lastTime = now
 
       if (visible.current && trackRef.current && setARef.current) {
         const setWidth = setARef.current.offsetWidth
         if (setWidth > 0) {
-          offsetRef.current =
-            (offsetRef.current + (delta / 1000) * SCROLL_PX_PER_S * speedMultiplier) % setWidth
-          trackRef.current.style.transform = `translateX(-${offsetRef.current}px)`
+          offset = (offset + (delta / 1000) * SCROLL_PX_PER_S * speedMultiplier) % setWidth
+          trackRef.current.style.transform = `translateX(-${offset}px)`
         }
       }
 
-      rafRef.current = requestAnimationFrame(tick)
-    },
-    [speedMultiplier, visible],
-  )
+      raf = requestAnimationFrame(tick)
+    }
 
-  useEffect(() => {
-    rafRef.current = requestAnimationFrame(tick)
-    return () => cancelAnimationFrame(rafRef.current)
-  }, [tick])
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [speedMultiplier, visible])
 
   function renderSet(keyPrefix: string) {
     return (

--- a/apps/web/src/components/__tests__/SplitHero.test.tsx
+++ b/apps/web/src/components/__tests__/SplitHero.test.tsx
@@ -5,11 +5,35 @@ import { SplitHero } from '../SplitHero'
 describe('SplitHero', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_CDN_DOMAINS = 'https://test.cloudfront.net'
+
+    // Mock APIs unavailable in test environment
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    )
+    vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe = vi.fn()
+        disconnect = vi.fn()
+        constructor(
+          _cb: IntersectionObserverCallback,
+          _opts?: IntersectionObserverInit,
+        ) {}
+      },
+    )
   })
 
   afterEach(() => {
     delete process.env.NEXT_PUBLIC_CDN_DOMAINS
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('should render the hero section with data-testid', () => {


### PR DESCRIPTION
## Summary
- Replace column-based collage layout with two horizontal rows scrolling at different speeds (parallax effect)
- Switch from CSS `translateX(-50%)` animation to `requestAnimationFrame`-driven scroll for pixel-perfect seamless looping
- Expand artwork from 8 images (2 artists) to 20 images (all 4 demo artists), no duplicates
- Replace popup-style drop shadow on CTA card with frosted glass (82% opacity, backdrop-blur) + inner glow hybrid

## Test plan
- [ ] Verify hero scrolls smoothly with no visible jump at the loop point
- [ ] Verify all 20 artwork images load from CDN (no broken images)
- [ ] Verify the CTA card looks integrated (not popup-like) in both light and dark mode
- [ ] Verify scroll pauses when hero is off-screen (scroll down and back)
- [ ] Verify `prefers-reduced-motion: reduce` disables the animation
- [ ] Verify mobile rendering — two rows visible, consistent speed feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redesign the SplitHero artwork section with a dual-row, rAF-driven horizontal scroll and a frosted-glass CTA overlay.

New Features:
- Introduce two horizontally scrolling artwork rows using a requestAnimationFrame-based loop with different speeds for a parallax effect.
- Expand the hero artwork set to 20 unique images spanning all demo artists and organize them into dedicated top and bottom rows.

Enhancements:
- Replace the CSS keyframe-based scroll animation with a visibility-aware, prefers-reduced-motion-aware JavaScript animation loop.
- Update the hero CTA card to use a frosted-glass style overlay with backdrop blur, subtle inner glow, and softer border styling.