### PR TITLE
fix(web): revise /for-artists copy to match brand voice guide

### DIFF
--- a/apps/web/src/app/(main)/for-artists/ForArtistsContent.tsx
+++ b/apps/web/src/app/(main)/for-artists/ForArtistsContent.tsx
@@ -353,7 +353,7 @@ function HorizontalTimeline() {
     { num: '1', title: 'Apply', desc: 'Show us what you make and how you make it' },
     { num: '2', title: 'Get reviewed', desc: 'A real person looks at your work, not an algorithm' },
     { num: '3', title: 'Set up your page', desc: 'Photos, bio, pricing. About 20 minutes' },
-    { num: '4', title: 'Start selling', desc: 'Share your link and let the gallery do the rest' },
+    { num: '4', title: 'Start selling', desc: 'Your work is live. Share your link, and buyers can find you from here.' },
   ]
 
   return (
@@ -541,7 +541,7 @@ export default function ForArtistsContent() {
                 Every other profession has a platform that takes it seriously.
               </p>
               <p className="text-body-large mx-auto mt-2 max-w-xl font-medium text-foreground">
-                Now you do too!
+                Now there&apos;s one for artists.
               </p>
 
               <div className="mt-8 flex justify-center">
@@ -584,8 +584,8 @@ export default function ForArtistsContent() {
             <div className="mx-auto max-w-3xl text-center">
               <p className="text-body-small mb-3 font-medium uppercase tracking-widest" style={{ color: 'var(--accent-secondary)' }}>Your Artist Portfolio</p>
               <h2 className="text-foreground">
-                A website for your art.{' '}
-                <span className="relative inline-block"><ShimmerText>No building required</ShimmerText><HandwrittenUnderline color="var(--accent-secondary)" /></span>
+                Your work, on a page that{' '}
+                <span className="relative inline-block"><ShimmerText>actually looks like art</ShimmerText><HandwrittenUnderline color="var(--accent-secondary)" /></span>
               </h2>
               <p className="text-body-default mx-auto mt-5 max-w-2xl text-muted-text">
                 Your portfolio page is a standalone website dedicated entirely to you and your work. No ads, no links to other artists, no distractions. Just your name and your art.
@@ -602,7 +602,7 @@ export default function ForArtistsContent() {
                 <div className="hidden flex-col justify-center gap-6 pt-16 lg:flex">
                   {[
                     { title: 'Your clean URL', desc: 'surfaced.art/your-name. A short, memorable link that goes straight to your portfolio', accent: 'var(--accent-primary)' },
-                    { title: 'Replace your website', desc: 'Bio, CV, artist statement, process photos. Everything a custom site would have, zero maintenance', accent: 'var(--accent-secondary)' },
+                    { title: 'Everything a portfolio site has', desc: 'Bio, CV, artist statement, process photos. Already built. Zero maintenance.', accent: 'var(--accent-secondary)' },
                     { title: 'Pure showcase', desc: 'No ads, no competitor links, no prices on the page. Just your work. Visitors who want to buy click through to the listing', accent: 'var(--accent-primary)' },
                   ].map((item, i) => (
                     <div key={item.title} className="text-right">
@@ -695,7 +695,7 @@ export default function ForArtistsContent() {
                 <div className="grid gap-4 sm:grid-cols-2 lg:hidden">
                   {[
                     { title: 'Your clean URL', desc: 'A memorable link you can share anywhere' },
-                    { title: 'Replace your website', desc: 'Bio, CV, process photos. Zero maintenance' },
+                    { title: 'Everything a portfolio site has', desc: 'Bio, CV, process photos. Zero maintenance' },
                     { title: 'Pure showcase', desc: 'No ads, no competitor links. Just your work' },
                     { title: 'Sold work stays visible', desc: 'Archive builds your full portfolio' },
                     { title: 'Always up to date', desc: 'New pieces appear on your page instantly' },
@@ -734,7 +734,7 @@ export default function ForArtistsContent() {
             <div className="mx-auto max-w-3xl text-center">
               <p className="text-body-small mb-3 font-medium uppercase tracking-widest" style={{ color: 'var(--accent-primary)' }}>Curated Gallery</p>
               <h2 className="text-foreground">
-                Every artist here was chosen
+                Every artist here made something real
               </h2>
               <p className="text-body-default mx-auto mt-6 max-w-xl text-muted-text">
                 Every application is reviewed by hand. When you&apos;re accepted, you join a community of{' '}
@@ -956,7 +956,7 @@ export default function ForArtistsContent() {
                   <HighlightMarker>30% commission</HighlightMarker>, and only when something sells
                 </h2>
                 <p className="text-body-default mx-auto mt-5 max-w-xl text-muted-text">
-                  Covers the platform, payment processing, and customer support. Most physical galleries take 40–50%. No listing fees, no monthly subscriptions.
+                  Covers the platform, payment processing, and customer support. Most physical galleries take 40–50%. And we never take a cut of your shipping costs — that goes straight to you.
                 </p>
               </div>
             </FadeIn>
@@ -1153,7 +1153,7 @@ export default function ForArtistsContent() {
               <div className="rounded-2xl border-2 bg-background p-10 text-center shadow-xl md:p-14" style={{ borderColor: 'color-mix(in srgb, var(--accent-primary) 30%, var(--border))' }}>
                 <h2 className="text-foreground">Your work deserves a <ShimmerText>home</ShimmerText></h2>
                 <p className="text-body-default mx-auto mt-4 max-w-md text-muted-text">
-                  Not another marketplace. Not another social feed. A real place for your art, built for the way you work. Applications are open!
+                  Not another marketplace. Not another social feed. A real place for your art, built for the way you work. Applications are open.
                 </p>
                 <div className="mt-8">
                   <Link

--- a/apps/web/src/app/(main)/for-artists/__tests__/page.test.tsx
+++ b/apps/web/src/app/(main)/for-artists/__tests__/page.test.tsx
@@ -85,4 +85,48 @@ describe('For Artists Page', () => {
     expect(screen.queryByText(/Surfaced Art Creator/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/selling through DMs/i)).not.toBeInTheDocument()
   })
+
+  describe('copy revisions (SUR-287)', () => {
+    it('should use revised hero subheading without hollow enthusiasm', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/Now you do too!/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/Now there's one for artists/i)).toBeInTheDocument()
+    })
+
+    it('should use revised portfolio headline without generic website-builder phrasing', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/No building required/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/actually looks like art/i)).toBeInTheDocument()
+    })
+
+    it('should not use "Replace your website" label that contradicts non-exclusivity', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/Replace your website/i)).not.toBeInTheDocument()
+      expect(screen.getAllByText(/Everything a portfolio site has/i).length).toBeGreaterThan(0)
+    })
+
+    it('should use revised curated gallery headline without gatekeeping tone', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/Every artist here was chosen/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/Every artist here made something real/i)).toBeInTheDocument()
+    })
+
+    it('should use revised how-it-works step 4 text', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/let the gallery do the rest/i)).not.toBeInTheDocument()
+      expect(screen.getAllByText(/buyers can find you from here/i).length).toBeGreaterThan(0)
+    })
+
+    it('should mention no commission on shipping in pricing section', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/No listing fees, no monthly subscriptions/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/we never take a cut of your shipping costs/i)).toBeInTheDocument()
+    })
+
+    it('should use period instead of exclamation on closing CTA', () => {
+      render(<ForArtistsContent />)
+      expect(screen.queryByText(/Applications are open!/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/Applications are open\./i)).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Applies 7 editorial copy revisions to the `/for-artists` page, identified by a full voice & tone audit against the Surfaced Art Voice & Tone Guide.

**Closes SUR-287**

## Changes

| # | Section | Old Copy | New Copy | Severity |
|---|---------|----------|----------|----------|
| 1 | Hero subheading | "Now you do too!" | "Now there's one for artists." | Medium |
| 2 | Portfolio headline | "No building required" | "actually looks like art" | Low |
| 3 | Portfolio feature label | "Replace your website" | "Everything a portfolio site has" | **High** |
| 4 | Curated gallery headline | "Every artist here was chosen" | "Every artist here made something real" | Medium |
| 5 | How It Works step 4 | "let the gallery do the rest" | "buyers can find you from here" | Low |
| 6 | Pricing body | "No listing fees, no monthly subscriptions" | "we never take a cut of your shipping costs" | Medium |
| 7 | Closing CTA | "Applications are open!" | "Applications are open." | Low |

The highest priority fix (#3) removes "Replace your website" which directly contradicts the platform's non-exclusivity stance stated elsewhere on the same page.

## Test plan

- [x] 7 new test cases verify each copy revision (old text absent, new text present)
- [x] All 16 for-artists page tests pass
- [x] Full test suite (707 tests), lint, typecheck, and build all pass

## Summary by Sourcery

Revise marketing copy on the /for-artists page to align with brand voice and non-exclusivity positioning, and add regression tests to lock in the new text.

Bug Fixes:
- Remove "Replace your website" messaging that conflicts with the platform's non-exclusivity stance on the for-artists page.

Enhancements:
- Update multiple headings and body copy on the for-artists page to better reflect the brand's voice and tone, including hero, portfolio, gallery, how-it-works, pricing, and closing CTA sections.

Tests:
- Add targeted tests that assert the absence of deprecated phrasing and the presence of the updated copy across the for-artists page.