### PR TITLE
fix(ci): add missing email_from_address var to bootstrap terraform plan

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -178,6 +178,7 @@ jobs:
             -var="stripe_secret_key=${{ secrets.TF_VAR_stripe_secret_key }}" \
             -var="stripe_webhook_secret=${{ secrets.TF_VAR_stripe_webhook_secret }}" \
             -var="postmark_server_token=${{ secrets.TF_VAR_postmark_server_token }}" \
+            -var="email_from_address=${{ secrets.TF_VAR_email_from_address }}" \
             -var="placeholder_image_uri=${{ env.LAMBDA_BOOTSTRAP_IMAGE }}" \
             -out=bootstrap.tfplan
           EXIT_CODE=$?

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,6 +184,7 @@ jobs:
             -var="stripe_secret_key=${{ secrets.TF_VAR_stripe_secret_key }}" \
             -var="stripe_webhook_secret=${{ secrets.TF_VAR_stripe_webhook_secret }}" \
             -var="postmark_server_token=${{ secrets.TF_VAR_postmark_server_token }}" \
+            -var="email_from_address=${{ secrets.TF_VAR_email_from_address }}" \
             -var="placeholder_image_uri=${{ env.LAMBDA_BOOTSTRAP_IMAGE }}" \
             -out=bootstrap.tfplan
           EXIT_CODE=$?


### PR DESCRIPTION
## Summary

- Add missing `email_from_address` terraform variable to the bootstrap ECR plan step in both `deploy-dev.yml` and `deploy.yml`

The bootstrap plan step was missing this variable, which was added as part of the Postmark email migration. The main terraform plan step had it, but the bootstrap plan (which runs first to ensure ECR repos exist) did not, causing the deploy to fail with `No value for required variable "email_from_address"`.

**Failed run**: https://github.com/nickcjordan/surfaced-art/actions/runs/23174813890

## Test plan

- [ ] Deploy (dev) workflow succeeds after merge

**Important**: Verify that the `TF_VAR_email_from_address` secret is set in GitHub repo settings. If it's missing, the main plan step will also fail even after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Pass the TF_VAR_email_from_address secret into the Terraform bootstrap plan step in both dev and production deploy GitHub Actions workflows to fix failing runs.