### PR TITLE
chore(deps): consolidated dependency updates

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,7 @@
     "@surfaced-art/types": "^0.0.1",
     "@surfaced-art/utils": "^0.0.1",
     "hono": "^4.12.9",
-    "stripe": "^20.4.1",
+    "stripe": "21.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/api/src/lib/stripe.ts
+++ b/apps/api/src/lib/stripe.ts
@@ -14,6 +14,6 @@ export function getStripeClient(): Stripe {
     throw new Error('STRIPE_SECRET_KEY is not configured')
   }
   return new Stripe(key, {
-    apiVersion: '2026-02-25.clover',
+    apiVersion: '2026-03-25.dahlia',
   })
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "amazon-cognito-identity-js": "^6.3.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "1.7.0",
     "next": "16.2.1",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.364.2",

--- a/apps/web/src/components/ContactSection.tsx
+++ b/apps/web/src/components/ContactSection.tsx
@@ -1,4 +1,15 @@
-import { Globe, Instagram, MapPin, CircleCheck, CircleX } from 'lucide-react'
+import { Globe, MapPin, CircleCheck, CircleX } from 'lucide-react'
+
+/** Instagram icon — removed from lucide-react v1.0 (brand icons dropped). */
+function InstagramIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect width="20" height="20" x="2" y="2" rx="5" ry="5" />
+      <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+      <line x1="17.5" x2="17.51" y1="6.5" y2="6.5" />
+    </svg>
+  )
+}
 import { cn } from '@/lib/utils'
 import { ContactArtistDialog } from '@/components/ContactArtistDialog'
 
@@ -66,7 +77,7 @@ export function ContactSection({
             rel="noopener noreferrer"
             className="flex items-center gap-3 text-foreground transition-colors hover:text-accent-primary"
           >
-            <Instagram className="size-4 shrink-0 text-muted-text" />
+            <InstagramIcon className="size-4 shrink-0 text-muted-text" />
             <span className="text-sm">{extractInstagramHandle(instagramUrl)}</span>
           </a>
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "tools/*"
       ],
       "dependencies": {
+        "flatted": "^3.4.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -45,7 +46,7 @@
         "@surfaced-art/types": "^0.0.1",
         "@surfaced-art/utils": "^0.0.1",
         "hono": "^4.12.9",
-        "stripe": "^20.4.1",
+        "stripe": "21.0.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -104,7 +105,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -168,23 +169,6 @@
         }
       }
     },
-    "apps/api/node_modules/stripe": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
-      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/node": ">=16"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "apps/api/node_modules/testcontainers": {
       "version": "11.13.0",
       "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.13.0.tgz",
@@ -244,7 +228,7 @@
         "amazon-cognito-identity-js": "^6.3.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "1.7.0",
         "next": "16.2.1",
         "next-themes": "^0.4.6",
         "posthog-js": "^1.364.2",
@@ -11345,10 +11329,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -13225,9 +13208,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -15865,6 +15848,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-21.0.1.tgz",
+      "integrity": "sha512-ocv0j7dWttswDWV2XL/kb6+yiLpDXNXL3RQAOB5OB2kr49z0cEatdQc12+zP/j5nrXk6rAsT4N3y/NUvBbK7Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {


### PR DESCRIPTION
## Summary
Consolidates 3 Dependabot PRs into one verified update. Closed 2 others that can't be merged yet.

### Merged updates
- **lucide-react** 0.577.0 → 1.7.0 (major) — brand icons removed in v1.0; replaced `Instagram` import in ContactSection with inline SVG
- **stripe** 20.4.1 → 21.0.1 (major) — updated pinned `apiVersion` from `2026-02-25.clover` to `2026-03-25.dahlia`; no breaking changes affect our usage (no `Decimal` fields, no OAuth, correct webhook method)
- **flatted** 3.3.3 → 3.4.2 (patch) — fixes high-severity prototype pollution CVE-1321 (dev-only transitive dep via eslint)

### Closed without merging
- **TypeScript** 5.9.3 → 6.0.2 (#508) — changes `types` default to `[]`, breaks all packages. Needs dedicated migration.
- **ESLint** 9.39.3 → 10.1.0 (#509) — `eslint-config-next` uses removed `context.getFilename()` API. Ecosystem not ready.

Closes #506, #514, #515

## Test plan
- [x] `npm ci` succeeds
- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes (0 errors)
- [x] All 1851 unit tests pass
- [ ] Verify Instagram icon renders correctly on artist profile pages
- [ ] Verify Stripe webhook handling still works in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update third-party dependencies and adjust related integrations for lucide-react and Stripe.

Bug Fixes:
- Replace removed lucide-react Instagram icon with a compatible inline SVG-based icon component in the contact section.

Enhancements:
- Upgrade Stripe SDK and pinned API version used by the API service to the latest supported release.
- Upgrade lucide-react in the web app to the latest major version and switch usage to the new Instagram icon component.

Build:
- Refresh lockfile and dependency versions across the repo to consolidate dependency updates into a single change.

Chores:
- Consolidate multiple automated dependency bump PRs into a single verified update.