### PR TITLE
feat(api,web): admin application management — delete, stats, KPI dashboard

### DIFF
--- a/apps/api/src/routes/admin/applications.test.ts
+++ b/apps/api/src/routes/admin/applications.test.ts
@@ -106,6 +106,7 @@ function createMockPrisma(overrides?: {
       findUnique: vi.fn().mockResolvedValue(overrides?.applicationDetail ?? null),
       count: vi.fn().mockResolvedValue(applicationCount),
       update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
     },
     artistProfile: {
       findUnique: vi.fn().mockResolvedValue(null),
@@ -297,5 +298,100 @@ describe('GET /admin/applications/:id', () => {
 
     const body = await res.json()
     expect(body.reviewerName).toBe('Reviewer Admin')
+  })
+})
+
+// ─── GET /admin/applications/stats ───────────────────────────────────
+
+describe('GET /admin/applications/stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 401 without auth token', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+
+    const res = await app.request('/admin/applications/stats')
+    expect(res.status).toBe(401)
+  })
+
+  it('should return counts by status', async () => {
+    const prisma = createMockPrisma()
+    // Override count to return specific values per status
+    let callIndex = 0
+    ;(prisma.artistApplication.count as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const values = [3, 10, 2] // pending, approved, rejected
+      return Promise.resolve(values[callIndex++])
+    })
+    const app = createTestApp(prisma)
+
+    const res = await app.request('/admin/applications/stats', {}, createAuthEnv())
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body).toEqual({ pending: 3, approved: 10, rejected: 2 })
+  })
+})
+
+// ─── DELETE /admin/applications/:id ─────────────────────────────────
+
+function deleteApplication(app: ReturnType<typeof createTestApp>, id: string, env?: Record<string, unknown>) {
+  return app.request(`/admin/applications/${id}`, { method: 'DELETE' }, env)
+}
+
+describe('DELETE /admin/applications/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 401 without auth token', async () => {
+    const prisma = createMockPrisma()
+    const app = createTestApp(prisma)
+
+    const res = await deleteApplication(app, 'app-uuid-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('should return 403 without admin role', async () => {
+    const prisma = createMockPrisma({ adminRoles: ['buyer'] })
+    const app = createTestApp(prisma)
+
+    const res = await deleteApplication(app, 'app-uuid-1', createAuthEnv())
+    expect(res.status).toBe(403)
+  })
+
+  it('should return 404 when application not found', async () => {
+    const prisma = createMockPrisma({ applicationDetail: null })
+    const app = createTestApp(prisma)
+
+    const res = await deleteApplication(app, 'nonexistent-uuid', createAuthEnv())
+    expect(res.status).toBe(404)
+  })
+
+  it('should delete application and return success', async () => {
+    const detail = { ...mockApplications[0] }
+    const prisma = createMockPrisma({ applicationDetail: detail })
+    ;(prisma.artistApplication as unknown as { delete: ReturnType<typeof vi.fn> }).delete = vi.fn().mockResolvedValue(detail)
+    const app = createTestApp(prisma)
+
+    const res = await deleteApplication(app, 'app-uuid-1', createAuthEnv())
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.message).toContain('deleted')
+
+    expect((prisma.artistApplication as unknown as { delete: ReturnType<typeof vi.fn> }).delete).toHaveBeenCalledWith({
+      where: { id: 'app-uuid-1' },
+    })
+  })
+
+  it('should not allow deleting approved applications', async () => {
+    const detail = { ...mockApplications[1] } // status: 'approved'
+    const prisma = createMockPrisma({ applicationDetail: detail })
+    const app = createTestApp(prisma)
+
+    const res = await deleteApplication(app, 'app-uuid-2', createAuthEnv())
+    expect(res.status).toBe(409)
   })
 })

--- a/apps/api/src/routes/admin/applications.ts
+++ b/apps/api/src/routes/admin/applications.ts
@@ -116,6 +116,20 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
   })
 
   /**
+   * GET /admin/applications/stats
+   * Counts of applications by status for KPI display.
+   */
+  app.get('/applications/stats', async (c) => {
+    const [pending, approved, rejected] = await Promise.all([
+      prisma.artistApplication.count({ where: { status: 'pending' } }),
+      prisma.artistApplication.count({ where: { status: 'approved' } }),
+      prisma.artistApplication.count({ where: { status: 'rejected' } }),
+    ])
+
+    return c.json({ pending, approved, rejected })
+  })
+
+  /**
    * GET /admin/applications/:id
    * Full detail of a single application, including reviewer name.
    */
@@ -374,6 +388,51 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
       })
       return internalError(c)
     }
+  })
+
+  /**
+   * DELETE /admin/applications/:id
+   * Permanently delete an application. Only pending or rejected applications can be deleted.
+   * Approved applications cannot be deleted because they have associated artist profiles.
+   */
+  app.delete('/applications/:id', async (c) => {
+    const start = Date.now()
+    const adminUser = c.get('user')
+    const { id } = c.req.param()
+
+    const application = await prisma.artistApplication.findUnique({
+      where: { id },
+    })
+
+    if (!application) {
+      return notFound(c, 'Application not found')
+    }
+
+    if (application.status === 'approved') {
+      return conflict(c, 'Cannot delete an approved application. The associated artist profile must be removed first.')
+    }
+
+    await prisma.artistApplication.delete({
+      where: { id },
+    })
+
+    // Audit log (fire-and-forget)
+    void logAdminAction(prisma, {
+      adminId: adminUser.id,
+      action: 'application_delete',
+      targetType: 'application',
+      targetId: id,
+      details: { email: application.email, fullName: application.fullName, status: application.status },
+    })
+
+    logger.info('Admin application deleted', {
+      applicationId: id,
+      email: application.email,
+      deletedBy: adminUser.id,
+      durationMs: Date.now() - start,
+    })
+
+    return c.json({ message: 'Application deleted successfully' })
   })
 
   return app

--- a/apps/web/src/app/(admin)/admin/applications/[id]/application-detail.tsx
+++ b/apps/web/src/app/(admin)/admin/applications/[id]/application-detail.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useAuth } from '@/lib/auth'
-import { getAdminApplication, getAdminUsers, approveApplication, rejectApplication } from '@/lib/api'
+import { useRouter } from 'next/navigation'
+import { getAdminApplication, getAdminUsers, approveApplication, rejectApplication, deleteApplication } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -18,8 +19,10 @@ export function AdminApplicationDetail({ applicationId }: { applicationId: strin
   const [actionLoading, setActionLoading] = useState(false)
   const [showApproveConfirm, setShowApproveConfirm] = useState(false)
   const [showRejectConfirm, setShowRejectConfirm] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [rejectNotes, setRejectNotes] = useState('')
   const [actionSuccess, setActionSuccess] = useState<string | null>(null)
+  const router = useRouter()
 
   const fetchApp = useCallback(async () => {
     setLoading(true)
@@ -83,6 +86,22 @@ export function AdminApplicationDetail({ applicationId }: { applicationId: strin
       await fetchApp()
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to reject')
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!app) return
+    setActionError(null)
+    setActionLoading(true)
+    try {
+      const token = await getIdToken()
+      if (!token) throw new Error('Not authenticated')
+      await deleteApplication(token, app.id)
+      router.push('/admin/applications')
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete')
     } finally {
       setActionLoading(false)
     }
@@ -206,26 +225,39 @@ export function AdminApplicationDetail({ applicationId }: { applicationId: strin
       </div>
 
       {/* Actions */}
-      {isPending && (
+      {(isPending || app.status === 'rejected') && (
         <div className="border border-border rounded-md p-4 space-y-4">
           <h2 className="text-sm font-medium text-muted-foreground">Actions</h2>
 
-          {!showApproveConfirm && !showRejectConfirm && (
+          {!showApproveConfirm && !showRejectConfirm && !showDeleteConfirm && (
             <div className="flex gap-3">
+              {isPending && (
+                <>
+                  <Button
+                    data-testid="approve-btn"
+                    onClick={() => setShowApproveConfirm(true)}
+                    disabled={actionLoading}
+                  >
+                    Approve
+                  </Button>
+                  <Button
+                    data-testid="reject-btn"
+                    variant="destructive"
+                    onClick={() => setShowRejectConfirm(true)}
+                    disabled={actionLoading}
+                  >
+                    Reject
+                  </Button>
+                </>
+              )}
               <Button
-                data-testid="approve-btn"
-                onClick={() => setShowApproveConfirm(true)}
+                data-testid="delete-btn"
+                variant="ghost"
+                className="text-error hover:text-error"
+                onClick={() => setShowDeleteConfirm(true)}
                 disabled={actionLoading}
               >
-                Approve
-              </Button>
-              <Button
-                data-testid="reject-btn"
-                variant="destructive"
-                onClick={() => setShowRejectConfirm(true)}
-                disabled={actionLoading}
-              >
-                Reject
+                Delete
               </Button>
             </div>
           )}
@@ -278,6 +310,31 @@ export function AdminApplicationDetail({ applicationId }: { applicationId: strin
                 <Button
                   variant="ghost"
                   onClick={() => { setShowRejectConfirm(false); setRejectNotes('') }}
+                  disabled={actionLoading}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {showDeleteConfirm && (
+            <div className="space-y-3">
+              <p className="text-sm text-foreground">
+                Permanently delete <strong>{app.fullName}</strong>&apos;s application? This cannot be undone.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  data-testid="confirm-delete-btn"
+                  variant="destructive"
+                  onClick={handleDelete}
+                  disabled={actionLoading}
+                >
+                  {actionLoading ? 'Deleting...' : 'Confirm Delete'}
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowDeleteConfirm(false)}
                   disabled={actionLoading}
                 >
                   Cancel

--- a/apps/web/src/app/(admin)/admin/applications/application-list.tsx
+++ b/apps/web/src/app/(admin)/admin/applications/application-list.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useAuth } from '@/lib/auth'
-import { getAdminApplications } from '@/lib/api'
+import { getAdminApplications, getApplicationStats } from '@/lib/api'
+import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { AdminApplicationListItem, PaginatedResponse } from '@surfaced-art/types'
@@ -15,8 +16,20 @@ export function AdminApplicationList() {
   const [data, setData] = useState<PaginatedResponse<AdminApplicationListItem> | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [stats, setStats] = useState<{ pending: number; approved: number; rejected: number } | null>(null)
   const [statusFilter, setStatusFilter] = useState('')
   const [page, setPage] = useState(1)
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const token = await getIdToken()
+      if (!token) return
+      const result = await getApplicationStats(token)
+      setStats(result)
+    } catch {
+      // Stats are non-critical — fail silently
+    }
+  }, [getIdToken])
 
   const fetchApplications = useCallback(async (params: { status?: string; page?: number }) => {
     setLoading(true)
@@ -38,8 +51,9 @@ export function AdminApplicationList() {
   }, [getIdToken])
 
   useEffect(() => {
+    void fetchStats()
     void fetchApplications({ status: statusFilter, page })
-  }, [fetchApplications, statusFilter, page])
+  }, [fetchStats, fetchApplications, statusFilter, page])
 
   const handleStatusFilter = (value: string) => {
     setStatusFilter(value)
@@ -66,6 +80,48 @@ export function AdminApplicationList() {
 
   return (
     <div data-testid="admin-application-list">
+      {/* KPI Stats */}
+      {stats && (
+        <div data-testid="application-stats" className="grid grid-cols-3 gap-4 mb-6">
+          <button
+            onClick={() => handleStatusFilter('pending')}
+            className={cn(
+              'rounded-md border p-4 text-center transition-colors',
+              statusFilter === 'pending'
+                ? 'border-warning bg-warning/5'
+                : 'border-border hover:border-warning/50',
+            )}
+          >
+            <p data-testid="stat-pending" className="text-2xl font-semibold text-warning">{stats.pending}</p>
+            <p className="text-xs text-muted-foreground mt-1">Pending</p>
+          </button>
+          <button
+            onClick={() => handleStatusFilter('approved')}
+            className={cn(
+              'rounded-md border p-4 text-center transition-colors',
+              statusFilter === 'approved'
+                ? 'border-success bg-success/5'
+                : 'border-border hover:border-success/50',
+            )}
+          >
+            <p data-testid="stat-approved" className="text-2xl font-semibold text-success">{stats.approved}</p>
+            <p className="text-xs text-muted-foreground mt-1">Approved</p>
+          </button>
+          <button
+            onClick={() => handleStatusFilter('rejected')}
+            className={cn(
+              'rounded-md border p-4 text-center transition-colors',
+              statusFilter === 'rejected'
+                ? 'border-error bg-error/5'
+                : 'border-border hover:border-error/50',
+            )}
+          >
+            <p data-testid="stat-rejected" className="text-2xl font-semibold text-error">{stats.rejected}</p>
+            <p className="text-xs text-muted-foreground mt-1">Rejected</p>
+          </button>
+        </div>
+      )}
+
       <div className="flex flex-col sm:flex-row gap-3 mb-6">
         <select
           data-testid="admin-applications-status-filter"

--- a/apps/web/src/components/admin/admin-sidebar.tsx
+++ b/apps/web/src/components/admin/admin-sidebar.tsx
@@ -1,12 +1,15 @@
 'use client'
 
+import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useAuth } from '@/lib/auth'
+import { getApplicationStats } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
 const navItems = [
   { href: '/admin', label: 'Dashboard', testId: 'admin-sidebar-dashboard' },
-  { href: '/admin/applications', label: 'Applications', testId: 'admin-sidebar-applications' },
+  { href: '/admin/applications', label: 'Applications', testId: 'admin-sidebar-applications', badgeKey: 'pending' as const },
   { href: '/admin/artists', label: 'Artists', testId: 'admin-sidebar-artists' },
   { href: '/admin/listings', label: 'Listings', testId: 'admin-sidebar-listings' },
   { href: '/admin/users', label: 'Users', testId: 'admin-sidebar-users' },
@@ -16,6 +19,24 @@ const navItems = [
 
 export function AdminSidebar() {
   const pathname = usePathname()
+  const { getIdToken } = useAuth()
+  const [pendingCount, setPendingCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const token = await getIdToken()
+        if (!token || cancelled) return
+        const stats = await getApplicationStats(token)
+        if (!cancelled) setPendingCount(stats.pending)
+      } catch {
+        // Non-critical — fail silently
+      }
+    }
+    void load()
+    return () => { cancelled = true }
+  }, [getIdToken])
 
   return (
     <nav data-testid="admin-sidebar" className="md:w-56 shrink-0">
@@ -25,19 +46,28 @@ export function AdminSidebar() {
             item.href === '/admin'
               ? pathname === '/admin'
               : pathname.startsWith(item.href)
+          const showBadge = item.badgeKey === 'pending' && pendingCount > 0
           return (
             <Link
               key={item.href}
               href={item.href}
               data-testid={item.testId}
               className={cn(
-                'flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
+                'flex items-center justify-between gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
                 isActive
                   ? 'bg-accent-primary/10 text-accent-primary'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
               )}
             >
               {item.label}
+              {showBadge && (
+                <span
+                  data-testid="pending-applications-badge"
+                  className="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-warning text-white text-xs font-semibold"
+                >
+                  {pendingCount}
+                </span>
+              )}
             </Link>
           )
         })}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -645,6 +645,28 @@ export async function rejectApplication(
   )
 }
 
+export async function getApplicationStats(
+  token: string,
+): Promise<{ pending: number; approved: number; rejected: number }> {
+  return apiFetch<{ pending: number; approved: number; rejected: number }>(
+    '/admin/applications/stats',
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+}
+
+export async function deleteApplication(
+  token: string,
+  applicationId: string,
+): Promise<{ message: string }> {
+  return apiFetch<{ message: string }>(
+    `/admin/applications/${encodeURIComponent(applicationId)}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  )
+}
+
 // ─── Admin: Artist Management ───────────────────────────────────────
 
 export async function getAdminArtists(

--- a/bruno/Admin/Delete Application (Not Found).bru
+++ b/bruno/Admin/Delete Application (Not Found).bru
@@ -1,0 +1,25 @@
+meta {
+  name: Delete Application (Not Found)
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{sa_baseUrl}}/admin/applications/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_authToken}}
+}
+
+assert {
+  res.status: eq 404
+}
+
+tests {
+  test("should return 404 for nonexistent application", function() {
+    expect(res.getStatus()).to.equal(404);
+  });
+}

--- a/bruno/Admin/Delete Application.bru
+++ b/bruno/Admin/Delete Application.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Delete Application
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{sa_baseUrl}}/admin/applications/{{sa_applicationId}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{sa_authToken}}
+}
+
+assert {
+  res.status: eq 200
+  res.body.message: isDefined
+}
+
+tests {
+  test("should delete application successfully", function() {
+    const body = res.getBody();
+    expect(body.message).to.include("deleted");
+  });
+}


### PR DESCRIPTION
## Summary
- Add `DELETE /admin/applications/:id` endpoint — deletes pending or rejected applications (blocks approved ones to protect associated artist profiles)
- Add `GET /admin/applications/stats` endpoint — returns counts by status for KPI display and sidebar badge
- Add KPI stat cards (pending/approved/rejected) above the application list filter, clickable to filter by status
- Add pending count badge on the Applications sidebar tab across all admin pages
- Add delete button with confirmation dialog on application detail page (pending and rejected only)
- Bruno collection updated with delete request files

## Test plan
- [ ] API: DELETE returns 200 for pending/rejected, 409 for approved, 404 for missing
- [ ] API: Stats endpoint returns correct counts
- [ ] Admin list: KPI cards show counts, clicking filters the list
- [ ] Admin detail: Delete button appears for pending/rejected, not for approved
- [ ] Admin sidebar: Badge shows pending count, disappears when 0
- [ ] Deleting an application allows re-submission with the same email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add admin application deletion and statistics endpoints and surface application KPIs and deletion controls in the admin UI and API tooling.

New Features:
- Expose an admin API endpoint to retrieve application counts by status for KPI use.
- Expose an admin API endpoint to delete pending or rejected applications while blocking deletion of approved ones.
- Display KPI stat cards for pending, approved, and rejected applications that also act as list filters in the admin applications page.
- Show a pending applications count badge on the Applications item in the admin sidebar.
- Add a delete action with confirmation to the admin application detail view that returns to the list after deletion.
- Add Bruno requests for deleting applications and handling not-found cases.

Tests:
- Add API tests covering authorization, success, conflict, and not-found behavior for the new delete endpoint and status stats endpoint.