### PR TITLE
fix(ci): use placeholders for all Terraform vars in PR prod plan

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,10 +96,14 @@ jobs:
         run: |
           terraform plan -no-color -input=false \
             -var-file="environments/prod.tfvars" \
-            -var="db_password=${{ secrets.TF_VAR_db_password }}" \
-            -var="google_client_id=${{ secrets.TF_VAR_google_client_id }}" \
-            -var="google_client_secret=${{ secrets.TF_VAR_google_client_secret }}" \
-            -var="alert_email_address=${{ secrets.TF_VAR_alert_email_address }}"
+            -var="db_password=plan-placeholder" \
+            -var="google_client_id=plan-placeholder" \
+            -var="google_client_secret=plan-placeholder" \
+            -var="alert_email_address=plan@placeholder.com" \
+            -var="stripe_secret_key=plan-placeholder" \
+            -var="stripe_webhook_secret=plan-placeholder" \
+            -var="postmark_server_token=plan-placeholder" \
+            -var="placeholder_image_uri=public.ecr.aws/lambda/nodejs:20"
         continue-on-error: true
 
       - name: Comment Plan on PR


### PR DESCRIPTION
## Summary
- PR prod Terraform plan was missing `postmark_server_token`, `stripe_secret_key`, `stripe_webhook_secret`, and `placeholder_image_uri` vars, causing CI failure on PR #488
- Switch from environment secrets to plan-placeholder values, matching how the dev CI plan already works — this is a read-only plan, not an apply

## Test plan
- [ ] PR #488 (dev → main) Terraform Plan (prod) passes after this merges into dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Replace secret-based Terraform variable inputs in the PR production plan with non-sensitive placeholder values and add placeholders for previously missing variables.