### PR TITLE
fix(web): grant role dropdown sends stale selection

### DIFF
--- a/apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx
+++ b/apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx
@@ -16,7 +16,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
   const [user, setUser] = useState<AdminUserDetailResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [selectedRole, setSelectedRole] = useState<UserRoleType>('artist')
+  const [selectedRole, setSelectedRole] = useState<UserRoleType | ''>('')
   const [actionError, setActionError] = useState<string | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
 
@@ -45,7 +45,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
     try {
       const token = await getIdToken()
       if (!token) throw new Error('Not authenticated')
-      await grantRole(token, userId, selectedRole)
+      await grantRole(token, userId, effectiveSelectedRole as UserRoleType)
       await fetchUser()
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to grant role')
@@ -90,6 +90,11 @@ export function AdminUserDetail({ userId }: { userId: string }) {
 
   const existingRoles = user.roles.map((r) => r.role)
   const grantableRoles = ALL_ROLES.filter((r) => !existingRoles.includes(r))
+
+  // Sync selectedRole to the first grantable role when user data changes
+  const effectiveSelectedRole = grantableRoles.includes(selectedRole as UserRoleType)
+    ? (selectedRole as UserRoleType)
+    : grantableRoles[0] ?? ''
 
   return (
     <div data-testid="admin-user-detail" className="space-y-8">
@@ -167,7 +172,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
           <div className="flex items-center gap-2 pt-2 border-t border-border/50">
             <select
               data-testid="grant-role-select"
-              value={selectedRole}
+              value={effectiveSelectedRole}
               onChange={(e) => setSelectedRole(e.target.value as UserRoleType)}
               className="h-9 rounded-md border border-border bg-transparent px-3 text-sm text-foreground"
             >


### PR DESCRIPTION
## Summary
- Fix bug where the "Grant Role" button sent the wrong role value
- `selectedRole` was hardcoded to `'artist'` on init and never synced when the user's roles changed
- If the user already had `artist`, the dropdown visually showed `admin` but the state still held `'artist'`, causing a "User already has artist role" error
- Now computes an `effectiveSelectedRole` that falls back to the first available grantable role

## Test plan
- [x] 758 web tests pass, typecheck passes
- [ ] Manual: go to admin user detail for a user with buyer+artist roles, select admin from dropdown, click Grant Role — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the Grant Role action uses an effective selected role that is always one of the current grantable roles, avoiding stale or invalid role submissions.