### PR TITLE
fix: address AI code review findings (batch 2026-03-31)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -66,7 +66,7 @@ app.use(
 // Rate limiting for sensitive endpoints
 app.use('/waitlist', rateLimiter({ maxRequests: 5, windowMs: 60_000 }))
 app.use('/artists/apply', rateLimiter({ maxRequests: 5, windowMs: 60_000 }))
-app.use('/artists/*/contact', rateLimiter({ maxRequests: 5, windowMs: 60_000 }))
+app.use('/artists/:slug/contact', rateLimiter({ maxRequests: 5, windowMs: 60_000 }))
 app.use('/uploads/*', rateLimiter({ maxRequests: 10, windowMs: 60_000 }))
 app.use('/me/*', rateLimiter({ maxRequests: 20, windowMs: 60_000 }))
 app.use('/auth/*', rateLimiter({ maxRequests: 20, windowMs: 60_000 }))
@@ -78,7 +78,7 @@ app.use('/webhooks/*', rateLimiter({ maxRequests: 30, windowMs: 60_000 }))
 // /artists/apply has a GET that checks real-time status — exclude from public caching
 app.use('/artists/apply/*', cacheControl('private, no-cache'))
 app.use('/artists/apply', cacheControl('private, no-cache'))
-app.use('/artists/*/contact', cacheControl('private, no-cache'))
+app.use('/artists/:slug/contact', cacheControl('private, no-cache'))
 app.use('/artists/*', cacheControl('public, max-age=300'))
 app.use('/artists', cacheControl('public, max-age=300'))
 app.use('/listings/*', cacheControl('public, max-age=300'))

--- a/apps/api/src/routes/admin/applications.ts
+++ b/apps/api/src/routes/admin/applications.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import type { PrismaClient, Prisma } from '@surfaced-art/db'
+import { Prisma } from '@surfaced-art/db'
+import type { PrismaClient } from '@surfaced-art/db'
 import { logger, generateSlug, isReservedSlug } from '@surfaced-art/utils'
 import { adminReviewBody, adminApplicationsQuery } from '@surfaced-art/types'
 import type {

--- a/apps/api/src/routes/admin/applications.ts
+++ b/apps/api/src/routes/admin/applications.ts
@@ -413,9 +413,17 @@ export function createAdminApplicationRoutes(prisma: PrismaClient) {
       return conflict(c, 'Cannot delete an approved application. The associated artist profile must be removed first.')
     }
 
-    await prisma.artistApplication.delete({
-      where: { id },
-    })
+    try {
+      await prisma.artistApplication.delete({
+        where: { id },
+      })
+    } catch (err) {
+      // Handle race condition: another admin deleted between findUnique and delete
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+        return notFound(c, 'Application not found')
+      }
+      throw err
+    }
 
     // Audit log (fire-and-forget)
     void logAdminAction(prisma, {

--- a/apps/api/src/routes/admin/financials.ts
+++ b/apps/api/src/routes/admin/financials.ts
@@ -82,7 +82,6 @@ export function createAdminFinancialRoutes(prisma: PrismaClient) {
       by: ['artistId'],
       where: {
         status: { in: [...QUALIFYING_STATUSES] },
-        artistId: { not: null },
         ...(dateFilter ? { createdAt: dateFilter } : {}),
       },
       _sum: {

--- a/apps/api/src/routes/admin/financials.ts
+++ b/apps/api/src/routes/admin/financials.ts
@@ -15,7 +15,7 @@ const QUALIFYING_STATUSES = ['paid', 'shipped', 'delivered', 'complete'] as cons
 function buildDateFilter(from?: string, to?: string) {
   if (!from && !to) return undefined
   const filter: { gte?: Date; lte?: Date } = {}
-  if (from) filter.gte = new Date(from)
+  if (from) filter.gte = new Date(`${from}T00:00:00.000Z`)
   if (to) filter.lte = new Date(`${to}T23:59:59.999Z`)
   return filter
 }
@@ -82,6 +82,7 @@ export function createAdminFinancialRoutes(prisma: PrismaClient) {
       by: ['artistId'],
       where: {
         status: { in: [...QUALIFYING_STATUSES] },
+        artistId: { not: null },
         ...(dateFilter ? { createdAt: dateFilter } : {}),
       },
       _sum: {

--- a/apps/web/src/app/(admin)/admin/applications/application-list.tsx
+++ b/apps/web/src/app/(admin)/admin/applications/application-list.tsx
@@ -52,8 +52,11 @@ export function AdminApplicationList() {
 
   useEffect(() => {
     void fetchStats()
+  }, [fetchStats])
+
+  useEffect(() => {
     void fetchApplications({ status: statusFilter, page })
-  }, [fetchStats, fetchApplications, statusFilter, page])
+  }, [fetchApplications, statusFilter, page])
 
   const handleStatusFilter = (value: string) => {
     setStatusFilter(value)

--- a/apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx
+++ b/apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx
@@ -45,6 +45,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
     try {
       const token = await getIdToken()
       if (!token) throw new Error('Not authenticated')
+      if (!effectiveSelectedRole) throw new Error('No role selected to grant')
       await grantRole(token, userId, effectiveSelectedRole as UserRoleType)
       await fetchUser()
     } catch (err) {

--- a/bruno/collection.bru
+++ b/bruno/collection.bru
@@ -68,6 +68,8 @@ script:pre-request {
         bru.setVar('sa_authTokenExpiresAt', String(auth.expiresAt));
         console.log('✓ sa_authToken refreshed');
       } catch (err) {
+        bru.setVar('sa_authToken', '');
+        bru.setVar('sa_authTokenExpiresAt', '0');
         console.error('✗ Failed to authenticate (sa_authToken):', err.response?.data?.message || err.message);
       }
     }
@@ -85,6 +87,8 @@ script:pre-request {
         bru.setVar('sa_buyerAuthTokenExpiresAt', String(auth.expiresAt));
         console.log('✓ sa_buyerAuthToken refreshed');
       } catch (err) {
+        bru.setVar('sa_buyerAuthToken', '');
+        bru.setVar('sa_buyerAuthTokenExpiresAt', '0');
         console.error('✗ Failed to authenticate (sa_buyerAuthToken):', err.response?.data?.message || err.message);
       }
     }


### PR DESCRIPTION
## Summary
Batch fix addressing AI code review findings.
Triaged 12 bot review comments across 7 PRs.

## Fixes Applied
| File | Issue | Source | Commit |
|------|-------|--------|--------|
| `apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx` | Guard grantRole against empty role selection | Sourcery (PR #524) | `f44f1e6` |
| `apps/api/src/routes/admin/applications.ts` | Handle race condition between findUnique and delete (Prisma P2025) | Sourcery (PR #518) | `55f78e3` |
| `apps/web/src/app/(admin)/admin/applications/application-list.tsx` | Split useEffect to avoid re-fetching stats on filter/page change | Sourcery (PR #518) | `98db347` |
| `bruno/collection.bru` | Clear stale auth tokens on Cognito authentication failure | Sourcery (PR #516) | `16f1645` |
| `apps/api/src/index.ts` | Use named param `:slug` instead of `*` wildcard for contact route middleware | Sourcery (PR #512) | `7eb0bbd` |
| `apps/api/src/routes/admin/financials.ts` | Normalize `from` date filter to explicit UTC (symmetric with `to`) | Sourcery (PR #505) | `7709871` |

## Skipped (with reasoning)
| File | Issue | Reason |
|------|-------|--------|
| `apps/web/src/components/ListingCard.tsx` | Check sold dot layout collision (PR #525) | Design verification question, not a code bug — dot is 10px and doesn't overlap |
| `apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx` | Refactor effectiveSelectedRole with useMemo (PR #524) | Overlapping with simpler guard fix applied above |
| `apps/web/src/app/(admin)/admin/users/[id]/user-detail.tsx` | Align select value/onChange types (PR #524) | Overlapping with simpler guard fix applied above |
| `apps/web/src/app/(admin)/admin/artists/[id]/artist-detail.tsx` | Deduplicate statusBadgeClass across list/detail (PR #521) | Two identical 7-line switch functions — premature abstraction |
| `bruno/collection.bru` | Remove unused sa_cognitoUserPoolId env var (PR #516) | Not needed by USER_PASSWORD_AUTH flow; harmless documentation value |
| `apps/api/src/routes/admin/financials.ts` | Filter null artistId from groupBy (PR #505) | artistId is a required field in schema — null values impossible; adding filter caused type error |

## Source Reviews
- PR #525: https://github.com/nickcjordan/surfaced-art/pull/525
- PR #524: https://github.com/nickcjordan/surfaced-art/pull/524
- PR #521: https://github.com/nickcjordan/surfaced-art/pull/521
- PR #518: https://github.com/nickcjordan/surfaced-art/pull/518
- PR #516: https://github.com/nickcjordan/surfaced-art/pull/516
- PR #512: https://github.com/nickcjordan/surfaced-art/pull/512
- PR #505: https://github.com/nickcjordan/surfaced-art/pull/505

## Summary by Sourcery

Address multiple AI code review findings across admin APIs, web admin UI, and API client tooling to improve robustness and request handling.

Bug Fixes:
- Handle Prisma P2025 race condition when deleting artist applications by returning a not-found response if the record is already removed.
- Prevent unnecessary re-fetching of admin application stats when filters or pagination change by separating stats and applications effects.
- Align rate limiting and cache-control middleware for artist contact routes to use a named :slug parameter instead of a wildcard segment.
- Clear stale Cognito authentication tokens and their expiry when authentication fails in Bruno API collection scripts.
- Normalize the admin financials from-date filter to an explicit UTC start-of-day timestamp for consistency with the to-date handling.
- Guard role-granting in the admin user detail view against attempts to grant a role when none is selected.