### PR TITLE
fix(api): search artist name returns listings + partial failure resilience

### DIFF
--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -183,4 +183,77 @@ describe('GET /search', () => {
       expect(body.query).toBe('ceramic')
     })
   })
+
+  describe('artist name matching listings (SUR-296)', () => {
+    it('should return listings when artist name matches but listing title does not', async () => {
+      // Scenario: user searches "keiko" — listing title is "Woven Tapestry"
+      // but the artist is "Keiko Watanabe". Listings should still appear.
+      vi.clearAllMocks()
+      const artistNameMatchedListing = {
+        ...mockListingResult,
+        title: 'Woven Tapestry',
+        medium: 'Fiber Art',
+        artistName: 'Keiko Watanabe',
+        artistSlug: 'keiko-watanabe',
+      }
+      mockPrisma = createMockPrisma({
+        listings: [artistNameMatchedListing],
+        artists: [{ ...mockArtistResult, slug: 'keiko-watanabe', displayName: 'Keiko Watanabe' }],
+      })
+      app = createTestApp(mockPrisma)
+
+      const res = await app.request('/search?q=keiko')
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      // The key assertion: listings should be returned even when only artist name matches
+      expect(body.listings.data).toHaveLength(1)
+      expect(body.listings.data[0].artistName).toBe('Keiko Watanabe')
+      expect(body.artists.data).toHaveLength(1)
+    })
+  })
+
+  describe('partial query failure resilience (SUR-295)', () => {
+    it('should return 200 with empty listings when listings query throws', async () => {
+      vi.clearAllMocks()
+      let callCount = 0
+      const prisma = {
+        $queryRaw: vi.fn().mockImplementation(() => {
+          callCount++
+          if (callCount === 1) return Promise.reject(new Error('DB connection failed'))
+          return Promise.resolve([mockArtistResult])
+        }),
+      } as unknown as Parameters<typeof createSearchRoutes>[0]
+      app = createTestApp(prisma)
+
+      const res = await app.request('/search?q=keiko')
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.listings.data).toEqual([])
+      expect(body.listings.total).toBe(0)
+      expect(body.artists.data).toHaveLength(1)
+    })
+
+    it('should return 200 with empty artists when artists query throws', async () => {
+      vi.clearAllMocks()
+      let callCount = 0
+      const prisma = {
+        $queryRaw: vi.fn().mockImplementation(() => {
+          callCount++
+          if (callCount === 1) return Promise.resolve([mockListingResult])
+          return Promise.reject(new Error('DB connection failed'))
+        }),
+      } as unknown as Parameters<typeof createSearchRoutes>[0]
+      app = createTestApp(prisma)
+
+      const res = await app.request('/search?q=ceramic')
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.listings.data).toHaveLength(1)
+      expect(body.artists.data).toEqual([])
+      expect(body.artists.total).toBe(0)
+    })
+  })
 })

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -34,7 +34,8 @@ export function createSearchRoutes(prisma: PrismaClient) {
 
     // Two parallel queries: listings (paginated) and artists (top 8)
     // plainto_tsquery safely converts user input to AND-joined lexemes
-    const [listingsResult, artistsResult] = await Promise.all([
+    // Use Promise.allSettled so one query failure doesn't kill the other (SUR-295)
+    const [listingsOutcome, artistsOutcome] = await Promise.allSettled([
       prisma.$queryRaw`
         SELECT
           l.id,
@@ -48,11 +49,15 @@ export function createSearchRoutes(prisma: PrismaClient) {
           (SELECT height FROM listing_images li WHERE li.listing_id = l.id ORDER BY li.sort_order ASC LIMIT 1) AS "primaryImageHeight",
           ap.display_name AS "artistName",
           ap.slug AS "artistSlug",
-          ts_rank(l.search_vector, plainto_tsquery('english', ${q})) AS rank,
+          GREATEST(
+            ts_rank(l.search_vector, plainto_tsquery('english', ${q})),
+            ts_rank(ap.search_vector, plainto_tsquery('english', ${q}))
+          ) AS rank,
           COUNT(*) OVER() AS "totalCount"
         FROM listings l
         JOIN artist_profiles ap ON l.artist_id = ap.id
-        WHERE l.search_vector @@ plainto_tsquery('english', ${q})
+        WHERE (l.search_vector @@ plainto_tsquery('english', ${q})
+           OR ap.search_vector @@ plainto_tsquery('english', ${q}))
           AND l.status IN ('available', 'reserved_system')
           AND ap.status = 'approved'
         ORDER BY rank DESC, l.created_at DESC
@@ -71,12 +76,15 @@ export function createSearchRoutes(prisma: PrismaClient) {
           COALESCE(
             (SELECT ARRAY_AGG(sub.url ORDER BY sub.rn)
              FROM (
-               SELECT DISTINCT ON (l2.id) li.url, ROW_NUMBER() OVER (ORDER BY l2.created_at DESC) AS rn
-               FROM listings l2
-               JOIN listing_images li ON li.listing_id = l2.id AND li.is_process_photo = false
-               WHERE l2.artist_id = ap.id
-                 AND l2.status IN ('available', 'reserved_system')
-               ORDER BY l2.id, li.sort_order ASC
+               SELECT url, ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn
+               FROM (
+                 SELECT DISTINCT ON (l2.id) li.url, l2.created_at
+                 FROM listings l2
+                 JOIN listing_images li ON li.listing_id = l2.id AND li.is_process_photo = false
+                 WHERE l2.artist_id = ap.id
+                   AND l2.status IN ('available', 'reserved_system')
+                 ORDER BY l2.id, li.sort_order ASC
+               ) deduped
              ) sub
              WHERE sub.rn <= 4),
             '{}'::text[]
@@ -90,6 +98,21 @@ export function createSearchRoutes(prisma: PrismaClient) {
         LIMIT 8
       ` as Promise<RawArtistRow[]>,
     ])
+
+    // Extract results, falling back to empty on failure (SUR-295)
+    const listingsResult = listingsOutcome.status === 'fulfilled'
+      ? listingsOutcome.value
+      : [] as RawListingRow[]
+    const artistsResult = artistsOutcome.status === 'fulfilled'
+      ? artistsOutcome.value
+      : [] as RawArtistRow[]
+
+    if (listingsOutcome.status === 'rejected') {
+      logger.error('Listing search query failed', { query: q, error: String(listingsOutcome.reason) })
+    }
+    if (artistsOutcome.status === 'rejected') {
+      logger.error('Artist search query failed', { query: q, error: String(artistsOutcome.reason) })
+    }
 
     // Raw queries return BigInt for COUNT — convert to number
     const listingsTotal = listingsResult.length > 0 ? Number(listingsResult[0]!.totalCount) : 0

--- a/docs/Brand_Guide_Requirements.md
+++ b/docs/Brand_Guide_Requirements.md
@@ -1,5 +1,7 @@
 # Surfaced Art -- Brand Guide Requirements
 
+> **⚠️ HISTORICAL** — This requirements doc was used during the initial brand exploration. The palette decisions below (muted gold #B8956A, terracotta #C4775A) have been superseded. The current palette is warm monochrome (black/white/grays) with selective use of logo red (#AA1D45). See `Surfaced_Art_Brand_Design_System_v2_0.md` for all current values.
+
 **Purpose**: This document captures every visual and brand decision the front-end implementation depends on. The COO fills in decisions; the CTO uses them to implement the design system.
 
 **How to use this document**: For each item, you will see the current tentative value (what is implemented today as a placeholder), why the decision matters, and a clear question for you to answer. Fill in the "Your Decision" field. If you are unsure, write "keep tentative" and we will revisit.

--- a/docs/Design_System_Audit.md
+++ b/docs/Design_System_Audit.md
@@ -1,5 +1,7 @@
 # Surfaced Art -- Design System Audit
 
+> **⚠️ HISTORICAL** — This audit was run on 2026-02-23 against an earlier version of the design system. Color values referenced below (#B8956A, #C4775A) are no longer active. The current palette is warm monochrome (black/white/grays) with selective use of logo red (#AA1D45). See `Surfaced_Art_Brand_Design_System_v2_0.md` for current values.
+
 **Date**: 2026-02-23
 **Branch**: `dev`
 **Auditor**: Claude Code (automated audit)

--- a/docs/Surfaced_Art_Brand_Design_System_v2_0.md
+++ b/docs/Surfaced_Art_Brand_Design_System_v2_0.md
@@ -187,12 +187,12 @@ ShadCN components consume their own token names. These alias our brand tokens so
   /* Sidebar */
   --sidebar: #F2F0ED;
   --sidebar-foreground: #1A1A1A;
-  --sidebar-primary: #B8956A;
+  --sidebar-primary: #2C2926;
   --sidebar-primary-foreground: #FFFFFF;
   --sidebar-accent: #F2F0ED;
   --sidebar-accent-foreground: #1A1A1A;
   --sidebar-border: #E5E0DB;
-  --sidebar-ring: #B8956A;
+  --sidebar-ring: #2C2926;
 
   /* Font stacks */
   --active-font-sans: var(--font-dm-sans), 'DM Sans', sans-serif;
@@ -627,7 +627,7 @@ ShadCN Card sub-components available: `Card`, `CardHeader`, `CardTitle`, `CardDe
 | Background | Transparent (shows page background) |
 | Text | `--foreground` |
 | Placeholder text | `--muted` |
-| Focus state | Border color changes to `--accent-primary` (#B8956A) |
+| Focus state | Border color changes to `--accent-primary` (#2C2926) |
 | Error state | Border color changes to `--error` (#C4534A) |
 | Transition | 200ms ease-in-out on border-color |
 | Padding | 10px 14px |

--- a/docs/Surfaced_Art_Brand_Guide_v1_0.md
+++ b/docs/Surfaced_Art_Brand_Guide_v1_0.md
@@ -2,6 +2,8 @@
 
 **Version 1.0 | February 2026**
 
+> **⚠️ DEPRECATED** — Superseded by `Surfaced_Art_Brand_Design_System_v2_0.md`. The palette described below (muted gold #B8956A, terracotta #C4775A) is no longer active. The current palette is warm monochrome (black/white/grays) with selective use of logo red (#AA1D45). See v2.0 for all current values.
+
 ---
 
 ## How to Use This Document


### PR DESCRIPTION
## Summary
- **SUR-295**: Search endpoint no longer returns 500 when one of the two parallel queries (listings or artists) fails. Switched from `Promise.all` to `Promise.allSettled` — failed queries return empty results and log the error instead of crashing the entire endpoint.
- **SUR-296**: Listing search now matches against both the listing's and the artist's `search_vector`, so searching an artist's name (e.g. "keiko") returns their available listings. Uses `GREATEST()` to rank by the stronger match.
- Fixed the `artworkImageUrls` subquery to apply `ROW_NUMBER()` after `DISTINCT ON`, ensuring correct top-4 image selection ordering.
- Updated palette documentation: removed stale `#B8956A` references in Design System v2.0, added DEPRECATED/HISTORICAL notices to superseded docs.

## Test plan
- [x] 12 search unit tests pass (including 3 new: artist name matching, partial failure resilience for listings and artists queries)
- [x] Build, typecheck, lint all green
- [ ] Manual QA: search "keiko" on pieces tab returns Keiko Watanabe's listings
- [ ] Manual QA: search "keiko" on artists tab returns Keiko Watanabe's profile (no 500)
- [ ] Manual QA: search a term that matches nothing returns empty state (not error)

## Summary by Sourcery

Improve search robustness and relevance while aligning brand documentation with the current design system.

New Features:
- Allow listing search results to match on either listing or artist search vectors so artist-name queries return relevant listings.

Bug Fixes:
- Prevent the search endpoint from failing entirely when either the listings or artists query errors by returning empty results for the failed side.
- Correct artwork image URL selection so the top four images are chosen in deterministic created-at order after de-duplication.

Documentation:
- Update the v2.0 brand design system palette references to the current sidebar and accent colors.
- Mark older brand and design system documents as historical or deprecated and point readers to the v2.0 design system as the source of truth.

Tests:
- Add search tests covering artist-name-driven listing matches and resilience to partial query failures.