### PR TITLE
fix(api): auto-approve artist profile on application approval

### DIFF
--- a/apps/api/src/routes/admin/applications.test.ts
+++ b/apps/api/src/routes/admin/applications.test.ts
@@ -301,6 +301,73 @@ describe('GET /admin/applications/:id', () => {
   })
 })
 
+// ─── POST /admin/artists/:userId/approve ─────────────────────────────
+
+describe('POST /admin/artists/:userId/approve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should create artist profile with approved status', async () => {
+    const targetUser = {
+      id: 'target-user-uuid',
+      cognitoId: 'cognito-target',
+      email: 'artist1@example.com',
+      fullName: 'Jane Artist',
+      roles: [],
+    }
+
+    const mockCreate = vi.fn().mockResolvedValue({
+      id: 'profile-uuid',
+      slug: 'jane-artist',
+      displayName: 'Jane Artist',
+    })
+
+    const prisma = createMockPrisma()
+    // Override user lookup to return the target user for the userId param
+    ;(prisma.user.findUnique as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ where }: { where: { cognitoId?: string; id?: string } }) => {
+        if (where.cognitoId === 'cognito-admin') {
+          return Promise.resolve(mockAdminUser)
+        }
+        if (where.id === 'target-user-uuid') {
+          return Promise.resolve(targetUser)
+        }
+        return Promise.resolve(null)
+      },
+    )
+    // Override findFirst to return a pending application
+    ;(prisma.artistApplication.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(mockApplications[0])
+    // Override $transaction to capture the create call
+    ;(prisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        return fn({
+          artistApplication: { update: vi.fn().mockResolvedValue({}) },
+          artistProfile: { findFirst: vi.fn().mockResolvedValue(null), create: mockCreate },
+          userRole: { create: vi.fn().mockResolvedValue({}) },
+        })
+      },
+    )
+
+    const app = createTestApp(prisma)
+    const res = await app.request('/admin/artists/target-user-uuid/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    }, createAuthEnv())
+
+    expect(res.status).toBe(200)
+
+    // Verify the artist profile was created with status 'approved'
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'target-user-uuid',
+        status: 'approved',
+      }),
+    })
+  })
+})
+
 // ─── GET /admin/applications/stats ───────────────────────────────────
 
 describe('GET /admin/applications/stats', () => {

--- a/apps/api/src/routes/admin/applications.ts
+++ b/apps/api/src/routes/admin/applications.ts
@@ -229,7 +229,7 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
           },
         })
 
-        // 2. Create artist profile
+        // 2. Create artist profile (auto-approved — application review is the vetting step)
         const newProfile = await tx.artistProfile.create({
           data: {
             userId: targetUser.id,
@@ -238,6 +238,7 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
             bio: application.statement ?? '',
             location: '',
             originZip: '',
+            status: 'approved',
           },
         })
 


### PR DESCRIPTION
## Summary
- When an application is approved, the created `ArtistProfile` now starts with `status: 'approved'` instead of `'pending'`
- This makes approved artists immediately visible on the platform without a redundant second approval step
- The application review process itself serves as the vetting step

## Test plan
- [x] Added test verifying `artistProfile.create` is called with `status: 'approved'`
- [x] All 682 API tests pass
- [x] Build, typecheck, and lint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Auto-approve artist profiles when an artist application is approved so approved artists become immediately visible on the platform.

Bug Fixes:
- Ensure newly created artist profiles are stored with status set to 'approved' when an application is approved, removing the need for a separate approval step.

Tests:
- Add API test verifying that artist profile creation on admin approval includes status 'approved'.