### PR TITLE
feat(web): auth-aware header navigation

### DIFF
--- a/apps/web/src/components/AuthButton.tsx
+++ b/apps/web/src/components/AuthButton.tsx
@@ -18,7 +18,7 @@ import {
  * Menu items adapt based on the user's roles (artist, admin).
  */
 export function AuthButton() {
-  const { user, loading, signOut, isArtist, isAdmin } = useAuth()
+  const { user, loading, signOut } = useAuth()
 
   if (loading) {
     return <div data-testid="auth-loading" className="h-10 w-20" />
@@ -65,32 +65,6 @@ export function AuthButton() {
           <DropdownMenuLabel data-testid="menu-user-name">
             {user.name || user.email}
           </DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem asChild data-testid="menu-dashboard">
-            <Link href="/dashboard">Dashboard</Link>
-          </DropdownMenuItem>
-
-          {isArtist && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem asChild data-testid="menu-artist-profile">
-                <Link href="/dashboard/profile">Artist Profile</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild data-testid="menu-manage-listings">
-                <Link href="/dashboard/listings">Manage Listings</Link>
-              </DropdownMenuItem>
-            </>
-          )}
-
-          {isAdmin && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem asChild data-testid="menu-admin">
-                <Link href="/admin">Admin Panel</Link>
-              </DropdownMenuItem>
-            </>
-          )}
-
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild data-testid="menu-settings">
             <Link href="/dashboard/settings">Settings</Link>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -10,6 +10,7 @@ import { AuthButton } from './AuthButton'
 import { Wordmark } from './Wordmark'
 import { SkipToContent } from './SkipToContent'
 import { Container } from './ui/container'
+import { useAuth } from '@/lib/auth'
 import { cn } from '@/lib/utils'
 
 const SCROLL_CONDENSE_THRESHOLD = 50
@@ -29,6 +30,7 @@ const SCROLL_EXPAND_THRESHOLD = 20
  * flickering when the height change shifts scroll position back across the threshold.
  */
 export function Header() {
+  const { user, isArtist, isAdmin } = useAuth()
   const [isCondensed, setIsCondensed] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
 
@@ -91,17 +93,43 @@ export function Header() {
             </div>
           </div>
 
-          {/* Right: for-artists link + search + auth + theme toggle + mobile nav */}
+          {/* Right: role-aware links + search + auth + theme toggle + mobile nav */}
           <div className="flex items-center gap-2">
-            <Link
-              href="/for-artists"
-              className={cn(
-                'hidden md:block text-sm font-medium text-accent-primary transition-colors hover:text-foreground',
-                isSearchOpen && 'md:hidden'
-              )}
-            >
-              For Artists
-            </Link>
+            {!user && (
+              <Link
+                href="/for-artists"
+                className={cn(
+                  'hidden md:block text-sm font-medium text-accent-primary transition-colors hover:text-foreground',
+                  isSearchOpen && 'md:hidden'
+                )}
+              >
+                For Artists
+              </Link>
+            )}
+            {isArtist && (
+              <Link
+                href="/dashboard"
+                data-testid="nav-studio"
+                className={cn(
+                  'hidden md:block text-sm font-medium text-accent-primary transition-colors hover:text-foreground',
+                  isSearchOpen && 'md:hidden'
+                )}
+              >
+                Studio
+              </Link>
+            )}
+            {isAdmin && (
+              <Link
+                href="/admin"
+                data-testid="nav-admin"
+                className={cn(
+                  'hidden md:block text-sm font-medium text-foreground transition-colors hover:text-accent-primary',
+                  isSearchOpen && 'md:hidden'
+                )}
+              >
+                Admin
+              </Link>
+            )}
             <div className="hidden md:block">
               <SearchInput onOpenChange={handleSearchOpenChange} />
             </div>

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -166,16 +166,18 @@ export function MobileNav() {
               </ul>
             </nav>
 
-            {/* For Artists link */}
-            <div className="px-6 mt-4">
-              <Link
-                href="/for-artists"
-                onClick={close}
-                className="block py-3 text-base font-medium tracking-wide text-accent-primary transition-colors hover:text-foreground"
-              >
-                For Artists
-              </Link>
-            </div>
+            {/* For Artists link — only shown when not logged in */}
+            {!user && (
+              <div className="px-6 mt-4">
+                <Link
+                  href="/for-artists"
+                  onClick={close}
+                  className="block py-3 text-base font-medium tracking-wide text-accent-primary transition-colors hover:text-foreground"
+                >
+                  For Artists
+                </Link>
+              </div>
+            )}
 
             {/* Auth-aware links */}
             {user && (

--- a/apps/web/src/components/__tests__/AuthButton.test.tsx
+++ b/apps/web/src/components/__tests__/AuthButton.test.tsx
@@ -79,33 +79,21 @@ describe('AuthButton', () => {
       expect(screen.getByTestId('menu-user-name')).toHaveTextContent('buyer@test.com')
     })
 
-    it('should show Dashboard and Settings for all authenticated users', async () => {
+    it('should show Settings and Sign Out for all authenticated users', async () => {
       mockAuth.user = { email: 'buyer@test.com', name: 'Test Buyer' }
       const user = userEvent.setup()
 
       render(<AuthButton />)
       await user.click(screen.getByTestId('user-menu-trigger'))
 
-      expect(screen.getByTestId('menu-dashboard')).toBeInTheDocument()
       expect(screen.getByTestId('menu-settings')).toBeInTheDocument()
       expect(screen.getByTestId('menu-sign-out')).toBeInTheDocument()
     })
 
-    it('should show artist items when user has artist role', async () => {
-      mockAuth.user = { email: 'artist@test.com', name: 'Test Artist' }
+    it('should not show artist or admin items in dropdown (moved to top-level nav)', async () => {
+      mockAuth.user = { email: 'both@test.com', name: 'Both Roles' }
       mockAuth.isArtist = true
-      const user = userEvent.setup()
-
-      render(<AuthButton />)
-      await user.click(screen.getByTestId('user-menu-trigger'))
-
-      expect(screen.getByTestId('menu-artist-profile')).toBeInTheDocument()
-      expect(screen.getByTestId('menu-manage-listings')).toBeInTheDocument()
-    })
-
-    it('should not show artist items when user lacks artist role', async () => {
-      mockAuth.user = { email: 'buyer@test.com', name: 'Test Buyer' }
-      mockAuth.isArtist = false
+      mockAuth.isAdmin = true
       const user = userEvent.setup()
 
       render(<AuthButton />)
@@ -113,28 +101,8 @@ describe('AuthButton', () => {
 
       expect(screen.queryByTestId('menu-artist-profile')).not.toBeInTheDocument()
       expect(screen.queryByTestId('menu-manage-listings')).not.toBeInTheDocument()
-    })
-
-    it('should show admin link when user has admin role', async () => {
-      mockAuth.user = { email: 'admin@test.com', name: 'Admin User' }
-      mockAuth.isAdmin = true
-      const user = userEvent.setup()
-
-      render(<AuthButton />)
-      await user.click(screen.getByTestId('user-menu-trigger'))
-
-      expect(screen.getByTestId('menu-admin')).toBeInTheDocument()
-    })
-
-    it('should not show admin link when user lacks admin role', async () => {
-      mockAuth.user = { email: 'buyer@test.com', name: 'Test Buyer' }
-      mockAuth.isAdmin = false
-      const user = userEvent.setup()
-
-      render(<AuthButton />)
-      await user.click(screen.getByTestId('user-menu-trigger'))
-
       expect(screen.queryByTestId('menu-admin')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('menu-dashboard')).not.toBeInTheDocument()
     })
 
     it('should call signOut when sign out is clicked', async () => {

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -1,14 +1,40 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { Header } from '../Header'
 import { CATEGORIES } from '@/lib/categories'
 
-// Mock auth so Header can render without AuthProvider
+const mockAuth = {
+  user: null as { email: string; name: string } | null,
+  loading: false,
+  isArtist: false,
+  isAdmin: false,
+  roles: [] as string[],
+  hasRole: vi.fn(() => false),
+  signIn: vi.fn(),
+  signUp: vi.fn(),
+  confirmSignUp: vi.fn(),
+  resendCode: vi.fn(),
+  signOut: vi.fn(),
+  forgotPassword: vi.fn(),
+  confirmPassword: vi.fn(),
+  getIdToken: vi.fn(),
+  completeNewPassword: vi.fn(),
+  completeMfa: vi.fn(),
+  pendingChallenge: null,
+}
+
 vi.mock('@/lib/auth', () => ({
-  useAuth: () => ({ user: null, loading: false, signOut: vi.fn() }),
+  useAuth: () => mockAuth,
 }))
 
 describe('Header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.user = null
+    mockAuth.isArtist = false
+    mockAuth.isAdmin = false
+  })
+
   it('should render the Surfaced Art brand wordmark', () => {
     render(<Header />)
     expect(screen.getByRole('link', { name: /surfaced art/i })).toBeInTheDocument()
@@ -57,9 +83,56 @@ describe('Header', () => {
     expect(screen.getByTestId('search-toggle')).toBeInTheDocument()
   })
 
-  it('should render a For Artists link pointing to /for-artists', () => {
-    render(<Header />)
-    const link = screen.getByRole('link', { name: /for artists/i })
-    expect(link).toHaveAttribute('href', '/for-artists')
+  describe('For Artists link (logged out)', () => {
+    it('should render a For Artists link when not logged in', () => {
+      render(<Header />)
+      const link = screen.getByRole('link', { name: /for artists/i })
+      expect(link).toHaveAttribute('href', '/for-artists')
+    })
+  })
+
+  describe('logged-in navigation', () => {
+    it('should hide For Artists link when logged in', () => {
+      mockAuth.user = { email: 'user@test.com', name: 'Test User' }
+      render(<Header />)
+      expect(screen.queryByRole('link', { name: /for artists/i })).not.toBeInTheDocument()
+    })
+
+    it('should show Studio link for artists', () => {
+      mockAuth.user = { email: 'artist@test.com', name: 'Test Artist' }
+      mockAuth.isArtist = true
+      render(<Header />)
+      const link = screen.getByTestId('nav-studio')
+      expect(link).toHaveAttribute('href', '/dashboard')
+    })
+
+    it('should not show Studio link for non-artists', () => {
+      mockAuth.user = { email: 'buyer@test.com', name: 'Test Buyer' }
+      render(<Header />)
+      expect(screen.queryByTestId('nav-studio')).not.toBeInTheDocument()
+    })
+
+    it('should show Admin link for admins', () => {
+      mockAuth.user = { email: 'admin@test.com', name: 'Admin' }
+      mockAuth.isAdmin = true
+      render(<Header />)
+      const link = screen.getByTestId('nav-admin')
+      expect(link).toHaveAttribute('href', '/admin')
+    })
+
+    it('should not show Admin link for non-admins', () => {
+      mockAuth.user = { email: 'buyer@test.com', name: 'Test Buyer' }
+      render(<Header />)
+      expect(screen.queryByTestId('nav-admin')).not.toBeInTheDocument()
+    })
+
+    it('should show both Studio and Admin for admin+artist users', () => {
+      mockAuth.user = { email: 'both@test.com', name: 'Both Roles' }
+      mockAuth.isArtist = true
+      mockAuth.isAdmin = true
+      render(<Header />)
+      expect(screen.getByTestId('nav-studio')).toBeInTheDocument()
+      expect(screen.getByTestId('nav-admin')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/components/__tests__/MobileNav.test.tsx
+++ b/apps/web/src/components/__tests__/MobileNav.test.tsx
@@ -99,12 +99,20 @@ describe('MobileNav', () => {
     expect(inactiveLink).not.toHaveAttribute('aria-current')
   })
 
-  it('should render a For Artists link when opened', async () => {
+  it('should render a For Artists link when opened and not logged in', async () => {
     render(<MobileNav />)
     await userEvent.click(screen.getByRole('button', { name: 'Menu' }))
 
     const link = screen.getByRole('link', { name: /for artists/i })
     expect(link).toHaveAttribute('href', '/for-artists')
+  })
+
+  it('should hide For Artists link when logged in', async () => {
+    mockAuth.user = { email: 'user@test.com', name: 'Test User' }
+    render(<MobileNav />)
+    await userEvent.click(screen.getByRole('button', { name: 'Menu' }))
+
+    expect(screen.queryByRole('link', { name: /for artists/i })).not.toBeInTheDocument()
   })
 
   describe('authenticated user links', () => {


### PR DESCRIPTION
## Summary
- **Hide "For Artists"** link for all logged-in users (both desktop and mobile nav)
- **Add top-level "Studio" link** for artists — one-click access to the dashboard without opening the dropdown
- **Add top-level "Admin" link** for admins — visible alongside Studio for users with both roles
- **Slim down user dropdown** to just Settings + Sign Out (Dashboard, Artist Profile, Manage Listings, Admin Panel removed since they're now top-level)
- Same behavior applied to the mobile slide-out drawer

## Test plan
- [x] 758 web tests pass (6 new tests for auth-aware nav behavior)
- [x] Build, typecheck, lint all pass
- [ ] Manual: logged out — "For Artists" link visible, no Studio/Admin
- [ ] Manual: logged in as buyer — no "For Artists", no Studio, no Admin
- [ ] Manual: logged in as artist — "Studio" link visible, links to /dashboard
- [ ] Manual: logged in as admin — "Admin" link visible, links to /admin
- [ ] Manual: logged in as admin+artist — both Studio and Admin visible
- [ ] Manual: mobile nav matches desktop behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update web header and mobile navigation to be aware of authentication and user roles, exposing role-specific links at the top level and simplifying the user menu.

New Features:
- Show a top-level Studio link in the header for authenticated artist users, linking to the dashboard.
- Show a top-level Admin link in the header for authenticated admin users, alongside Studio when both roles are present.

Enhancements:
- Hide the For Artists link in desktop and mobile navigation for authenticated users, while keeping it visible for logged-out visitors.
- Simplify the authenticated user dropdown to only include Settings and Sign Out, moving artist and admin destinations to top-level navigation.

Tests:
- Expand header, auth button, and mobile navigation tests to cover auth- and role-aware visibility of For Artists, Studio, and Admin links, and the slimmed-down user dropdown.