### PR TITLE
fix(web): prevent horizontal overflow on mobile

### DIFF
--- a/apps/web/src/app/(main)/artist/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/artist/[slug]/page.tsx
@@ -282,7 +282,7 @@ export default async function ArtistProfilePage({ params }: Props) {
         <h2 className="mb-6 font-heading text-2xl text-foreground">Available Work</h2>
         {availableListings.length > 0 ? (
           <MasonryGrid
-            columns={[2, 2, 3, 3]}
+            columns={[1, 2, 3, 3]}
             itemHeights={availableListings.map((l) =>
               estimateCardHeight(l.images[0]?.width, l.images[0]?.height)
             )}
@@ -318,7 +318,7 @@ export default async function ArtistProfilePage({ params }: Props) {
         <section data-testid="archive-section">
           <h2 className="mb-6 font-heading text-2xl text-foreground">Collection Archive</h2>
           <MasonryGrid
-            columns={[2, 2, 3, 3]}
+            columns={[1, 2, 3, 3]}
             className="opacity-75"
             itemHeights={soldListings.map((l) =>
               estimateCardHeight(l.images[0]?.width, l.images[0]?.height)

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -98,7 +98,7 @@ export default async function Home() {
             </Link>
           </div>
           <MasonryGrid
-            columns={[2, 2, 3, 3]}
+            columns={[1, 2, 3, 3]}
             itemHeights={listings.map((l) =>
               estimateCardHeight(l.primaryImage?.width, l.primaryImage?.height)
             )}

--- a/apps/web/src/app/(portfolio)/[slug]/page.tsx
+++ b/apps/web/src/app/(portfolio)/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function PortfolioWorkPage({ params }: Props) {
       {availableListings.length > 0 && (
         <section data-testid="available-work">
           <MasonryGrid
-            columns={[2, 2, 3, 3]}
+            columns={[1, 2, 3, 3]}
             itemHeights={availableListings.map((l) =>
               estimateCardHeight(l.images[0]?.width, l.images[0]?.height)
             )}
@@ -62,7 +62,7 @@ export default async function PortfolioWorkPage({ params }: Props) {
         <section data-testid="archive-section" className="mt-16">
           <h2 className="mb-6 font-heading text-2xl text-muted-text">Archive</h2>
           <MasonryGrid
-            columns={[2, 2, 3, 3]}
+            columns={[1, 2, 3, 3]}
             className="opacity-60 grayscale-[20%]"
             itemHeights={soldListings.map((l) =>
               estimateCardHeight(l.images[0]?.width, l.images[0]?.height)

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${josefinSans.variable} ${dmSans.variable}`} suppressHydrationWarning>
-      <body className="antialiased min-h-screen flex flex-col">
+      <body className="antialiased min-h-screen flex flex-col overflow-x-hidden">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <AuthProvider>
             <AnalyticsProvider>

--- a/apps/web/src/components/SplitHero.tsx
+++ b/apps/web/src/components/SplitHero.tsx
@@ -233,22 +233,22 @@ export function SplitHero() {
             A Place for Artists
           </h1>
 
-          <div className="mt-8 grid grid-cols-4 gap-4 sm:gap-6">
+          <div className="mt-8 grid grid-cols-4 gap-2 sm:gap-6">
             <div className="flex flex-col items-center gap-2">
               <Images className="h-7 w-7 text-accent-primary" strokeWidth={1.5} />
-              <span className="text-sm font-medium text-foreground">Portfolio</span>
+              <span className="text-xs sm:text-sm font-medium text-foreground">Portfolio</span>
             </div>
             <div className="flex flex-col items-center gap-2">
               <BadgeDollarSign className="h-7 w-7 text-accent-primary" strokeWidth={1.5} />
-              <span className="text-sm font-medium text-foreground">Sales</span>
+              <span className="text-xs sm:text-sm font-medium text-foreground">Sales</span>
             </div>
             <div className="flex flex-col items-center gap-2">
               <Users className="h-7 w-7 text-accent-primary" strokeWidth={1.5} />
-              <span className="text-sm font-medium text-foreground">Community</span>
+              <span className="text-xs sm:text-sm font-medium text-foreground">Community</span>
             </div>
             <div className="flex flex-col items-center gap-2">
               <Search className="h-7 w-7 text-accent-primary" strokeWidth={1.5} />
-              <span className="text-sm font-medium text-foreground">Discovery</span>
+              <span className="text-xs sm:text-sm font-medium text-foreground">Discovery</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Add `overflow-x-hidden` to `<body>` to contain the full-bleed hero's `100vw` width, which was causing horizontal scroll on all pages
- Switch MasonryGrid from 2 columns to 1 column on phones (<640px) across homepage, artist profile, and portfolio pages — prevents content clipping on narrow viewports
- Reduce hero CTA icon grid gap and label font size on mobile to prevent "Community" and "Discovery" text from overlapping

## Test plan
- [ ] Open homepage on mobile (375px) — no horizontal scrollbar, listings stack in single column
- [ ] Check hero CTA labels have proper spacing on mobile
- [ ] Verify artist profile and portfolio pages also use single-column masonry on mobile
- [ ] Confirm desktop layout unchanged (2+ columns at sm breakpoint and above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent horizontal overflow and improve mobile layout for hero and masonry grids.

Bug Fixes:
- Contain full-bleed hero content by hiding horizontal overflow on the body to remove mobile horizontal scrolling.
- Adjust hero CTA grid spacing and label sizing to avoid text overlap on small screens.

Enhancements:
- Change masonry grids on homepage, artist profile, and portfolio pages to a single column on narrow viewports while preserving multi-column layouts on larger screens.