### PR TITLE
fix(web): use brand red for sold dot, move to bottom-right

### DIFF
--- a/apps/web/src/components/ListingCard.tsx
+++ b/apps/web/src/components/ListingCard.tsx
@@ -79,9 +79,9 @@ export function ListingCard({
           </div>
         )}
 
-        {/* Sold indicator dot */}
+        {/* Sold indicator dot — brand red (#AA1D45), bottom-right like traditional art sales */}
         {isSold && (
-          <div className="absolute top-2 right-2 size-2.5 rounded-full bg-error" />
+          <div className="absolute bottom-2 right-2 size-2.5 rounded-full bg-accent-red" />
         )}
 
         {/* Browse variant: hover overlay */}


### PR DESCRIPTION
## Summary
- Change sold indicator dot color from `bg-error` (#C4534A) to `bg-accent-red` (#AA1D45) to match the logo wordmark red dot
- Reposition from top-right to bottom-right, matching traditional art sale conventions

## Test plan
- [x] 758 web tests pass
- [ ] Visual: sold listings show the dot in bottom-right with the same red as the logo

## Summary by Sourcery

Update the sold indicator on listing cards to better align with brand styling and visual conventions.

Enhancements:
- Adjust the sold indicator dot color to use the brand accent red matching the logo.
- Reposition the sold indicator dot to the bottom-right corner of listing cards.