### PR TITLE
fix(web): rename Studio to Dashboard in header nav

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -109,13 +109,13 @@ export function Header() {
             {isArtist && (
               <Link
                 href="/dashboard"
-                data-testid="nav-studio"
+                data-testid="nav-dashboard"
                 className={cn(
                   'hidden md:block text-sm font-medium text-accent-primary transition-colors hover:text-foreground',
                   isSearchOpen && 'md:hidden'
                 )}
               >
-                Studio
+                Dashboard
               </Link>
             )}
             {isAdmin && (

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -98,18 +98,18 @@ describe('Header', () => {
       expect(screen.queryByRole('link', { name: /for artists/i })).not.toBeInTheDocument()
     })
 
-    it('should show Studio link for artists', () => {
+    it('should show Dashboard link for artists', () => {
       mockAuth.user = { email: 'artist@test.com', name: 'Test Artist' }
       mockAuth.isArtist = true
       render(<Header />)
-      const link = screen.getByTestId('nav-studio')
+      const link = screen.getByTestId('nav-dashboard')
       expect(link).toHaveAttribute('href', '/dashboard')
     })
 
-    it('should not show Studio link for non-artists', () => {
+    it('should not show Dashboard link for non-artists', () => {
       mockAuth.user = { email: 'buyer@test.com', name: 'Test Buyer' }
       render(<Header />)
-      expect(screen.queryByTestId('nav-studio')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('nav-dashboard')).not.toBeInTheDocument()
     })
 
     it('should show Admin link for admins', () => {
@@ -131,7 +131,7 @@ describe('Header', () => {
       mockAuth.isArtist = true
       mockAuth.isAdmin = true
       render(<Header />)
-      expect(screen.getByTestId('nav-studio')).toBeInTheDocument()
+      expect(screen.getByTestId('nav-dashboard')).toBeInTheDocument()
       expect(screen.getByTestId('nav-admin')).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
## Summary
- Rename "Studio" to "Dashboard" in the header nav link for artists
- Update test IDs from `nav-studio` to `nav-dashboard`

Follow-up to #522.

## Test plan
- [x] 758 web tests pass

## Summary by Sourcery

Tests:
- Update header navigation tests to use the new `nav-dashboard` test ID for artist dashboard visibility and access control.