### PR TITLE
feat(web): add artist activate button and pending status in admin

### DIFF
--- a/apps/api/src/routes/admin/applications.test.ts
+++ b/apps/api/src/routes/admin/applications.test.ts
@@ -301,6 +301,73 @@ describe('GET /admin/applications/:id', () => {
   })
 })
 
+// ─── POST /admin/artists/:userId/approve ─────────────────────────────
+
+describe('POST /admin/artists/:userId/approve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should create artist profile with approved status', async () => {
+    const targetUser = {
+      id: 'target-user-uuid',
+      cognitoId: 'cognito-target',
+      email: 'artist1@example.com',
+      fullName: 'Jane Artist',
+      roles: [],
+    }
+
+    const mockCreate = vi.fn().mockResolvedValue({
+      id: 'profile-uuid',
+      slug: 'jane-artist',
+      displayName: 'Jane Artist',
+    })
+
+    const prisma = createMockPrisma()
+    // Override user lookup to return the target user for the userId param
+    ;(prisma.user.findUnique as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ where }: { where: { cognitoId?: string; id?: string } }) => {
+        if (where.cognitoId === 'cognito-admin') {
+          return Promise.resolve(mockAdminUser)
+        }
+        if (where.id === 'target-user-uuid') {
+          return Promise.resolve(targetUser)
+        }
+        return Promise.resolve(null)
+      },
+    )
+    // Override findFirst to return a pending application
+    ;(prisma.artistApplication.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(mockApplications[0])
+    // Override $transaction to capture the create call
+    ;(prisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        return fn({
+          artistApplication: { update: vi.fn().mockResolvedValue({}) },
+          artistProfile: { findFirst: vi.fn().mockResolvedValue(null), create: mockCreate },
+          userRole: { create: vi.fn().mockResolvedValue({}) },
+        })
+      },
+    )
+
+    const app = createTestApp(prisma)
+    const res = await app.request('/admin/artists/target-user-uuid/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    }, createAuthEnv())
+
+    expect(res.status).toBe(200)
+
+    // Verify the artist profile was created with status 'approved'
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'target-user-uuid',
+        status: 'approved',
+      }),
+    })
+  })
+})
+
 // ─── GET /admin/applications/stats ───────────────────────────────────
 
 describe('GET /admin/applications/stats', () => {

--- a/apps/api/src/routes/admin/applications.ts
+++ b/apps/api/src/routes/admin/applications.ts
@@ -229,7 +229,7 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
           },
         })
 
-        // 2. Create artist profile
+        // 2. Create artist profile (auto-approved — application review is the vetting step)
         const newProfile = await tx.artistProfile.create({
           data: {
             userId: targetUser.id,
@@ -238,6 +238,7 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
             bio: application.statement ?? '',
             location: '',
             originZip: '',
+            status: 'approved',
           },
         })
 

--- a/apps/web/src/app/(admin)/admin/artists/[id]/artist-detail.tsx
+++ b/apps/web/src/app/(admin)/admin/artists/[id]/artist-detail.tsx
@@ -25,6 +25,9 @@ export function AdminArtistDetail({ artistId }: { artistId: string }) {
   // Unsuspend state
   const [showUnsuspendConfirm, setShowUnsuspendConfirm] = useState(false)
 
+  // Activate state
+  const [showActivateConfirm, setShowActivateConfirm] = useState(false)
+
   // Edit state
   const [editing, setEditing] = useState(false)
   const [editForm, setEditForm] = useState({
@@ -93,6 +96,24 @@ export function AdminArtistDetail({ artistId }: { artistId: string }) {
       await fetchArtist()
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to unsuspend')
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
+  const handleActivate = async () => {
+    setActionError(null)
+    setActionSuccess(null)
+    setActionLoading(true)
+    try {
+      const token = await getIdToken()
+      if (!token) throw new Error('Not authenticated')
+      await updateAdminArtist(token, artistId, { status: 'approved' })
+      setActionSuccess('Artist activated successfully')
+      setShowActivateConfirm(false)
+      await fetchArtist()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to activate')
     } finally {
       setActionLoading(false)
     }
@@ -318,8 +339,17 @@ export function AdminArtistDetail({ artistId }: { artistId: string }) {
       <div className="border border-border rounded-md p-4 space-y-4">
         <h2 className="text-sm font-medium text-muted-foreground">Actions</h2>
 
-        {!showSuspendConfirm && !showUnsuspendConfirm && (
+        {!showSuspendConfirm && !showUnsuspendConfirm && !showActivateConfirm && (
           <div className="flex gap-3">
+            {artist.status === 'pending' && (
+              <Button
+                data-testid="activate-btn"
+                onClick={() => setShowActivateConfirm(true)}
+                disabled={actionLoading}
+              >
+                Activate
+              </Button>
+            )}
             {artist.status === 'approved' && (
               <Button
                 data-testid="suspend-btn"
@@ -339,6 +369,30 @@ export function AdminArtistDetail({ artistId }: { artistId: string }) {
                 Unsuspend
               </Button>
             )}
+          </div>
+        )}
+
+        {showActivateConfirm && (
+          <div className="space-y-3">
+            <p className="text-sm text-foreground">
+              Activate <strong>{artist.displayName}</strong>? Their profile will become publicly visible.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                data-testid="confirm-activate-btn"
+                onClick={handleActivate}
+                disabled={actionLoading}
+              >
+                {actionLoading ? 'Activating...' : 'Confirm Activate'}
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => setShowActivateConfirm(false)}
+                disabled={actionLoading}
+              >
+                Cancel
+              </Button>
+            </div>
           </div>
         )}
 
@@ -420,6 +474,7 @@ function StatCard({ testId, label, value }: { testId: string; label: string; val
 
 function statusBadgeClass(status: string): string {
   switch (status) {
+    case 'pending': return 'bg-warning/10 text-warning'
     case 'approved': return 'bg-success/10 text-success'
     case 'suspended': return 'bg-error/10 text-error'
     default: return ''

--- a/apps/web/src/app/(admin)/admin/artists/artist-list.tsx
+++ b/apps/web/src/app/(admin)/admin/artists/artist-list.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { AdminArtistListItem, PaginatedResponse } from '@surfaced-art/types'
 
-const STATUSES = ['approved', 'suspended'] as const
+const STATUSES = ['pending', 'approved', 'suspended'] as const
 
 export function AdminArtistList() {
   const { getIdToken } = useAuth()
@@ -178,6 +178,7 @@ export function AdminArtistList() {
 
 function statusBadgeClass(status: string): string {
   switch (status) {
+    case 'pending': return 'bg-warning/10 text-warning'
     case 'approved': return 'bg-success/10 text-success'
     case 'suspended': return 'bg-error/10 text-error'
     default: return ''


### PR DESCRIPTION
## Summary
- Admin artist detail page shows an **Activate** button for pending artists (uses existing `PUT /admin/artists/:id` with `{ status: 'approved' }`)
- Activate button includes a confirmation dialog before taking action
- Artist list status filter now includes `pending` option
- Both list and detail pages show pending status with warning-colored badge

## Context
Follow-up to #520 (auto-approve on application approval). For any existing pending artists, admins can now activate them from the admin UI without needing a separate endpoint.

## Test plan
- [x] All 682 API tests pass
- [x] Build, typecheck, and lint all pass
- [ ] Manual: navigate to admin artist detail for a pending artist, verify Activate button appears
- [ ] Manual: click Activate, confirm dialog, verify status changes to approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add admin support for activating pending artists and ensure artist profiles created from approved applications are immediately approved.

New Features:
- Allow admins to activate pending artists from the artist detail page with a confirmation step.
- Expose a pending status filter and badge styling in the admin artist list and detail views.

Enhancements:
- Set artist profiles created via admin application approval to have an approved status by default.

Tests:
- Add API test coverage for creating an approved artist profile via the admin approve endpoint.