### PR TITLE
feat(api): send welcome email on waitlist signup

### DIFF
--- a/apps/api/src/routes/waitlist.test.ts
+++ b/apps/api/src/routes/waitlist.test.ts
@@ -3,6 +3,11 @@ import { Hono } from 'hono'
 import { Prisma } from '@surfaced-art/db'
 import { createWaitlistRoutes } from './waitlist'
 
+vi.mock('@surfaced-art/email', () => ({
+  sendEmail: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-123' }),
+  WaitlistWelcome: vi.fn(),
+}))
+
 function createMockPrisma(overrides?: {
   create?: unknown
   createError?: Error
@@ -242,6 +247,77 @@ describe('POST /waitlist', () => {
       const body = await res.json()
       expect(body.error.code).toBe('INTERNAL_ERROR')
       expect(body.error.message).toBe('Internal server error')
+    })
+  })
+
+  describe('welcome email', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      mockPrisma = createMockPrisma()
+      app = createTestApp(mockPrisma)
+    })
+
+    it('should send welcome email on successful signup', async () => {
+      const { sendEmail } = await import('@surfaced-art/email')
+
+      await app.request('/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'newuser@example.com' }),
+      })
+
+      expect(sendEmail).toHaveBeenCalledOnce()
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'newuser@example.com',
+          subject: expect.stringContaining('Surfaced Art'),
+        })
+      )
+    })
+
+    it('should not send email on duplicate signup', async () => {
+      vi.clearAllMocks()
+      const uniqueError = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed on the fields: (`email`)',
+        { code: 'P2002', clientVersion: '5.0.0' }
+      )
+      mockPrisma = createMockPrisma({ createError: uniqueError })
+      app = createTestApp(mockPrisma)
+
+      const { sendEmail } = await import('@surfaced-art/email')
+
+      await app.request('/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'existing@example.com' }),
+      })
+
+      expect(sendEmail).not.toHaveBeenCalled()
+    })
+
+    it('should not send email on validation failure', async () => {
+      const { sendEmail } = await import('@surfaced-art/email')
+
+      await app.request('/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'bad' }),
+      })
+
+      expect(sendEmail).not.toHaveBeenCalled()
+    })
+
+    it('should not fail the request if email sending throws', async () => {
+      const { sendEmail } = await import('@surfaced-art/email')
+      vi.mocked(sendEmail).mockRejectedValue(new Error('Postmark unavailable'))
+
+      const res = await app.request('/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'newuser@example.com' }),
+      })
+
+      expect(res.status).toBe(201)
     })
   })
 })

--- a/apps/api/src/routes/waitlist.ts
+++ b/apps/api/src/routes/waitlist.ts
@@ -1,7 +1,9 @@
+import { createElement } from 'react'
 import { Hono } from 'hono'
 import type { PrismaClient } from '@surfaced-art/db'
 import { Prisma } from '@surfaced-art/db'
 import { logger } from '@surfaced-art/utils'
+import { sendEmail, WaitlistWelcome } from '@surfaced-art/email'
 import { waitlistBody } from '@surfaced-art/types'
 import { badRequest, validationError, internalError } from '../errors'
 
@@ -42,6 +44,17 @@ export function createWaitlistRoutes(prisma: PrismaClient) {
 
       logger.info('Waitlist signup', {
         durationMs: Date.now() - start,
+      })
+
+      // Fire-and-forget welcome email
+      sendEmail({
+        to: normalizedEmail,
+        subject: 'Welcome to Surfaced Art',
+        template: createElement(WaitlistWelcome),
+      }).catch((err) => {
+        logger.error('Failed to send waitlist welcome email', {
+          error: err,
+        })
       })
 
       return c.json({ message: 'Successfully joined the waitlist' }, 201)


### PR DESCRIPTION
## Summary
- Wires the existing `WaitlistWelcome` React Email template to `POST /waitlist`
- Fire-and-forget pattern: email failures are logged but don't block the API response
- Only new signups get the email — duplicates and validation errors do not trigger it

## Test plan
- [x] Unit tests: email sent on success, not sent on duplicate/validation error, API resilient to email failure (4 new tests, 17 total passing)
- [x] Build, typecheck, lint all pass
- [ ] Live test: submit waitlist signup and verify email arrives + check Postmark Activity tab

## Summary by Sourcery

Send a welcome email when a user successfully joins the waitlist without impacting API responses on email failures.

New Features:
- Trigger a waitlist welcome email for new signups via the waitlist API endpoint.

Tests:
- Add tests to verify emails are sent only on successful signups, skipped on duplicates/validation failures, and that API responses remain successful when email sending fails.