### PR TITLE
fix: address AI code review findings (batch 2026-03-16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,25 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const hasInfra = files.some(f => f.filename.startsWith('infrastructure/'));
+            const perPage = 100;
+            const totalChanged = context.payload.pull_request.changed_files;
+            const totalPages = Math.ceil(totalChanged / perPage);
+
+            let hasInfra = false;
+            let page = 1;
+
+            while (page <= totalPages && !hasInfra) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: perPage,
+                page,
+              });
+              hasInfra = files.some(f => f.filename.startsWith('infrastructure/'));
+              page += 1;
+            }
+
             core.setOutput('changed', hasInfra ? 'true' : 'false');
 
       - name: Setup Terraform
@@ -88,7 +100,9 @@ jobs:
           set -o pipefail
           terraform plan -no-color \
             2>&1 | tee /tmp/shared-plan.txt
-          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          PLAN_EXIT=${PIPESTATUS[0]}
+          echo "exitcode=${PLAN_EXIT}" >> "$GITHUB_OUTPUT"
+          exit $PLAN_EXIT
 
       - name: Post shared plan as PR comment
         if: steps.infra_changes.outputs.changed == 'true' && always()
@@ -154,13 +168,25 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const hasInfra = files.some(f => f.filename.startsWith('infrastructure/'));
+            const perPage = 100;
+            const totalChanged = context.payload.pull_request.changed_files;
+            const totalPages = Math.ceil(totalChanged / perPage);
+
+            let hasInfra = false;
+            let page = 1;
+
+            while (page <= totalPages && !hasInfra) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: perPage,
+                page,
+              });
+              hasInfra = files.some(f => f.filename.startsWith('infrastructure/'));
+              page += 1;
+            }
+
             core.setOutput('changed', hasInfra ? 'true' : 'false');
 
       - name: Setup Terraform
@@ -200,9 +226,12 @@ jobs:
             -var="stripe_secret_key=plan-placeholder" \
             -var="stripe_webhook_secret=plan-placeholder" \
             -var="postmark_server_token=plan-placeholder" \
+            -var="email_from_address=plan@placeholder.com" \
             -var="placeholder_image_uri=public.ecr.aws/lambda/nodejs:20" \
             2>&1 | tee /tmp/plan.txt
-          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          PLAN_EXIT=${PIPESTATUS[0]}
+          echo "exitcode=${PLAN_EXIT}" >> "$GITHUB_OUTPUT"
+          exit $PLAN_EXIT
 
       - name: Post plan as PR comment
         if: steps.infra_changes.outputs.changed == 'true' && always()

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -249,6 +249,7 @@ jobs:
             -var="stripe_secret_key=${{ secrets.TF_VAR_stripe_secret_key }}" \
             -var="stripe_webhook_secret=${{ secrets.TF_VAR_stripe_webhook_secret }}" \
             -var="postmark_server_token=${{ secrets.TF_VAR_postmark_server_token }}" \
+            -var="email_from_address=${{ secrets.TF_VAR_email_from_address }}" \
             -var="placeholder_image_uri=${{ steps.bootstrap.outputs.placeholder_uri }}" \
             -out=tfplan
           EXIT_CODE=$?

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,6 +266,7 @@ jobs:
             -var="stripe_secret_key=${{ secrets.TF_VAR_stripe_secret_key }}" \
             -var="stripe_webhook_secret=${{ secrets.TF_VAR_stripe_webhook_secret }}" \
             -var="postmark_server_token=${{ secrets.TF_VAR_postmark_server_token }}" \
+            -var="email_from_address=${{ secrets.TF_VAR_email_from_address }}" \
             -var="placeholder_image_uri=${{ steps.bootstrap.outputs.placeholder_uri }}" \
             -out=tfplan
           EXIT_CODE=$?

--- a/apps/api/src/routes/waitlist.ts
+++ b/apps/api/src/routes/waitlist.ts
@@ -54,6 +54,7 @@ export function createWaitlistRoutes(prisma: PrismaClient) {
       }).catch((err) => {
         logger.error('Failed to send waitlist welcome email', {
           error: err,
+          email: normalizedEmail,
         })
       })
 

--- a/apps/web/src/components/SplitHero.tsx
+++ b/apps/web/src/components/SplitHero.tsx
@@ -219,7 +219,7 @@ export function SplitHero() {
       {/* Frosted-glass CTA overlay */}
       <div className="absolute inset-0 flex items-center justify-center">
         <div
-          className="mx-6 max-w-md rounded-xl px-8 py-10 text-center"
+          className="mx-6 max-w-md rounded-xl bg-background/90 px-8 py-10 text-center"
           style={{
             backgroundColor: 'color-mix(in srgb, var(--background) 82%, transparent)',
             backdropFilter: 'blur(24px) saturate(1.2)',

--- a/apps/web/src/components/ThemePicker.tsx
+++ b/apps/web/src/components/ThemePicker.tsx
@@ -334,18 +334,20 @@ export function ThemePicker() {
         onClick={() => setIsOpen(!isOpen)}
         aria-label="Switch color palette"
         aria-expanded={isOpen}
+        aria-haspopup="menu"
         className="inline-flex items-center justify-center w-9 h-9 rounded-md text-muted-foreground hover:text-foreground transition-colors"
       >
         <Palette className="h-5 w-5" />
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-52 rounded-lg border border-border bg-background shadow-lg z-50 py-1">
+        <div role="menu" className="absolute right-0 top-full mt-2 w-52 rounded-lg border border-border bg-background shadow-lg z-50 py-1">
           <p className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
             Color Palette
           </p>
           {PALETTES.map(p => (
             <button
+              role="menuitem"
               key={p.id}
               type="button"
               onClick={() => selectPalette(p.id)}

--- a/docs/decisions/009-postmark-over-ses.md
+++ b/docs/decisions/009-postmark-over-ses.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-03-15
 
-**Context:** Surfaced Art needs production-ready transactional email for artist application confirmations, approval/rejection notices, and future order-related emails. AWS SES was initially implemented (packages/email/ workspace, Terraform module, IAM policies) but was never fully activated — DNS records were never added to the domain registrar, and the account remained in sandbox mode. With real artist onboarding approaching, we evaluated the email landscape for a solution that provides reliable delivery, a non-technical-friendly dashboard for the COO, and automatic bounce/complaint handling.
+**Context:** Surfaced Art needs production-ready transactional email for artist application confirmations, approval/rejection notices, and future order-related emails. AWS SES was initially implemented (packages/email/ workspace, Terraform module, IAM policies) but was never fully activated — DNS records were never added to the domain registrar, and the account remained in sandbox mode. With real artist onboarding approaching, we evaluated the email landscape for a solution that provides reliable delivery, a dashboard accessible to non-technical stakeholders (the COO), and automatic bounce/complaint handling.
 
 **Decision:** Replace AWS SES with Postmark for all transactional email. The existing `sendEmail()` abstraction in `packages/email/` means only the transport layer changes — React Email templates, API route integrations, and the public package API remain unchanged. Marketing email (newsletters, campaigns) is deferred to a separate service (Kit/ConvertKit is the leading candidate) when needed.
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -250,7 +250,7 @@ module "lambda_api" {
   s3_bucket_name             = module.s3_cloudfront.bucket_name
   cloudfront_url             = module.s3_cloudfront.cloudfront_url
   cloudfront_domain          = module.s3_cloudfront.cloudfront_domain_name
-  email_from_address         = "support@surfaced.art"
+  email_from_address         = var.email_from_address
   postmark_server_token      = var.postmark_server_token
   admin_email                = var.admin_email
   stripe_secret_key          = var.stripe_secret_key

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -104,6 +104,11 @@ variable "postmark_server_token" {
   sensitive   = true
 }
 
+variable "email_from_address" {
+  description = "Sender email address for transactional email (e.g., support@surfaced.art)"
+  type        = string
+}
+
 variable "admin_email" {
   description = "Admin email for internal notifications (e.g., new artist applications)"
   type        = string


### PR DESCRIPTION
## Summary
Batch fix addressing AI code review findings from Sourcery.
Triaged 8 bot review comments across 5 PRs.

## Fixes Applied
| File | Issue | Source | Commit |
|------|-------|--------|--------|
| `infrastructure/terraform/main.tf` + `variables.tf` | Hardcoded `email_from_address` — now a proper Terraform variable | Sourcery (PR #483) | `e6a01c7` |
| `docs/decisions/009-postmark-over-ses.md` | Ambiguous "non-technical-friendly" wording | Sourcery (PR #483) | `4a47ae3` |
| `apps/web/src/components/ThemePicker.tsx` | Missing `aria-haspopup="menu"`, `role="menu"`, `role="menuitem"` | Sourcery (PR #486) | `bea400a` |
| `.github/workflows/ci.yml` | Terraform plan exit code not failing CI + infra change detector 100-file pagination limit | Sourcery (PR #487) | `e3d219c` |
| `apps/web/src/components/SplitHero.tsx` | No CSS fallback for `color-mix()` in frosted glass overlay | Sourcery (PR #490) | `4a5b847` |
| `apps/api/src/routes/waitlist.ts` | Missing email in welcome email failure log | Sourcery (PR #497) | `b9d5221` |

## Skipped (with reasoning)
| File | Issue | Reason |
|------|-------|--------|
| `apps/web/src/components/SplitHero.tsx` | `addEventListener('change')` on MediaQueryList may not work in older browsers | Ignored — `addEventListener` is supported in all target browsers (Safari 14+); `addListener` is deprecated |

## Action Required
- Add GitHub Secret `TF_VAR_email_from_address` (value: `support@surfaced.art`) to both dev and prod environments before next deploy

## Source Reviews
- PR #483: https://github.com/nickcjordan/surfaced-art/pull/483
- PR #486: https://github.com/nickcjordan/surfaced-art/pull/486
- PR #487: https://github.com/nickcjordan/surfaced-art/pull/487
- PR #490: https://github.com/nickcjordan/surfaced-art/pull/490
- PR #497: https://github.com/nickcjordan/surfaced-art/pull/497

## Summary by Sourcery

Address AI code review findings across infrastructure, CI, web UI, API logging, and documentation.

Bug Fixes:
- Ensure Terraform plan failures correctly fail CI by propagating the plan exit code.
- Fix CI infra-change detection to handle pull requests with more than 100 changed files.
- Remove hardcoded transactional email sender address from Terraform in favor of a configurable variable.
- Improve accessibility of the theme picker menu with appropriate ARIA attributes and roles.
- Add a visual background fallback for the frosted-glass CTA overlay when CSS color-mix is unsupported.
- Include the recipient email in waitlist welcome email failure logs for better observability.

Enhancements:
- Document the transactional email decision with clearer wording for non-technical stakeholders.
- Define a Terraform variable for the transactional email sender address and wire it through the API module configuration.

Build:
- Pass the new email_from_address Terraform variable via CI plans and dev/prod deployment workflows.